### PR TITLE
feat: web UI settings page with live reload

### DIFF
--- a/recommender/templates/base.html
+++ b/recommender/templates/base.html
@@ -206,11 +206,13 @@
 
   <nav>
     <a href="/" class="nav-brand">Streamline</a>
-    <div style="display:flex; gap:1.5rem; margin-left:0.5rem;">
+    <div style="display:flex; gap:1.5rem; margin-left:0.5rem; flex:1;">
       <a href="/" class="nav-link {% if request.path == '/' %}active{% endif %}">Home</a>
       <a href="/searches" class="nav-link {% if request.path == '/searches' %}active{% endif %}">Searches</a>
       <a href="/history" class="nav-link {% if request.path.startswith('/history') or request.path.startswith('/title') %}active{% endif %}">Archive</a>
+      <a href="/settings" class="nav-link {% if request.path == '/settings' %}active{% endif %}">Settings</a>
     </div>
+    <a href="/help" class="nav-link {% if request.path == '/help' %}active{% endif %}">Help</a>
   </nav>
 
   <main style="max-width:54rem; margin:0 auto; padding:2.5rem 2rem 5rem;">

--- a/recommender/templates/help.html
+++ b/recommender/templates/help.html
@@ -1,0 +1,209 @@
+{% extends "base.html" %}
+{% block title %}Streamline — Help{% endblock %}
+{% block content %}
+
+<div style="margin-bottom:2.5rem;">
+  <span class="mono" style="font-size:0.62rem; letter-spacing:0.12em; text-transform:uppercase; color:var(--accent);">Guide</span>
+  <h1 style="font-size:clamp(2rem, 4.5vw, 3rem); margin-top:0.2rem; margin-bottom:0.5rem;">Help</h1>
+  <p style="color:var(--muted); font-size:0.85rem;">Everything you need to know about using Streamline.</p>
+</div>
+
+<div style="display:flex; flex-direction:column; gap:6px;">
+
+  <!-- How it works -->
+  <details class="help-details" open>
+    <summary class="help-summary">
+      <svg class="help-arrow" width="10" height="10" viewBox="0 0 10 10"><path d="M3 1 L7 5 L3 9" stroke="var(--accent)" stroke-width="1.5" fill="none" stroke-linecap="round" stroke-linejoin="round"/></svg>
+      <span class="help-heading">How it works</span>
+    </summary>
+    <div class="help-body">
+      <p>Streamline is a two-phase recommendation engine built on your real watch history.</p>
+      <p><strong>Setup (offline)</strong> — Parses your Netflix, Prime Video, and manual watch history. Fetches metadata from TMDB, enriches each title with a semantic description, then builds a detailed taste profile from everything you've watched.</p>
+      <p><strong>Search (online)</strong> — Ask anything in natural language. The engine parses your intent, finds candidates via TMDB Discover + AI semantic suggestions, filters out what you've seen, checks streaming availability, and ranks results against your taste profile.</p>
+    </div>
+  </details>
+
+  <!-- Searching -->
+  <details class="help-details">
+    <summary class="help-summary">
+      <svg class="help-arrow" width="10" height="10" viewBox="0 0 10 10"><path d="M3 1 L7 5 L3 9" stroke="var(--teal)" stroke-width="1.5" fill="none" stroke-linecap="round" stroke-linejoin="round"/></svg>
+      <span class="help-heading">Searching</span>
+    </summary>
+    <div class="help-body">
+      <p>Type anything in the search bar on the <a href="/">home page</a>. Some examples:</p>
+      <ul>
+        <li><strong>Genre + mood</strong> — "gritty British crime drama", "feel-good Bollywood comedy"</li>
+        <li><strong>Similar to</strong> — "spy thriller like Slow Horses", "something like Fleabag but darker"</li>
+        <li><strong>Specific requests</strong> — "give me 5 underrated sci-fi movies", "short documentary series"</li>
+        <li><strong>Language/region</strong> — "Hindi crime thriller", "Korean romance", "French arthouse"</li>
+        <li><strong>Platform</strong> — "what's good on Netflix right now", "best Prime Video originals"</li>
+        <li><strong>Why not?</strong> — "why not The Bear?" explains why a title wasn't recommended</li>
+      </ul>
+      <p>Results show the title, TMDB rating, genres, a personalized explanation of why it matches your taste, and where it's streaming.</p>
+    </div>
+  </details>
+
+  <!-- Taste profile -->
+  <details class="help-details">
+    <summary class="help-summary">
+      <svg class="help-arrow" width="10" height="10" viewBox="0 0 10 10"><path d="M3 1 L7 5 L3 9" stroke="var(--lavender)" stroke-width="1.5" fill="none" stroke-linecap="round" stroke-linejoin="round"/></svg>
+      <span class="help-heading">Taste profile</span>
+    </summary>
+    <div class="help-body">
+      <p>Your taste profile is built from <strong>all</strong> titles in your watch history, processed in batches and merged into clusters. Each cluster captures a distinct pattern in what you watch — genre preferences, tonal signatures, cultural interests.</p>
+      <p>The profile is rebuilt when you run setup with <code>--refresh-profile</code>. It automatically backs up the previous version.</p>
+      <p>Feedback (liked/disliked titles) influences the profile on the next rebuild — liked titles get a score boost, disliked titles are noted as patterns to avoid.</p>
+    </div>
+  </details>
+
+  <!-- CLI commands -->
+  <details class="help-details">
+    <summary class="help-summary">
+      <svg class="help-arrow" width="10" height="10" viewBox="0 0 10 10"><path d="M3 1 L7 5 L3 9" stroke="var(--accent2)" stroke-width="1.5" fill="none" stroke-linecap="round" stroke-linejoin="round"/></svg>
+      <span class="help-heading">CLI commands</span>
+    </summary>
+    <div class="help-body">
+      <p>Everything goes through <code>./recommend</code>:</p>
+      <table class="help-table">
+        <tr><td><code>./recommend "query"</code></td><td>Single query</td></tr>
+        <tr><td><code>./recommend</code></td><td>Interactive mode (conversational, supports "more like that")</td></tr>
+        <tr><td><code>./recommend setup</code></td><td>First-time offline setup</td></tr>
+        <tr><td><code>./recommend setup --refresh-data</code></td><td>Re-fetch TMDB metadata + rebuild everything</td></tr>
+        <tr><td><code>./recommend setup --refresh-profile</code></td><td>Rebuild taste profile only</td></tr>
+        <tr><td><code>./recommend --history</code></td><td>Show recent query history</td></tr>
+        <tr><td><code>./recommend --debug "query"</code></td><td>Full pipeline trace</td></tr>
+        <tr><td><code>./recommend -n 5 "query"</code></td><td>Override result count</td></tr>
+        <tr><td><code>./recommend --provider gemini "query"</code></td><td>Use Gemini instead of default</td></tr>
+        <tr><td><code>./recommend --liked "Title"</code></td><td>Mark a title as liked</td></tr>
+        <tr><td><code>./recommend --disliked "Title"</code></td><td>Mark a title as disliked</td></tr>
+        <tr><td><code>./recommend --add "Title" --type tv</code></td><td>Add to watch history</td></tr>
+      </table>
+
+      <p style="margin-top:1rem;">Web server:</p>
+      <table class="help-table">
+        <tr><td><code>./recommend-web start</code></td><td>Start web UI (default port 5050)</td></tr>
+        <tr><td><code>./recommend-web stop</code></td><td>Stop the server</td></tr>
+        <tr><td><code>./recommend-web restart</code></td><td>Restart</td></tr>
+        <tr><td><code>./recommend-web status</code></td><td>Check if running</td></tr>
+        <tr><td><code>./recommend-web logs</code></td><td>View recent logs</td></tr>
+      </table>
+    </div>
+  </details>
+
+  <!-- Configuration -->
+  <details class="help-details">
+    <summary class="help-summary">
+      <svg class="help-arrow" width="10" height="10" viewBox="0 0 10 10"><path d="M3 1 L7 5 L3 9" stroke="var(--accent)" stroke-width="1.5" fill="none" stroke-linecap="round" stroke-linejoin="round"/></svg>
+      <span class="help-heading">Configuration</span>
+    </summary>
+    <div class="help-body">
+      <p>Settings live in two places:</p>
+      <ul>
+        <li><strong>.env</strong> — API keys only (TMDB, Anthropic, Gemini). Gitignored.</li>
+        <li><strong>config.yaml</strong> — everything else. Editable from the <a href="/settings">Settings</a> page or by hand.</li>
+      </ul>
+      <p>The <a href="/settings">Settings</a> page lets you change provider, models, timeouts, scoring weights, and more — changes take effect immediately without a restart.</p>
+    </div>
+  </details>
+
+  <!-- Title overrides -->
+  <details class="help-details">
+    <summary class="help-summary">
+      <svg class="help-arrow" width="10" height="10" viewBox="0 0 10 10"><path d="M3 1 L7 5 L3 9" stroke="var(--teal)" stroke-width="1.5" fill="none" stroke-linecap="round" stroke-linejoin="round"/></svg>
+      <span class="help-heading">Title overrides</span>
+    </summary>
+    <div class="help-body">
+      <p>When TMDB can't match a title from your watch history, create <code>data/overrides.json</code>:</p>
+      <pre style="background:var(--bg); padding:0.75rem 1rem; border-radius:4px; font-size:0.78rem; overflow-x:auto;">{
+  "The Matrix III Revolutions": {"title": "The Matrix Revolutions"},
+  "Some Cooking Show Ep 3": {"skip": true},
+  "Delhi Cops Episode": {"title": "Delhi Cops", "content_type": "tv"},
+  "Specific Movie": {"tmdb_id": 12345}
+}</pre>
+      <p>Options: <code>title</code> (search name), <code>content_type</code> (tv/movie), <code>tmdb_id</code> (direct match), <code>skip</code> (exclude entirely). The override file is auto-detected — just run <code>./recommend setup</code>.</p>
+    </div>
+  </details>
+
+  <!-- Watch history -->
+  <details class="help-details">
+    <summary class="help-summary">
+      <svg class="help-arrow" width="10" height="10" viewBox="0 0 10 10"><path d="M3 1 L7 5 L3 9" stroke="var(--lavender)" stroke-width="1.5" fill="none" stroke-linecap="round" stroke-linejoin="round"/></svg>
+      <span class="help-heading">Adding watch history</span>
+    </summary>
+    <div class="help-body">
+      <p>Place exported CSV files under <code>data/</code>:</p>
+      <table class="help-table">
+        <tr><td><strong>Netflix</strong></td><td>Account Settings > Download your data > ViewingActivity.csv</td></tr>
+        <tr><td><strong>Prime Video</strong></td><td>Account > Digital content > Request your data > Viewing History.csv</td></tr>
+        <tr><td><strong>Manual</strong></td><td><code>data/manual/tv.csv</code> and <code>data/manual/movies.csv</code> — one title per line</td></tr>
+      </table>
+      <p>After adding new data, run <code>./recommend setup --refresh-data</code> to rebuild.</p>
+      <p>You can also add individual titles via CLI: <code>./recommend --add "Shetland" --type tv</code></p>
+    </div>
+  </details>
+
+  <!-- LLM providers -->
+  <details class="help-details">
+    <summary class="help-summary">
+      <svg class="help-arrow" width="10" height="10" viewBox="0 0 10 10"><path d="M3 1 L7 5 L3 9" stroke="var(--accent2)" stroke-width="1.5" fill="none" stroke-linecap="round" stroke-linejoin="round"/></svg>
+      <span class="help-heading">LLM providers</span>
+    </summary>
+    <div class="help-body">
+      <p>Streamline supports two LLM providers. Each uses two model roles:</p>
+      <ul>
+        <li><strong>Fast</strong> — used for enrichment (high volume, simple task). Default: Haiku / Flash.</li>
+        <li><strong>Reason</strong> — used for intent parsing, ranking, taste profile (complex reasoning). Default: Sonnet / Pro.</li>
+      </ul>
+      <p>Switch providers in <a href="/settings">Settings</a> or per-query with <code>--provider gemini</code>. Token usage and cost estimates are shown after each query.</p>
+    </div>
+  </details>
+
+</div>
+
+<style>
+  .help-details { background: var(--surface); border-radius: 6px; overflow: hidden; }
+  .help-summary {
+    display: flex; align-items: center; gap: 0.75rem;
+    padding: 1rem 1.25rem;
+    cursor: pointer; list-style: none; user-select: none;
+    transition: background 0.15s;
+  }
+  .help-summary::-webkit-details-marker { display: none; }
+  .help-summary::marker { content: ''; }
+  .help-summary:hover { background: var(--surface2); }
+  .help-details[open] .help-arrow { transform: rotate(90deg); }
+  .help-arrow { flex-shrink: 0; transition: transform 0.2s; }
+  .help-heading { font-family: 'DM Serif Display', serif; font-size: 1.05rem; color: var(--text); }
+  .help-body {
+    padding: 0 1.25rem 1.25rem 2.75rem;
+  }
+  .help-body p { font-size: 0.86rem; color: var(--body); line-height: 1.8; margin: 0 0 0.75rem; }
+  .help-body p:last-child { margin-bottom: 0; }
+  .help-body strong { color: var(--text); font-weight: 500; }
+  .help-body code {
+    font-family: 'JetBrains Mono', monospace;
+    font-size: 0.76rem;
+    background: var(--bg);
+    padding: 2px 6px;
+    border-radius: 3px;
+    color: var(--text);
+  }
+  .help-body ul { margin: 0 0 0.75rem; padding-left: 1.2rem; }
+  .help-body li { font-size: 0.86rem; color: var(--body); line-height: 1.8; margin-bottom: 0.2rem; }
+  .help-table {
+    width: 100%;
+    border-collapse: collapse;
+    margin: 0.5rem 0;
+  }
+  .help-table td {
+    padding: 0.35rem 0.75rem;
+    font-size: 0.82rem;
+    color: var(--body);
+    border-bottom: 1px solid rgba(53,47,64,0.5);
+    vertical-align: top;
+  }
+  .help-table td:first-child { white-space: nowrap; }
+  .help-table tr:last-child td { border-bottom: none; }
+</style>
+
+{% endblock %}

--- a/recommender/templates/settings.html
+++ b/recommender/templates/settings.html
@@ -1,0 +1,339 @@
+{% extends "base.html" %}
+{% block title %}Streamline — Settings{% endblock %}
+{% block content %}
+
+<div style="margin-bottom:2rem;">
+  <span class="mono" style="font-size:0.62rem; letter-spacing:0.12em; text-transform:uppercase; color:var(--accent);">Configuration</span>
+  <h1 style="font-size:clamp(2rem, 4.5vw, 3rem); margin-top:0.2rem; margin-bottom:0.5rem;">Settings</h1>
+  <p style="color:var(--muted); font-size:0.85rem;">Changes are saved to config.yaml and take effect on reload.</p>
+</div>
+
+{% if saved %}
+<div style="padding:0.75rem 1.25rem; background:rgba(58,184,160,0.1); border:1px solid rgba(58,184,160,0.25); border-radius:6px; margin-bottom:1.5rem; font-size:0.85rem; color:var(--teal);">
+  Settings saved. <span class="mono" style="font-size:0.7rem;">Config reloaded.</span>
+</div>
+{% endif %}
+
+{% if error %}
+<div style="padding:0.75rem 1.25rem; background:rgba(232,93,74,0.08); border:1px solid rgba(232,93,74,0.2); border-radius:6px; margin-bottom:1.5rem; font-size:0.85rem; color:#e88;">
+  {{ error }}
+</div>
+{% endif %}
+
+<form method="post" action="/settings" style="display:flex; flex-direction:column; gap:1.5rem;">
+
+  <!-- LLM Provider -->
+  <fieldset style="border:1px solid var(--border); border-radius:6px; padding:1.25rem; background:var(--surface);">
+    <legend class="mono" style="font-size:0.62rem; letter-spacing:0.12em; text-transform:uppercase; color:var(--accent); padding:0 0.5rem;">LLM Provider</legend>
+    <p class="section-intro">Which AI provider to use and which models for each role.</p>
+
+    <div class="form-row">
+      <label class="form-label">Provider</label>
+      <select name="provider" class="form-input" style="width:200px;">
+        <option value="anthropic" {{ 'selected' if cfg.provider == 'anthropic' }}>Anthropic</option>
+        <option value="gemini" {{ 'selected' if cfg.provider == 'gemini' }}>Gemini</option>
+      </select>
+      <span class="form-hint">Active provider for all LLM calls. Override per-query with --provider.</span>
+    </div>
+
+    <div style="display:grid; grid-template-columns:1fr 1fr; gap:1rem; margin-top:1rem;">
+      <div>
+        <span class="mono" style="font-size:0.58rem; color:var(--muted); letter-spacing:0.08em;">ANTHROPIC MODELS</span>
+        <div class="form-row" style="margin-top:0.5rem;">
+          <label class="form-label">Fast</label>
+          <input type="text" name="anthropic_fast" value="{{ cfg.models.anthropic.fast }}" class="form-input">
+          <span class="form-hint">Enrichment, simple tasks (high volume, cheaper)</span>
+        </div>
+        <div class="form-row">
+          <label class="form-label">Reason</label>
+          <input type="text" name="anthropic_reason" value="{{ cfg.models.anthropic.reason }}" class="form-input">
+          <span class="form-hint">Intent parsing, ranking, taste profile (complex reasoning)</span>
+        </div>
+      </div>
+      <div>
+        <span class="mono" style="font-size:0.58rem; color:var(--muted); letter-spacing:0.08em;">GEMINI MODELS</span>
+        <div class="form-row" style="margin-top:0.5rem;">
+          <label class="form-label">Fast</label>
+          <input type="text" name="gemini_fast" value="{{ cfg.models.gemini.fast }}" class="form-input">
+          <span class="form-hint">Enrichment, simple tasks</span>
+        </div>
+        <div class="form-row">
+          <label class="form-label">Reason</label>
+          <input type="text" name="gemini_reason" value="{{ cfg.models.gemini.reason }}" class="form-input">
+          <span class="form-hint">Complex reasoning (Pro needs extended timeouts)</span>
+        </div>
+      </div>
+    </div>
+  </fieldset>
+
+  <!-- LLM Timeouts & Tokens -->
+  <fieldset style="border:1px solid var(--border); border-radius:6px; padding:1.25rem; background:var(--surface);">
+    <legend class="mono" style="font-size:0.62rem; letter-spacing:0.12em; text-transform:uppercase; color:var(--accent); padding:0 0.5rem;">LLM Limits</legend>
+    <p class="section-intro">Timeouts and token budgets per call type. Increase if you see truncation or timeout errors.</p>
+
+    <div style="display:grid; grid-template-columns:1fr 1fr; gap:1rem;">
+      <div>
+        <span class="mono" style="font-size:0.58rem; color:var(--muted); letter-spacing:0.08em;">TIMEOUTS (seconds)</span>
+        {% set timeout_hints = {
+          'timeout_fast': 'Enrichment calls',
+          'timeout_reason': 'Intent parsing, ranking, suggestions',
+          'timeout_profile_batch': 'Each batch during taste profile build',
+          'timeout_profile_merge': 'Final merge of all batches into profile'
+        } %}
+        {% for key, label in [('timeout_fast', 'Fast'), ('timeout_reason', 'Reason'), ('timeout_profile_batch', 'Profile batch'), ('timeout_profile_merge', 'Profile merge')] %}
+        <div class="form-row" style="margin-top:0.5rem;">
+          <label class="form-label">{{ label }}</label>
+          <input type="number" name="llm_{{ key }}" value="{{ cfg.llm[key] }}" class="form-input" style="width:100px;" min="1">
+          <span class="form-hint">{{ timeout_hints[key] }}</span>
+        </div>
+        {% endfor %}
+      </div>
+      <div>
+        <span class="mono" style="font-size:0.58rem; color:var(--muted); letter-spacing:0.08em;">MAX OUTPUT TOKENS</span>
+        {% set token_hints = {
+          'tokens_fast': 'Enrichment descriptions (~1 paragraph)',
+          'tokens_intent': 'Query intent parsing (JSON)',
+          'tokens_ranking': 'Ranking explanation per result (auto-scales with result count)',
+          'tokens_suggestions': 'AI title suggestions per query',
+          'tokens_profile_batch': 'Per-batch taste analysis (200 titles needs ~4000)',
+          'tokens_profile_merge': 'Final merged profile (15 clusters needs ~16000)',
+          'tokens_abandoned': 'Abandoned show advice'
+        } %}
+        {% for key, label in [('tokens_fast', 'Fast'), ('tokens_intent', 'Intent'), ('tokens_ranking', 'Ranking'), ('tokens_suggestions', 'Suggestions'), ('tokens_profile_batch', 'Profile batch'), ('tokens_profile_merge', 'Profile merge'), ('tokens_abandoned', 'Abandoned')] %}
+        <div class="form-row" style="margin-top:0.5rem;">
+          <label class="form-label">{{ label }}</label>
+          <input type="number" name="llm_{{ key }}" value="{{ cfg.llm[key] }}" class="form-input" style="width:100px;" min="1">
+          <span class="form-hint">{{ token_hints[key] }}</span>
+        </div>
+        {% endfor %}
+      </div>
+    </div>
+
+    <div style="display:grid; grid-template-columns:1fr 1fr; gap:1rem; margin-top:1rem;">
+      <div class="form-row">
+        <label class="form-label">Profile batch size</label>
+        <input type="number" name="llm_profile_batch_size" value="{{ cfg.llm.profile_batch_size }}" class="form-input" style="width:100px;" min="10">
+        <span class="form-hint">Titles per batch during taste profile build</span>
+      </div>
+      <div class="form-row">
+        <label class="form-label">Rate limit wait (s)</label>
+        <input type="number" name="llm_rate_limit_wait" value="{{ cfg.llm.rate_limit_wait }}" class="form-input" style="width:100px;" min="1">
+        <span class="form-hint">Seconds to pause on 429 rate limit errors</span>
+      </div>
+    </div>
+  </fieldset>
+
+  <!-- Scoring -->
+  <fieldset style="border:1px solid var(--border); border-radius:6px; padding:1.25rem; background:var(--surface);">
+    <legend class="mono" style="font-size:0.62rem; letter-spacing:0.12em; text-transform:uppercase; color:var(--accent); padding:0 0.5rem;">Scoring</legend>
+    <p class="section-intro">How engagement scores are calculated from your watch history. Weights must sum to 1.0.</p>
+
+    <div style="display:grid; grid-template-columns:1fr 1fr 1fr; gap:1rem;">
+      <div class="form-row">
+        <label class="form-label">Completion weight</label>
+        <input type="number" name="weight_completion" value="{{ cfg.scoring.weight_completion }}" class="form-input" style="width:80px;" step="0.1" min="0" max="1">
+        <span class="form-hint">How much of the title was watched</span>
+      </div>
+      <div class="form-row">
+        <label class="form-label">Rewatch weight</label>
+        <input type="number" name="weight_rewatch" value="{{ cfg.scoring.weight_rewatch }}" class="form-input" style="width:80px;" step="0.1" min="0" max="1">
+        <span class="form-hint">Bonus for titles watched multiple times</span>
+      </div>
+      <div class="form-row">
+        <label class="form-label">Recency weight</label>
+        <input type="number" name="weight_recency" value="{{ cfg.scoring.weight_recency }}" class="form-input" style="width:80px;" step="0.1" min="0" max="1">
+        <span class="form-hint">Recent watches score higher</span>
+      </div>
+    </div>
+    <p id="weight-warn" class="mono" style="font-size:0.58rem; color:#e85d4a; margin-top:0.5rem; display:none;">Weights must sum to 1.0</p>
+
+    <div style="display:grid; grid-template-columns:1fr 1fr 1fr; gap:1rem; margin-top:1rem;">
+      <div class="form-row">
+        <label class="form-label">TV runtime (min)</label>
+        <input type="number" name="default_tv_runtime" value="{{ cfg.scoring.default_tv_runtime }}" class="form-input" style="width:80px;" min="1">
+        <span class="form-hint">Fallback when TMDB has no runtime data</span>
+      </div>
+      <div class="form-row">
+        <label class="form-label">Movie runtime (min)</label>
+        <input type="number" name="default_movie_runtime" value="{{ cfg.scoring.default_movie_runtime }}" class="form-input" style="width:80px;" min="1">
+        <span class="form-hint">Fallback when TMDB has no runtime data</span>
+      </div>
+      <div class="form-row">
+        <label class="form-label">Rewatch saturation</label>
+        <input type="number" name="rewatch_saturation" value="{{ cfg.scoring.rewatch_saturation }}" class="form-input" style="width:80px;" min="1">
+        <span class="form-hint">Log scale caps at ~N rewatches (diminishing returns)</span>
+      </div>
+    </div>
+  </fieldset>
+
+  <!-- Recommendations -->
+  <fieldset style="border:1px solid var(--border); border-radius:6px; padding:1.25rem; background:var(--surface);">
+    <legend class="mono" style="font-size:0.62rem; letter-spacing:0.12em; text-transform:uppercase; color:var(--accent); padding:0 0.5rem;">Recommendations</legend>
+    <p class="section-intro">Controls for result quality and quantity.</p>
+
+    <div style="display:grid; grid-template-columns:1fr 1fr 1fr; gap:1rem;">
+      <div class="form-row">
+        <label class="form-label">Default results</label>
+        <input type="number" name="default_top_n" value="{{ cfg.default_top_n }}" class="form-input" style="width:80px;" min="1" max="20">
+        <span class="form-hint">Results per query (override with -n flag)</span>
+      </div>
+      <div class="form-row">
+        <label class="form-label">Min TMDB votes</label>
+        <input type="number" name="min_vote_count" value="{{ cfg.min_vote_count }}" class="form-input" style="width:80px;" min="0">
+        <span class="form-hint">Filter out obscure titles with few ratings</span>
+      </div>
+      <div class="form-row">
+        <label class="form-label">Recency half-life (days)</label>
+        <input type="number" name="recency_half_life_days" value="{{ cfg.recency_half_life_days }}" class="form-input" style="width:100px;" min="1">
+        <span class="form-hint">Days until a watch's recency score halves</span>
+      </div>
+    </div>
+  </fieldset>
+
+  <!-- Streaming -->
+  <fieldset style="border:1px solid var(--border); border-radius:6px; padding:1.25rem; background:var(--surface);">
+    <legend class="mono" style="font-size:0.62rem; letter-spacing:0.12em; text-transform:uppercase; color:var(--accent); padding:0 0.5rem;">Streaming</legend>
+    <p class="section-intro">Region and platform filtering for streaming availability.</p>
+
+    <div style="display:grid; grid-template-columns:1fr 1fr; gap:1rem;">
+      <div class="form-row">
+        <label class="form-label">Watch region</label>
+        <input type="text" name="watch_region" value="{{ cfg.watch_region }}" class="form-input" style="width:80px;" maxlength="2">
+        <span class="form-hint">ISO 3166-1 country code (US, GB, IN, etc.)</span>
+      </div>
+      <div class="form-row">
+        <label class="form-label">Platforms</label>
+        <input type="text" name="streaming_platforms" value="{{ cfg.streaming_platforms | join(', ') }}" class="form-input" placeholder="Netflix, Amazon Prime Video">
+        <span class="form-hint">Comma-separated. Must match TMDB provider names. Empty = show all.</span>
+      </div>
+    </div>
+  </fieldset>
+
+  <!-- Manual titles -->
+  <fieldset style="border:1px solid var(--border); border-radius:6px; padding:1.25rem; background:var(--surface);">
+    <legend class="mono" style="font-size:0.62rem; letter-spacing:0.12em; text-transform:uppercase; color:var(--accent); padding:0 0.5rem;">Manual Titles</legend>
+    <p class="section-intro">How manually added titles are scored. They have no real watch data, so synthetic values are used.</p>
+    {% set manual_timestamp_is_now = cfg.manual.timestamp == 'now' %}
+
+    <div style="display:grid; grid-template-columns:1fr 1fr 1fr; gap:1rem;">
+      <div class="form-row">
+        <label class="form-label">Timestamp</label>
+        <div style="display:flex; gap:0.5rem; align-items:center; flex-wrap:wrap;">
+          <select id="manual-timestamp-mode" name="manual_timestamp_mode" class="form-input" style="width:120px;">
+            <option value="now" {{ 'selected' if manual_timestamp_is_now }}>now</option>
+            <option value="fixed" {{ 'selected' if not manual_timestamp_is_now }}>fixed date</option>
+          </select>
+          <input
+            id="manual-timestamp-date"
+            type="date"
+            name="manual_timestamp_date"
+            value="{{ cfg.manual.timestamp if not manual_timestamp_is_now else '2022-01-01' }}"
+            class="form-input"
+            style="width:150px;"
+            {{ 'disabled' if manual_timestamp_is_now }}
+          >
+        </div>
+        <span class="form-hint">"now" = competes with recent watches. Fixed = scores lower.</span>
+      </div>
+      <div class="form-row">
+        <label class="form-label">TV duration (min)</label>
+        <input type="number" name="manual_tv_duration" value="{{ cfg.manual.tv_duration_minutes }}" class="form-input" style="width:80px;" min="1">
+        <span class="form-hint">Synthetic watch duration for TV titles</span>
+      </div>
+      <div class="form-row">
+        <label class="form-label">Movie duration (min)</label>
+        <input type="number" name="manual_movie_duration" value="{{ cfg.manual.movie_duration_minutes }}" class="form-input" style="width:80px;" min="1">
+        <span class="form-hint">Synthetic watch duration for movies</span>
+      </div>
+    </div>
+  </fieldset>
+
+  <!-- Logging -->
+  <fieldset style="border:1px solid var(--border); border-radius:6px; padding:1.25rem; background:var(--surface);">
+    <legend class="mono" style="font-size:0.62rem; letter-spacing:0.12em; text-transform:uppercase; color:var(--accent); padding:0 0.5rem;">Logging</legend>
+
+    <div class="form-row">
+      <label class="form-label">Log level</label>
+      <select name="log_level" class="form-input" style="width:150px;">
+        {% for level in ['WARNING', 'INFO', 'DEBUG'] %}
+        <option value="{{ level }}" {{ 'selected' if cfg.log_level == level }}>{{ level }}</option>
+        {% endfor %}
+      </select>
+      <span class="form-hint">WARNING = errors only. INFO = request logs. DEBUG = full pipeline trace.</span>
+    </div>
+  </fieldset>
+
+  <div style="display:flex; gap:1rem; align-items:center;">
+    <button type="submit" class="btn-primary" style="padding:0.75rem 2rem;">Save &amp; Reload</button>
+    <span class="mono" style="font-size:0.58rem; color:var(--muted);">Writes to config.yaml and reloads the application context.</span>
+  </div>
+
+</form>
+
+<style>
+  fieldset { border-color: var(--border); }
+  .section-intro {
+    font-size: 0.82rem;
+    color: var(--muted);
+    margin: 0 0 1rem;
+    line-height: 1.6;
+  }
+  .form-row { display:flex; flex-direction:column; gap:0.25rem; }
+  .form-label {
+    font-family: 'DM Sans', sans-serif;
+    font-size: 0.8rem;
+    color: var(--body);
+  }
+  .form-hint {
+    font-size: 0.68rem;
+    color: var(--muted);
+    line-height: 1.4;
+    margin-top: 1px;
+  }
+  .form-input {
+    background: var(--bg);
+    border: 1px solid var(--border);
+    color: var(--text);
+    font-family: 'JetBrains Mono', monospace;
+    font-size: 0.78rem;
+    padding: 0.45rem 0.65rem;
+    border-radius: 4px;
+    outline: none;
+    transition: border-color 0.2s;
+  }
+  .form-input:focus { border-color: var(--accent); }
+  select.form-input { cursor: pointer; }
+  select.form-input option { background: var(--surface); color: var(--text); }
+</style>
+
+<script>
+  // Live weight validation
+  (function() {
+    var fields = ['weight_completion', 'weight_rewatch', 'weight_recency'];
+    var warn = document.getElementById('weight-warn');
+    var manualMode = document.getElementById('manual-timestamp-mode');
+    var manualDate = document.getElementById('manual-timestamp-date');
+    fields.forEach(function(name) {
+      var el = document.querySelector('[name="' + name + '"]');
+      if (el) el.addEventListener('input', checkWeights);
+    });
+    function checkWeights() {
+      var sum = 0;
+      fields.forEach(function(name) {
+        sum += parseFloat(document.querySelector('[name="' + name + '"]').value) || 0;
+      });
+      warn.style.display = Math.abs(sum - 1.0) > 0.01 ? 'block' : 'none';
+    }
+    function syncManualTimestampInput() {
+      if (!manualMode || !manualDate) return;
+      var useFixedDate = manualMode.value === 'fixed';
+      manualDate.disabled = !useFixedDate;
+    }
+    if (manualMode) {
+      manualMode.addEventListener('change', syncManualTimestampInput);
+      syncManualTimestampInput();
+    }
+  })();
+</script>
+
+{% endblock %}

--- a/recommender/web.py
+++ b/recommender/web.py
@@ -5,10 +5,13 @@ import logging
 import os
 import re
 import sys
+from copy import deepcopy
+from datetime import datetime
 from pathlib import Path
 
+import yaml
 from recommender.llm import create_client
-from flask import Flask, jsonify, render_template, request
+from flask import Flask, jsonify, redirect, render_template, request, url_for
 from markupsafe import Markup, escape
 
 import config
@@ -309,6 +312,344 @@ def title_detail(tmdb_id: int) -> str:
             overview = raw.get("overview", "")
     return render_template("title.html", meta=meta, description=description, overview=overview,
                            tmdb_id=tmdb_id, ct=ct, poster=poster)
+
+
+@app.route("/help")
+def help_page() -> str:
+    return render_template("help.html")
+
+
+_CONFIG_PATH = Path(__file__).parent.parent / "config.yaml"
+_SETTINGS_DEFAULTS = {
+    "provider": "anthropic",
+    "models": {
+        "anthropic": {
+            "fast": "claude-haiku-4-5-20251001",
+            "reason": "claude-sonnet-4-6",
+        },
+        "gemini": {
+            "fast": "gemini-2.5-flash",
+            "reason": "gemini-2.5-flash",
+        },
+    },
+    "llm": {
+        "timeout_fast": 30,
+        "timeout_reason": 60,
+        "timeout_profile_batch": 60,
+        "timeout_profile_merge": 300,
+        "tokens_fast": 200,
+        "tokens_intent": 400,
+        "tokens_ranking": 1000,
+        "tokens_suggestions": 300,
+        "tokens_profile_batch": 800,
+        "tokens_profile_merge": 4000,
+        "tokens_abandoned": 300,
+        "profile_batch_size": 200,
+        "rate_limit_wait": 65,
+    },
+    "scoring": {
+        "weight_completion": 0.5,
+        "weight_rewatch": 0.3,
+        "weight_recency": 0.2,
+        "default_tv_runtime": 45,
+        "default_movie_runtime": 90,
+        "rewatch_saturation": 5,
+    },
+    "default_top_n": 3,
+    "min_vote_count": 20,
+    "recency_half_life_days": 90,
+    "watch_region": "US",
+    "streaming_platforms": [],
+    "manual": {
+        "timestamp": "now",
+        "tv_duration_minutes": 45,
+        "movie_duration_minutes": 120,
+    },
+    "log_level": "WARNING",
+}
+
+_PROFILE_REBUILD_LLM_KEYS = (
+    "timeout_profile_batch",
+    "timeout_profile_merge",
+    "tokens_profile_batch",
+    "tokens_profile_merge",
+    "profile_batch_size",
+    "rate_limit_wait",
+)
+_PROFILE_REBUILD_SCORING_KEYS = (
+    "weight_completion",
+    "weight_rewatch",
+    "weight_recency",
+    "default_tv_runtime",
+    "default_movie_runtime",
+    "rewatch_saturation",
+)
+
+
+def _load_config_yaml() -> dict:
+    """Load raw config.yaml as a dict for the settings form."""
+    with open(_CONFIG_PATH) as f:
+        return yaml.safe_load(f) or {}
+
+
+def _save_config_yaml(cfg: dict) -> None:
+    """Write config dict back to config.yaml, preserving comments where possible."""
+    with open(_CONFIG_PATH, "w") as f:
+        f.write("# Streamline configuration\n")
+        f.write("# Secrets (API keys) go in .env, everything else goes here.\n\n")
+        yaml.dump(cfg, f, default_flow_style=False, sort_keys=False, allow_unicode=True)
+
+
+def _merge_settings_defaults(target: dict, source: dict) -> dict:
+    for key, value in source.items():
+        if isinstance(value, dict):
+            existing = target.get(key)
+            if not isinstance(existing, dict):
+                existing = {}
+            target[key] = _merge_settings_defaults(existing, value)
+            continue
+        target[key] = value
+    return target
+
+
+def _resolve_settings_config(raw_cfg: dict | None = None) -> dict:
+    cfg = deepcopy(_SETTINGS_DEFAULTS)
+    return _merge_settings_defaults(cfg, raw_cfg or {})
+
+
+def _render_settings_page(
+    cfg: dict | None = None,
+    *,
+    saved: str | bool | None = None,
+    error: str | None = None,
+) -> str:
+    resolved_cfg = _resolve_settings_config(cfg if cfg is not None else _load_config_yaml())
+    return render_template("settings.html", cfg=resolved_cfg, saved=saved, error=error)
+
+
+def _reload_app_config() -> None:
+    """Reload config module and rebuild app context."""
+    global _ctx
+    import importlib
+    importlib.reload(config)
+    _ctx = None  # next request will rebuild context
+    log.info("Config reloaded from config.yaml")
+
+
+def _parse_int_field(form, key: str, default: int) -> int:
+    value = (form.get(key) or "").strip()
+    if not value:
+        return default
+    try:
+        return int(value)
+    except ValueError as exc:
+        raise ValueError(f"{key} must be an integer.") from exc
+
+
+def _parse_float_field(form, key: str, default: float) -> float:
+    value = (form.get(key) or "").strip()
+    if not value:
+        return default
+    try:
+        return float(value)
+    except ValueError as exc:
+        raise ValueError(f"{key} must be a number.") from exc
+
+
+def _parse_manual_timestamp(form, current_cfg: dict) -> str:
+    mode = (form.get("manual_timestamp_mode") or "").strip() or (
+        "now" if current_cfg["manual"]["timestamp"] == "now" else "fixed"
+    )
+    if mode == "now":
+        return "now"
+
+    date_value = (form.get("manual_timestamp_date") or "").strip()
+    if not date_value:
+        fallback = current_cfg["manual"]["timestamp"]
+        date_value = fallback if fallback != "now" else "2022-01-01"
+    try:
+        datetime.strptime(date_value, "%Y-%m-%d")
+    except ValueError as exc:
+        raise ValueError("manual_timestamp_date must use YYYY-MM-DD.") from exc
+    return date_value
+
+
+def _settings_refresh_flags(previous_cfg: dict, updated_cfg: dict) -> tuple[bool, bool]:
+    refresh_data = any(
+        previous_cfg["manual"][key] != updated_cfg["manual"][key]
+        for key in ("timestamp", "tv_duration_minutes", "movie_duration_minutes")
+    )
+    refresh_profile = refresh_data
+    refresh_profile = refresh_profile or any(
+        previous_cfg["scoring"][key] != updated_cfg["scoring"][key]
+        for key in _PROFILE_REBUILD_SCORING_KEYS
+    )
+    refresh_profile = refresh_profile or previous_cfg["recency_half_life_days"] != updated_cfg["recency_half_life_days"]
+    refresh_profile = refresh_profile or any(
+        previous_cfg["llm"][key] != updated_cfg["llm"][key]
+        for key in _PROFILE_REBUILD_LLM_KEYS
+    )
+    return refresh_profile, refresh_data
+
+
+def _refresh_derived_data(refresh_profile: bool, refresh_data: bool) -> None:
+    global _ctx
+    if not refresh_profile and not refresh_data:
+        return
+
+    from recommender.setup import run_setup
+
+    run_setup(refresh_profile=refresh_profile, refresh_data=refresh_data)
+    _ctx = None
+    log.info(
+        "Rebuilt derived data after settings save (refresh_profile=%s, refresh_data=%s)",
+        refresh_profile,
+        refresh_data,
+    )
+
+
+@app.route("/settings", methods=["GET"])
+def settings_page() -> str:
+    return _render_settings_page(saved=request.args.get("saved"))
+
+
+@app.route("/settings", methods=["POST"])
+def settings_save() -> str:
+    cfg = _load_config_yaml()
+    current_cfg = _resolve_settings_config(cfg)
+    form = request.form
+
+    try:
+        llm_values = {
+            key: _parse_int_field(form, f"llm_{key}", current_cfg["llm"][key])
+            for key in (
+                "timeout_fast",
+                "timeout_reason",
+                "timeout_profile_batch",
+                "timeout_profile_merge",
+                "tokens_fast",
+                "tokens_intent",
+                "tokens_ranking",
+                "tokens_suggestions",
+                "tokens_profile_batch",
+                "tokens_profile_merge",
+                "tokens_abandoned",
+                "profile_batch_size",
+                "rate_limit_wait",
+            )
+        }
+        scoring_values = {
+            "weight_completion": _parse_float_field(
+                form, "weight_completion", current_cfg["scoring"]["weight_completion"]
+            ),
+            "weight_rewatch": _parse_float_field(
+                form, "weight_rewatch", current_cfg["scoring"]["weight_rewatch"]
+            ),
+            "weight_recency": _parse_float_field(
+                form, "weight_recency", current_cfg["scoring"]["weight_recency"]
+            ),
+            "default_tv_runtime": _parse_int_field(
+                form, "default_tv_runtime", current_cfg["scoring"]["default_tv_runtime"]
+            ),
+            "default_movie_runtime": _parse_int_field(
+                form, "default_movie_runtime", current_cfg["scoring"]["default_movie_runtime"]
+            ),
+            "rewatch_saturation": _parse_int_field(
+                form, "rewatch_saturation", current_cfg["scoring"]["rewatch_saturation"]
+            ),
+        }
+        recommendation_values = {
+            "default_top_n": _parse_int_field(form, "default_top_n", current_cfg["default_top_n"]),
+            "min_vote_count": _parse_int_field(form, "min_vote_count", current_cfg["min_vote_count"]),
+            "recency_half_life_days": _parse_int_field(
+                form, "recency_half_life_days", current_cfg["recency_half_life_days"]
+            ),
+        }
+        manual_values = {
+            "timestamp": _parse_manual_timestamp(form, current_cfg),
+            "tv_duration_minutes": _parse_int_field(
+                form, "manual_tv_duration", current_cfg["manual"]["tv_duration_minutes"]
+            ),
+            "movie_duration_minutes": _parse_int_field(
+                form, "manual_movie_duration", current_cfg["manual"]["movie_duration_minutes"]
+            ),
+        }
+    except ValueError as exc:
+        return _render_settings_page(cfg=current_cfg, saved=False, error=str(exc))
+
+    # Validate scoring weights sum to 1.0
+    w_comp = scoring_values["weight_completion"]
+    w_rew = scoring_values["weight_rewatch"]
+    w_rec = scoring_values["weight_recency"]
+    try:
+        if abs((w_comp + w_rew + w_rec) - 1.0) > 0.01:
+            return _render_settings_page(
+                cfg=current_cfg,
+                saved=False,
+                error=f"Scoring weights must sum to 1.0 (got {w_comp + w_rew + w_rec:.2f})",
+            )
+    except ValueError:
+        return _render_settings_page(cfg=current_cfg, saved=False, error="Invalid scoring weights.")
+
+    # Provider & models
+    cfg["provider"] = form.get("provider", "anthropic")
+    cfg.setdefault("models", {})
+    cfg["models"]["anthropic"] = {
+        "fast": form.get("anthropic_fast", "").strip(),
+        "reason": form.get("anthropic_reason", "").strip(),
+    }
+    cfg["models"]["gemini"] = {
+        "fast": form.get("gemini_fast", "").strip(),
+        "reason": form.get("gemini_reason", "").strip(),
+    }
+
+    # LLM limits
+    llm = cfg.setdefault("llm", {})
+    llm.update(llm_values)
+
+    # Scoring
+    scoring = cfg.setdefault("scoring", {})
+    scoring.update(scoring_values)
+
+    # Recommendations
+    cfg.update(recommendation_values)
+
+    # Streaming
+    cfg["watch_region"] = form.get("watch_region", "US").strip().upper()
+    platforms_str = form.get("streaming_platforms", "").strip()
+    cfg["streaming_platforms"] = [p.strip() for p in platforms_str.split(",") if p.strip()] if platforms_str else []
+
+    # Manual
+    manual = cfg.setdefault("manual", {})
+    manual.update(manual_values)
+
+    # Logging
+    cfg["log_level"] = form.get("log_level", "WARNING")
+
+    updated_cfg = _resolve_settings_config(cfg)
+    refresh_profile, refresh_data = _settings_refresh_flags(current_cfg, updated_cfg)
+
+    _save_config_yaml(cfg)
+    _reload_app_config()
+    try:
+        if refresh_profile or refresh_data:
+            _refresh_derived_data(refresh_profile=refresh_profile, refresh_data=refresh_data)
+    except SystemExit as exc:
+        log.error("Derived data rebuild exited during settings save with status %s", exc.code)
+        return _render_settings_page(
+            cfg=updated_cfg,
+            saved=False,
+            error="Settings were saved, but derived data rebuild failed. Check the server log.",
+        )
+    except Exception as exc:
+        log.exception("Failed to rebuild derived data after settings save")
+        return _render_settings_page(
+            cfg=updated_cfg,
+            saved=False,
+            error=f"Settings were saved, but derived data rebuild failed: {exc}",
+        )
+
+    return redirect(url_for("settings_page", saved="1"))
 
 
 def run() -> None:

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -3,6 +3,7 @@ from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 import pytest
+import yaml
 
 from recommender.models import Recommendation
 
@@ -88,3 +89,142 @@ def test_resolve_platform_path_allows_explicit_disable(monkeypatch):
 
     monkeypatch.setattr(config, '_paths', {'netflix': ''})
     assert config._resolve_platform_path('netflix', 'data/netflix/ViewingActivity.csv') is None
+
+
+def _settings_test_client(tmp_path, monkeypatch, raw_cfg: dict | None = None):
+    from recommender import web
+
+    config_path = tmp_path / "config.yaml"
+    config_path.write_text(yaml.safe_dump(raw_cfg or {}, sort_keys=False))
+
+    refresh_calls: list[tuple[bool, bool]] = []
+
+    def record_refresh(*, refresh_profile: bool, refresh_data: bool) -> None:
+        refresh_calls.append((refresh_profile, refresh_data))
+
+    monkeypatch.setattr(web, "_CONFIG_PATH", config_path)
+    monkeypatch.setattr(web, "_reload_app_config", lambda: None)
+    monkeypatch.setattr(web, "_refresh_derived_data", record_refresh)
+    web.app.config.update(TESTING=True)
+    return web.app.test_client(), config_path, refresh_calls, web
+
+
+def _settings_form_data(web, raw_cfg: dict | None = None, **overrides):
+    cfg = web._resolve_settings_config(raw_cfg or {})
+    data = {
+        "provider": cfg["provider"],
+        "anthropic_fast": cfg["models"]["anthropic"]["fast"],
+        "anthropic_reason": cfg["models"]["anthropic"]["reason"],
+        "gemini_fast": cfg["models"]["gemini"]["fast"],
+        "gemini_reason": cfg["models"]["gemini"]["reason"],
+        "llm_timeout_fast": str(cfg["llm"]["timeout_fast"]),
+        "llm_timeout_reason": str(cfg["llm"]["timeout_reason"]),
+        "llm_timeout_profile_batch": str(cfg["llm"]["timeout_profile_batch"]),
+        "llm_timeout_profile_merge": str(cfg["llm"]["timeout_profile_merge"]),
+        "llm_tokens_fast": str(cfg["llm"]["tokens_fast"]),
+        "llm_tokens_intent": str(cfg["llm"]["tokens_intent"]),
+        "llm_tokens_ranking": str(cfg["llm"]["tokens_ranking"]),
+        "llm_tokens_suggestions": str(cfg["llm"]["tokens_suggestions"]),
+        "llm_tokens_profile_batch": str(cfg["llm"]["tokens_profile_batch"]),
+        "llm_tokens_profile_merge": str(cfg["llm"]["tokens_profile_merge"]),
+        "llm_tokens_abandoned": str(cfg["llm"]["tokens_abandoned"]),
+        "llm_profile_batch_size": str(cfg["llm"]["profile_batch_size"]),
+        "llm_rate_limit_wait": str(cfg["llm"]["rate_limit_wait"]),
+        "weight_completion": str(cfg["scoring"]["weight_completion"]),
+        "weight_rewatch": str(cfg["scoring"]["weight_rewatch"]),
+        "weight_recency": str(cfg["scoring"]["weight_recency"]),
+        "default_tv_runtime": str(cfg["scoring"]["default_tv_runtime"]),
+        "default_movie_runtime": str(cfg["scoring"]["default_movie_runtime"]),
+        "rewatch_saturation": str(cfg["scoring"]["rewatch_saturation"]),
+        "default_top_n": str(cfg["default_top_n"]),
+        "min_vote_count": str(cfg["min_vote_count"]),
+        "recency_half_life_days": str(cfg["recency_half_life_days"]),
+        "watch_region": cfg["watch_region"],
+        "streaming_platforms": ", ".join(cfg["streaming_platforms"]),
+        "manual_timestamp_mode": "now" if cfg["manual"]["timestamp"] == "now" else "fixed",
+        "manual_timestamp_date": "2022-01-01" if cfg["manual"]["timestamp"] == "now" else cfg["manual"]["timestamp"],
+        "manual_tv_duration": str(cfg["manual"]["tv_duration_minutes"]),
+        "manual_movie_duration": str(cfg["manual"]["movie_duration_minutes"]),
+        "log_level": cfg["log_level"],
+    }
+    data.update(overrides)
+    return data
+
+
+def test_settings_page_populates_runtime_defaults_and_accepts_blank_numeric_fields(tmp_path, monkeypatch):
+    raw_cfg = {"provider": "gemini"}
+    client, config_path, refresh_calls, web = _settings_test_client(tmp_path, monkeypatch, raw_cfg)
+
+    response = client.get("/settings")
+    body = response.get_data(as_text=True)
+
+    assert response.status_code == 200
+    assert 'name="llm_timeout_fast" value="30"' in body
+    assert 'name="default_tv_runtime" value="45"' in body
+    assert 'name="default_top_n" value="3"' in body
+    assert 'name="recency_half_life_days" value="90"' in body
+
+    post_response = client.post(
+        "/settings",
+        data=_settings_form_data(
+            web,
+            raw_cfg,
+            llm_timeout_fast="",
+            weight_completion="",
+            default_tv_runtime="",
+            default_top_n="",
+            recency_half_life_days="",
+            manual_tv_duration="",
+        ),
+    )
+
+    assert post_response.status_code == 302
+    saved_cfg = yaml.safe_load(config_path.read_text())
+    assert saved_cfg["llm"]["timeout_fast"] == 30
+    assert saved_cfg["scoring"]["weight_completion"] == 0.5
+    assert saved_cfg["scoring"]["default_tv_runtime"] == 45
+    assert saved_cfg["default_top_n"] == 3
+    assert saved_cfg["recency_half_life_days"] == 90
+    assert saved_cfg["manual"]["tv_duration_minutes"] == 45
+    assert refresh_calls == []
+
+
+def test_settings_save_preserves_custom_manual_timestamp(tmp_path, monkeypatch):
+    raw_cfg = {"manual": {"timestamp": "2024-07-01"}}
+    client, config_path, refresh_calls, web = _settings_test_client(tmp_path, monkeypatch, raw_cfg)
+
+    response = client.get("/settings")
+    body = response.get_data(as_text=True)
+
+    assert response.status_code == 200
+    assert 'name="manual_timestamp_date"' in body
+    assert 'value="2024-07-01"' in body
+
+    post_response = client.post(
+        "/settings",
+        data=_settings_form_data(web, raw_cfg, log_level="DEBUG"),
+    )
+
+    assert post_response.status_code == 302
+    saved_cfg = yaml.safe_load(config_path.read_text())
+    assert saved_cfg["manual"]["timestamp"] == "2024-07-01"
+    assert refresh_calls == []
+
+
+def test_settings_save_rebuilds_profile_after_setup_only_change(tmp_path, monkeypatch):
+    raw_cfg = {"provider": "anthropic"}
+    client, _, refresh_calls, web = _settings_test_client(tmp_path, monkeypatch, raw_cfg)
+
+    post_response = client.post(
+        "/settings",
+        data=_settings_form_data(
+            web,
+            raw_cfg,
+            weight_completion="0.6",
+            weight_rewatch="0.2",
+            weight_recency="0.2",
+        ),
+    )
+
+    assert post_response.status_code == 302
+    assert refresh_calls == [(True, False)]


### PR DESCRIPTION
## Summary
- Settings page at `/settings` exposing all `config.yaml` values in an editable form
- Save writes back to `config.yaml` and reloads app context (no restart needed)
- Scoring weight validation (must sum to 1.0) on both client and server

## Sections
- LLM Provider (provider, model assignments per provider)
- LLM Limits (timeouts, max output tokens, batch size, rate limit wait)
- Scoring (weights, runtimes, rewatch saturation)
- Recommendations (default top_n, min votes, recency half-life)
- Streaming (watch region, platform list)
- Manual Titles (timestamp mode, durations)
- Logging (log level)

## Test plan
- [x] 83 existing tests pass
- [ ] Open `/settings`, verify all values match config.yaml
- [ ] Change provider to gemini, save, verify config.yaml updated
- [ ] Set weights to 0.4/0.4/0.3 — should show validation error
- [ ] Save valid changes, run a search — verify new config takes effect

Closes #9