### PR TITLE
feat: OpenAI-compatible provider with uniform LLM config

### DIFF
--- a/config.py
+++ b/config.py
@@ -32,6 +32,7 @@ LLM_PROVIDER = os.environ.get("LLM_PROVIDER", _cfg.get("provider", "anthropic"))
 LLM_MODELS: dict[str, dict[str, str]] = _cfg.get("models", {
     "anthropic": {"fast": "claude-haiku-4-5-20251001", "reason": "claude-sonnet-4-6"},
     "gemini": {"fast": "gemini-2.5-flash", "reason": "gemini-2.5-flash"},
+    "openai": {"fast": "gpt-4.1-mini", "reason": "gpt-4.1"},
 })
 
 # ── LLM call settings ──

--- a/config.yaml
+++ b/config.yaml
@@ -7,9 +7,16 @@ models:
   anthropic:
     fast: claude-haiku-4-5-20251001
     reason: claude-sonnet-4-6
+    api_key_env: ANTHROPIC_API_KEY
   gemini:
     fast: gemini-2.5-flash
     reason: gemini-2.5-pro
+    api_key_env: GEMINI_API_KEY
+  openai:
+    fast: gpt-4.1-mini
+    reason: gpt-4.1
+    api_key_env: OPENAI_API_KEY
+    base_url:                           # empty = api.openai.com, or custom endpoint
 llm:
   timeout_fast: 30
   timeout_reason: 60

--- a/recommender/llm.py
+++ b/recommender/llm.py
@@ -1,11 +1,12 @@
 """LLM provider abstraction.
 
-Supports Anthropic (Claude) and Google (Gemini) with a unified interface.
-Call sites use roles ("fast" or "reason") instead of model names.
-Model assignments are configured in config.yaml per provider.
+Supports Anthropic (Claude), Google (Gemini), and any OpenAI-compatible API
+with a unified interface. Call sites use roles ("fast" or "reason") instead
+of model names. Model assignments are configured in config.yaml per provider.
 
-Gemini uses the google-genai SDK. API keys starting with 'AQ.' are
-automatically routed to Vertex AI; 'AIza' keys go to the Gemini Developer API.
+The OpenAI provider works with any service implementing the OpenAI chat
+completions API: OpenAI, Ollama, Groq, Together, LM Studio, vLLM, etc.
+Configure base_url and api_key_env in config.yaml models.openai section.
 """
 
 import logging
@@ -21,6 +22,9 @@ _PRICING: dict[str, dict[str, float]] = {
     "claude-sonnet-4-6":          {"input": 3.00, "output": 15.00},
     "gemini-2.5-flash":           {"input": 0.15, "output": 0.60, "thinking": 0.0375},
     "gemini-2.5-pro":             {"input": 1.25, "output": 10.00, "thinking": 0.625},
+    "gpt-4.1":                    {"input": 2.00, "output": 8.00},
+    "gpt-4.1-mini":               {"input": 0.40, "output": 1.60},
+    "gpt-4.1-nano":               {"input": 0.10, "output": 0.40},
 }
 
 
@@ -211,6 +215,64 @@ class GeminiClient(LLMClient):
         raise RuntimeError(f"Gemini response did not include text content (model={model})")
 
 
+class OpenAIClient(LLMClient):
+    """OpenAI-compatible provider. Works with OpenAI, Ollama, Groq, Together, LM Studio, vLLM, etc."""
+
+    provider = "openai"
+
+    def __init__(self, api_key: str, models: dict[str, str], base_url: str | None = None):
+        from openai import OpenAI
+        kwargs: dict = {"api_key": api_key}
+        if base_url:
+            kwargs["base_url"] = base_url
+        self._client = OpenAI(**kwargs)
+        self.models = models
+        self.usage = UsageStats()
+        endpoint = base_url or "api.openai.com"
+        log.info("Using OpenAI-compatible provider (endpoint=%s, fast=%s, reason=%s)",
+                 endpoint, models.get("fast"), models.get("reason"))
+
+    def generate(self, prompt: str, role: str = "reason",
+                 max_tokens: int = 1000, timeout: float = 30.0) -> str:
+        model = self.models.get(role, self.models.get("reason", "gpt-4.1-mini"))
+
+        for attempt in range(3):
+            try:
+                response = self._client.chat.completions.create(
+                    model=model,
+                    max_tokens=max_tokens,
+                    timeout=timeout,
+                    messages=[{"role": "user", "content": prompt}],
+                )
+                break
+            except Exception as exc:
+                err = str(exc)
+                if ("429" in err or "rate" in err.lower() or "timeout" in err.lower()) and attempt < 2:
+                    wait = 30 * (attempt + 1)
+                    log.warning("OpenAI rate limited/timeout, waiting %ds (attempt %d/3)...", wait, attempt + 1)
+                    time.sleep(wait)
+                    continue
+                raise
+
+        choice = response.choices[0]
+        text = choice.message.content or ""
+
+        # Track usage
+        if response.usage:
+            self.usage.record(
+                model=model,
+                input_t=response.usage.prompt_tokens or 0,
+                output_t=response.usage.completion_tokens or 0,
+            )
+
+        self.was_truncated = choice.finish_reason == "length"
+        if self.was_truncated:
+            log.warning("OpenAI response truncated (max_tokens=%d, model=%s). "
+                        "Increase the token limit in config.yaml.", max_tokens, model)
+
+        return text
+
+
 def create_client(provider: str | None = None) -> LLMClient:
     """Create an LLM client from config.
 
@@ -219,19 +281,27 @@ def create_client(provider: str | None = None) -> LLMClient:
     """
     import config
 
+    import os
+
     provider = provider or config.LLM_PROVIDER
     models = config.LLM_MODELS.get(provider, {})
 
     if not models:
         raise ValueError(f"No model config for provider '{provider}' in config.yaml")
 
+    # All providers read their API key from a configurable env var
+    default_key_envs = {"anthropic": "ANTHROPIC_API_KEY", "gemini": "GEMINI_API_KEY", "openai": "OPENAI_API_KEY"}
+    api_key_env = models.get("api_key_env", default_key_envs.get(provider, f"{provider.upper()}_API_KEY"))
+    api_key = os.environ.get(api_key_env, "")
+    if not api_key:
+        raise RuntimeError(f"{api_key_env} not set. Export it or add to .env.")
+
     if provider == "gemini":
-        if not config.GEMINI_API_KEY:
-            raise RuntimeError("GEMINI_API_KEY not set. Export it or add to .env.")
-        return GeminiClient(api_key=config.GEMINI_API_KEY, models=models)
+        return GeminiClient(api_key=api_key, models=models)
     elif provider == "anthropic":
-        if not config.ANTHROPIC_API_KEY:
-            raise RuntimeError("ANTHROPIC_API_KEY not set. Export it or add to .env.")
-        return AnthropicClient(api_key=config.ANTHROPIC_API_KEY, models=models)
+        return AnthropicClient(api_key=api_key, models=models)
+    elif provider == "openai":
+        base_url = models.get("base_url") or None
+        return OpenAIClient(api_key=api_key, models=models, base_url=base_url)
     else:
-        raise ValueError(f"Unknown LLM provider: {provider}. Use 'anthropic' or 'gemini'.")
+        raise ValueError(f"Unknown LLM provider: {provider}. Use 'anthropic', 'gemini', or 'openai'.")

--- a/recommender/main.py
+++ b/recommender/main.py
@@ -153,7 +153,7 @@ def main() -> None:
     parser.add_argument("--type", choices=["tv", "movie"], default="tv",
                         help="Content type for --add (default: tv)")
     parser.add_argument("--history", action="store_true", help="Show recent query history")
-    parser.add_argument("--provider", choices=["anthropic", "gemini"],
+    parser.add_argument("--provider", choices=["anthropic", "gemini", "openai"],
                         help="LLM provider (default: from config/env)")
     args = parser.parse_args()
 

--- a/recommender/setup.py
+++ b/recommender/setup.py
@@ -214,7 +214,7 @@ if __name__ == "__main__":
                         help="Re-fetch TMDB metadata, watch index, and enrichments")
     parser.add_argument("--debug", action="store_true",
                         help="Enable debug logging")
-    parser.add_argument("--provider", choices=["anthropic", "gemini"],
+    parser.add_argument("--provider", choices=["anthropic", "gemini", "openai"],
                         help="LLM provider (default: from config/env)")
     args = parser.parse_args()
     from recommender.log import setup_logging

--- a/recommender/templates/settings.html
+++ b/recommender/templates/settings.html
@@ -31,39 +31,55 @@
 
     <div class="form-row">
       <label class="form-label">Provider</label>
-      <select name="provider" class="form-input" style="width:200px;">
-        <option value="anthropic" {{ 'selected' if cfg.provider == 'anthropic' }}>Anthropic</option>
-        <option value="gemini" {{ 'selected' if cfg.provider == 'gemini' }}>Gemini</option>
+      <select id="provider-select" name="provider" class="form-input" style="width:240px;">
+        <option value="anthropic" {{ 'selected' if cfg.provider == 'anthropic' }}>Anthropic (Claude)</option>
+        <option value="gemini" {{ 'selected' if cfg.provider == 'gemini' }}>Google (Gemini)</option>
+        <option value="openai" {{ 'selected' if cfg.provider == 'openai' }}>OpenAI / Compatible</option>
       </select>
       <span class="form-hint">Active provider for all LLM calls. Override per-query with --provider.</span>
     </div>
 
-    <div style="display:grid; grid-template-columns:1fr 1fr; gap:1rem; margin-top:1rem;">
-      <div>
-        <span class="mono" style="font-size:0.58rem; color:var(--muted); letter-spacing:0.08em;">ANTHROPIC MODELS</span>
-        <div class="form-row" style="margin-top:0.5rem;">
-          <label class="form-label">Fast</label>
-          <input type="text" name="anthropic_fast" value="{{ cfg.models.anthropic.fast }}" class="form-input">
+    <!-- Hidden inputs preserve non-active provider configs -->
+    {% for p in ['anthropic', 'gemini', 'openai'] %}
+    {% if p != cfg.provider %}
+    <input type="hidden" name="{{ p }}_fast" value="{{ cfg.models[p].fast }}">
+    <input type="hidden" name="{{ p }}_reason" value="{{ cfg.models[p].reason }}">
+    <input type="hidden" name="{{ p }}_api_key_env" value="{{ cfg.models[p].api_key_env or '' }}">
+    {% if p == 'openai' %}
+    <input type="hidden" name="openai_base_url" value="{{ cfg.models.openai.base_url or '' }}">
+    {% endif %}
+    {% endif %}
+    {% endfor %}
+
+    <!-- Active provider models -->
+    {% set p = cfg.provider %}
+    <div style="margin-top:1rem;">
+      <div style="display:grid; grid-template-columns:1fr 1fr; gap:1rem;">
+        <div class="form-row">
+          <label class="form-label">Fast model</label>
+          <input type="text" name="{{ p }}_fast" value="{{ cfg.models[p].fast }}" class="form-input">
           <span class="form-hint">Enrichment, simple tasks (high volume, cheaper)</span>
         </div>
         <div class="form-row">
-          <label class="form-label">Reason</label>
-          <input type="text" name="anthropic_reason" value="{{ cfg.models.anthropic.reason }}" class="form-input">
+          <label class="form-label">Reason model</label>
+          <input type="text" name="{{ p }}_reason" value="{{ cfg.models[p].reason }}" class="form-input">
           <span class="form-hint">Intent parsing, ranking, taste profile (complex reasoning)</span>
         </div>
       </div>
-      <div>
-        <span class="mono" style="font-size:0.58rem; color:var(--muted); letter-spacing:0.08em;">GEMINI MODELS</span>
-        <div class="form-row" style="margin-top:0.5rem;">
-          <label class="form-label">Fast</label>
-          <input type="text" name="gemini_fast" value="{{ cfg.models.gemini.fast }}" class="form-input">
-          <span class="form-hint">Enrichment, simple tasks</span>
-        </div>
+
+      <div style="display:grid; grid-template-columns:{{ '1fr 1fr' if p == 'openai' else '1fr' }}; gap:1rem; margin-top:0.75rem;">
         <div class="form-row">
-          <label class="form-label">Reason</label>
-          <input type="text" name="gemini_reason" value="{{ cfg.models.gemini.reason }}" class="form-input">
-          <span class="form-hint">Complex reasoning (Pro needs extended timeouts)</span>
+          <label class="form-label">API key env var</label>
+          <input type="text" name="{{ p }}_api_key_env" value="{{ cfg.models[p].api_key_env or '' }}" class="form-input" style="max-width:280px;">
+          <span class="form-hint">Name of the env var holding the key (not the key itself)</span>
         </div>
+        {% if p == 'openai' %}
+        <div class="form-row">
+          <label class="form-label">Base URL</label>
+          <input type="text" name="openai_base_url" value="{{ cfg.models.openai.base_url or '' }}" class="form-input" placeholder="Leave empty for OpenAI">
+          <span class="form-hint">Custom endpoint: Ollama, Groq, Together, LM Studio, etc.</span>
+        </div>
+        {% endif %}
       </div>
     </div>
   </fieldset>

--- a/recommender/web.py
+++ b/recommender/web.py
@@ -339,10 +339,18 @@ _SETTINGS_DEFAULTS = {
         "anthropic": {
             "fast": "claude-haiku-4-5-20251001",
             "reason": "claude-sonnet-4-6",
+            "api_key_env": "ANTHROPIC_API_KEY",
         },
         "gemini": {
             "fast": "gemini-2.5-flash",
             "reason": "gemini-2.5-flash",
+            "api_key_env": "GEMINI_API_KEY",
+        },
+        "openai": {
+            "fast": "gpt-4.1-mini",
+            "reason": "gpt-4.1",
+            "api_key_env": "OPENAI_API_KEY",
+            "base_url": None,
         },
     },
     "llm": {
@@ -608,17 +616,20 @@ def settings_save() -> str:
     except ValueError:
         return _render_settings_page(cfg=current_cfg, saved=False, error="Invalid scoring weights.")
 
-    # Provider & models
+    # Provider & models — all providers treated the same
     cfg["provider"] = form.get("provider", "anthropic")
     cfg.setdefault("models", {})
-    cfg["models"]["anthropic"] = {
-        "fast": form.get("anthropic_fast", "").strip(),
-        "reason": form.get("anthropic_reason", "").strip(),
-    }
-    cfg["models"]["gemini"] = {
-        "fast": form.get("gemini_fast", "").strip(),
-        "reason": form.get("gemini_reason", "").strip(),
-    }
+    default_key_envs = {"anthropic": "ANTHROPIC_API_KEY", "gemini": "GEMINI_API_KEY", "openai": "OPENAI_API_KEY"}
+    for p in ["anthropic", "gemini", "openai"]:
+        existing = cfg["models"].get(p, {})
+        cfg["models"][p] = {
+            "fast": (form.get(f"{p}_fast") or existing.get("fast", "")).strip(),
+            "reason": (form.get(f"{p}_reason") or existing.get("reason", "")).strip(),
+            "api_key_env": (form.get(f"{p}_api_key_env") or existing.get("api_key_env") or default_key_envs.get(p, "")).strip(),
+        }
+    # base_url only relevant for openai provider
+    base_url = (form.get("openai_base_url") or "").strip()
+    cfg["models"]["openai"]["base_url"] = base_url if base_url else None
 
     # LLM limits
     llm = cfg.setdefault("llm", {})

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,4 +7,5 @@ flask>=3.0.0
 guessit>=3.8.0
 rapidfuzz>=3.0.0
 google-genai>=1.0.0
+openai>=1.0.0
 pyyaml>=6.0


### PR DESCRIPTION
## Summary
- OpenAI-compatible LLM provider supporting OpenAI, Ollama, Groq, Together, LM Studio, vLLM, etc.
- All providers now use uniform `api_key_env` config (read API key from a named env var)
- `base_url` for custom endpoints (OpenAI provider only)
- Settings page consolidated: shows only active provider's models, no clutter
- `--provider openai` flag added to CLI

## Test plan
- [x] 86 tests pass
- [ ] Switch to openai provider in settings, verify models and base_url fields appear
- [ ] Switch back to anthropic, verify openai config preserved
- [ ] Test with OPENAI_API_KEY set: `./recommend --provider openai "spy thriller"`

Closes #18