### PR TITLE
feat: unified LLM config and env-first secrets

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -32,8 +32,8 @@ python3 -m pytest tests/test_query_engine.py -v
 ./recommend-web restart
 ```
 
-Required env vars in `.env`: `TMDB_API_KEY`, plus `ANTHROPIC_API_KEY` and/or `GEMINI_API_KEY`.
-Settings in `config.yaml`: provider, model assignments, tunables, data paths.
+Required environment variables: `TMDB_API_KEY`, plus `ANTHROPIC_API_KEY` and/or `GEMINI_API_KEY` or `OPENAI_API_KEY`.
+`.env` is optional local convenience. Settings in `config.yaml`: provider, model assignments, tunables, data paths.
 
 ## Architecture
 
@@ -68,7 +68,8 @@ All under `recommender/cache/`: `tmdb/`, `enrichments/` (+ index.json), `provide
 
 ## Configuration
 
-- **`.env`** — secrets: `TMDB_API_KEY`, `ANTHROPIC_API_KEY`, `GEMINI_API_KEY`
+- **Environment variables** — secrets: `TMDB_API_KEY`, `ANTHROPIC_API_KEY`, `GEMINI_API_KEY`, `OPENAI_API_KEY`
+- **`.env`** — optional local convenience for setting those variables
 - **`config.yaml`** — all settings in sections:
   - `provider`, `models.*` — LLM provider and model assignments
   - `llm.*` — timeouts, token limits, batch sizes, rate limit wait
@@ -76,4 +77,5 @@ All under `recommender/cache/`: `tmdb/`, `enrichments/` (+ index.json), `provide
   - `manual.*` — synthetic timestamp and durations for manual list titles
   - Top-level: `default_top_n`, `min_vote_count`, `recency_half_life_days`, `watch_region`, `streaming_platforms`
   - Data paths: `platform_paths.*`, `overrides_path`
-- **`config.py`** — thin loader, reads from both. All values have sensible defaults.
+- `models.<provider>.api_key_env` is optional. Use it only for non-standard environment variable names.
+- **`config.py`** — thin loader, reads settings from `config.yaml` and secrets from the environment. All values have sensible defaults.

--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ git clone https://github.com/abhichandra21/streamline.git
 cd streamline
 python3 -m venv venv && source venv/bin/activate && pip install -r requirements.txt
 
-# 2. Add your API keys to .env (gitignored)
+# 2. Set your API keys in the environment (.env is optional local convenience)
 cat > .env << 'EOF'
 TMDB_API_KEY=your_key_here
 ANTHROPIC_API_KEY=your_key_here
@@ -146,7 +146,8 @@ Port and host are configurable via `STREAMLINE_PORT` and `STREAMLINE_HOST` envir
 
 Settings live in two places:
 
-- **`.env`** — secrets only (API keys, gitignored)
+- **Environment variables** — secrets only (`TMDB_API_KEY`, `ANTHROPIC_API_KEY`, `GEMINI_API_KEY`, `OPENAI_API_KEY`)
+- **`.env`** — optional local convenience for setting those environment variables (gitignored)
 - **`config.yaml`** — everything else (editable from the Settings page or by hand)
 
 ### LLM Providers
@@ -165,6 +166,14 @@ models:
 ```
 
 Switch providers by changing `provider:` in config.yaml or per-query with `--provider gemini`.
+
+By default, each provider reads its API key from the standard environment variable name:
+
+- Anthropic: `ANTHROPIC_API_KEY`
+- Gemini: `GEMINI_API_KEY`
+- OpenAI / compatible: `OPENAI_API_KEY`
+
+Only add `models.<provider>.api_key_env` in `config.yaml` when you need a non-standard variable name.
 
 ### Quality Filters
 

--- a/config.py
+++ b/config.py
@@ -1,6 +1,6 @@
 """Configuration loader.
 
-Reads secrets from environment (.env) and settings from config.yaml.
+Reads non-secret settings from config.yaml and secrets from the environment.
 All module-level attributes are available as before for backward compat.
 """
 
@@ -22,18 +22,39 @@ else:
 # ── Logging ──
 LOG_LEVEL = os.environ.get("LOG_LEVEL", _cfg.get("log_level", "WARNING")).upper()
 
-# ── Secrets (from .env / environment only) ──
+# ── Secrets (from environment only; .env is an optional launcher convenience) ──
 TMDB_API_KEY = os.environ.get("TMDB_API_KEY", "")
 ANTHROPIC_API_KEY = os.environ.get("ANTHROPIC_API_KEY", "")
 GEMINI_API_KEY = os.environ.get("GEMINI_API_KEY", "")
+OPENAI_API_KEY = os.environ.get("OPENAI_API_KEY", "")
+
+LLM_DEFAULT_API_KEY_ENVS: dict[str, str] = {
+    "anthropic": "ANTHROPIC_API_KEY",
+    "gemini": "GEMINI_API_KEY",
+    "openai": "OPENAI_API_KEY",
+}
 
 # ── LLM settings ──
 LLM_PROVIDER = os.environ.get("LLM_PROVIDER", _cfg.get("provider", "anthropic"))
 LLM_MODELS: dict[str, dict[str, str]] = _cfg.get("models", {
     "anthropic": {"fast": "claude-haiku-4-5-20251001", "reason": "claude-sonnet-4-6"},
     "gemini": {"fast": "gemini-2.5-flash", "reason": "gemini-2.5-flash"},
-    "openai": {"fast": "gpt-4.1-mini", "reason": "gpt-4.1"},
+    "openai": {"fast": "gpt-4.1-mini", "reason": "gpt-4.1", "base_url": None},
 })
+
+
+def get_llm_api_key_env(provider: str) -> str:
+    """Resolve the environment variable name for a provider API key.
+
+    The common case uses provider-specific defaults. config.yaml only needs an
+    api_key_env entry when the deployment uses a non-standard variable name.
+    """
+    configured_models = LLM_MODELS.get(provider, {})
+    configured_env = str(configured_models.get("api_key_env") or "").strip()
+    if configured_env:
+        return configured_env
+
+    return LLM_DEFAULT_API_KEY_ENVS.get(provider, f"{provider.upper()}_API_KEY")
 
 # ── LLM call settings ──
 _llm_cfg = _cfg.get("llm", {})

--- a/config.yaml
+++ b/config.yaml
@@ -1,5 +1,5 @@
 # Streamline configuration
-# Secrets (API keys) go in .env, everything else goes here.
+# Set API keys in the environment. .env is optional local convenience.
 
 log_level: DEBUG
 provider: anthropic
@@ -7,15 +7,12 @@ models:
   anthropic:
     fast: claude-haiku-4-5-20251001
     reason: claude-sonnet-4-6
-    api_key_env: ANTHROPIC_API_KEY
   gemini:
     fast: gemini-2.5-flash
     reason: gemini-2.5-pro
-    api_key_env: GEMINI_API_KEY
   openai:
     fast: gpt-4.1-mini
     reason: gpt-4.1
-    api_key_env: OPENAI_API_KEY
     base_url:                           # empty = api.openai.com, or custom endpoint
 llm:
   timeout_fast: 30

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -197,12 +197,15 @@ recommender/cache/
 
 ## Configuration
 
-Split across two files:
+Secrets come from the environment. `config.yaml` holds tracked application settings.
 
-**`.env`** — secrets only (gitignored):
+**Environment variables**:
 - `TMDB_API_KEY` — TMDB v3 API key
 - `ANTHROPIC_API_KEY` — Anthropic API key
 - `GEMINI_API_KEY` — Google Gemini API key (AIza* for AI Studio, AQ.* for Vertex AI)
+- `OPENAI_API_KEY` — OpenAI-compatible API key
+
+**`.env`** — optional local convenience for setting those variables (gitignored)
 
 **`config.yaml`** — all settings, organized in sections:
 
@@ -216,7 +219,9 @@ Split across two files:
 | *(top-level)* | `watch_region`, `streaming_platforms` | Streaming availability |
 | *(top-level)* | `platform_paths.*`, `manual_*_path`, `overrides_path` | Data file locations |
 
-`config.py` is a thin loader that reads from both. All values have sensible defaults — a minimal `config.yaml` with just `provider:` works.
+Provider API keys use the standard environment variable names by default. Add `models.<provider>.api_key_env` only when a deployment needs a non-standard variable name.
+
+`config.py` is a thin loader that reads settings from `config.yaml` and secrets from the environment. All values have sensible defaults — a minimal `config.yaml` with just `provider:` works.
 
 ### Taste Profile Batch Caching
 

--- a/recommend-web
+++ b/recommend-web
@@ -43,6 +43,34 @@ wait_for_port() {
     return 1
 }
 
+llm_api_key_env() {
+    python3 - "$SCRIPT_DIR" <<'PY'
+import sys
+import os
+from pathlib import Path
+
+import yaml
+
+script_dir = Path(sys.argv[1])
+cfg_path = script_dir / "config.yaml"
+default_key_envs = {
+    "anthropic": "ANTHROPIC_API_KEY",
+    "gemini": "GEMINI_API_KEY",
+    "openai": "OPENAI_API_KEY",
+}
+
+cfg = {}
+if cfg_path.exists():
+    with open(cfg_path) as f:
+        cfg = yaml.safe_load(f) or {}
+
+provider = str(os.environ.get("LLM_PROVIDER") or cfg.get("provider", "anthropic")).strip() or "anthropic"
+models = cfg.get("models", {}).get(provider, {})
+configured_env = str(models.get("api_key_env") or "").strip()
+print(configured_env or default_key_envs.get(provider, f"{provider.upper()}_API_KEY"))
+PY
+}
+
 start() {
     if is_running; then
         echo "Already running (PID $(cat "$PIDFILE")). http://$HOST:$PORT"
@@ -56,8 +84,14 @@ start() {
     fi
 
     # Verify API keys
-    if [ -z "${ANTHROPIC_API_KEY:-}" ] || [ -z "${TMDB_API_KEY:-}" ]; then
-        echo "Error: ANTHROPIC_API_KEY and TMDB_API_KEY must be set in .env or environment." >&2
+    local llm_key_env
+    llm_key_env="$(llm_api_key_env)"
+    if [ -z "${TMDB_API_KEY:-}" ]; then
+        echo "Error: TMDB_API_KEY must be set in .env or environment." >&2
+        exit 1
+    fi
+    if [ -z "${!llm_key_env:-}" ]; then
+        echo "Error: $llm_key_env must be set in .env or environment." >&2
         exit 1
     fi
 

--- a/recommender/llm.py
+++ b/recommender/llm.py
@@ -6,10 +6,12 @@ of model names. Model assignments are configured in config.yaml per provider.
 
 The OpenAI provider works with any service implementing the OpenAI chat
 completions API: OpenAI, Ollama, Groq, Together, LM Studio, vLLM, etc.
-Configure base_url and api_key_env in config.yaml models.openai section.
+Configure base_url in config.yaml models.openai. api_key_env is optional and
+only needed when the deployment uses a non-standard environment variable name.
 """
 
 import logging
+import os
 import time
 from abc import ABC, abstractmethod
 from dataclasses import dataclass, field
@@ -291,17 +293,13 @@ def create_client(provider: str | None = None) -> LLMClient:
     """
     import config
 
-    import os
-
     provider = provider or config.LLM_PROVIDER
     models = config.LLM_MODELS.get(provider, {})
 
     if not models:
         raise ValueError(f"No model config for provider '{provider}' in config.yaml")
 
-    # All providers read their API key from a configurable env var
-    default_key_envs = {"anthropic": "ANTHROPIC_API_KEY", "gemini": "GEMINI_API_KEY", "openai": "OPENAI_API_KEY"}
-    api_key_env = models.get("api_key_env", default_key_envs.get(provider, f"{provider.upper()}_API_KEY"))
+    api_key_env = config.get_llm_api_key_env(provider)
     api_key = os.environ.get(api_key_env, "")
     if not api_key:
         raise RuntimeError(f"{api_key_env} not set. Export it or add to .env.")

--- a/recommender/templates/help.html
+++ b/recommender/templates/help.html
@@ -99,9 +99,11 @@
     <div class="help-body">
       <p>Settings live in two places:</p>
       <ul>
-        <li><strong>.env</strong> — API keys only (TMDB, Anthropic, Gemini). Gitignored.</li>
+        <li><strong>Environment variables</strong> — API keys only (<code>TMDB_API_KEY</code>, <code>ANTHROPIC_API_KEY</code>, <code>GEMINI_API_KEY</code>, <code>OPENAI_API_KEY</code>).</li>
+        <li><strong>.env</strong> — optional local convenience for setting those variables. Gitignored.</li>
         <li><strong>config.yaml</strong> — everything else. Editable from the <a href="/settings">Settings</a> page or by hand.</li>
       </ul>
+      <p>Provider API keys use the standard variable names by default. Only set <span class="mono">api_key_env</span> when you need a custom variable name.</p>
       <p>The <a href="/settings">Settings</a> page lets you change provider, models, timeouts, scoring weights, and more — changes take effect immediately without a restart.</p>
     </div>
   </details>

--- a/recommender/templates/settings.html
+++ b/recommender/templates/settings.html
@@ -39,48 +39,39 @@
       <span class="form-hint">Active provider for all LLM calls. Override per-query with --provider.</span>
     </div>
 
-    <!-- Hidden inputs preserve non-active provider configs -->
-    {% for p in ['anthropic', 'gemini', 'openai'] %}
-    {% if p != cfg.provider %}
-    <input type="hidden" name="{{ p }}_fast" value="{{ cfg.models[p].fast }}">
-    <input type="hidden" name="{{ p }}_reason" value="{{ cfg.models[p].reason }}">
-    <input type="hidden" name="{{ p }}_api_key_env" value="{{ cfg.models[p].api_key_env or '' }}">
-    {% if p == 'openai' %}
-    <input type="hidden" name="openai_base_url" value="{{ cfg.models.openai.base_url or '' }}">
-    {% endif %}
-    {% endif %}
-    {% endfor %}
-
-    <!-- Active provider models -->
-    {% set p = cfg.provider %}
+    {% set default_key_envs = {'anthropic': 'ANTHROPIC_API_KEY', 'gemini': 'GEMINI_API_KEY', 'openai': 'OPENAI_API_KEY'} %}
     <div style="margin-top:1rem;">
-      <div style="display:grid; grid-template-columns:1fr 1fr; gap:1rem;">
-        <div class="form-row">
-          <label class="form-label">Fast model</label>
-          <input type="text" name="{{ p }}_fast" value="{{ cfg.models[p].fast }}" class="form-input">
-          <span class="form-hint">Enrichment, simple tasks (high volume, cheaper)</span>
+      {% for p in ['anthropic', 'gemini', 'openai'] %}
+      <div data-provider-panel="{{ p }}" style="display:{{ 'block' if p == cfg.provider else 'none' }};">
+        <div style="display:grid; grid-template-columns:1fr 1fr; gap:1rem;">
+          <div class="form-row">
+            <label class="form-label">Fast model</label>
+            <input type="text" name="{{ p }}_fast" value="{{ cfg.models[p].fast }}" class="form-input">
+            <span class="form-hint">Enrichment, simple tasks (high volume, cheaper)</span>
+          </div>
+          <div class="form-row">
+            <label class="form-label">Reason model</label>
+            <input type="text" name="{{ p }}_reason" value="{{ cfg.models[p].reason }}" class="form-input">
+            <span class="form-hint">Intent parsing, ranking, taste profile (complex reasoning)</span>
+          </div>
         </div>
-        <div class="form-row">
-          <label class="form-label">Reason model</label>
-          <input type="text" name="{{ p }}_reason" value="{{ cfg.models[p].reason }}" class="form-input">
-          <span class="form-hint">Intent parsing, ranking, taste profile (complex reasoning)</span>
-        </div>
-      </div>
 
-      <div style="display:grid; grid-template-columns:{{ '1fr 1fr' if p == 'openai' else '1fr' }}; gap:1rem; margin-top:0.75rem;">
-        <div class="form-row">
-          <label class="form-label">API key env var</label>
-          <input type="text" name="{{ p }}_api_key_env" value="{{ cfg.models[p].api_key_env or '' }}" class="form-input" style="max-width:280px;">
-          <span class="form-hint">Name of the env var holding the key (not the key itself)</span>
+        <div style="display:grid; grid-template-columns:{{ '1fr 1fr' if p == 'openai' else '1fr' }}; gap:1rem; margin-top:0.75rem;">
+          <div class="form-row">
+            <label class="form-label">API key env var override</label>
+            <input type="text" name="{{ p }}_api_key_env" value="{{ cfg.models[p].api_key_env or '' }}" class="form-input" style="max-width:280px;" placeholder="{{ default_key_envs[p] }}">
+            <span class="form-hint">Optional. Leave empty to use {{ default_key_envs[p] }} from the environment.</span>
+          </div>
+          {% if p == 'openai' %}
+          <div class="form-row">
+            <label class="form-label">Base URL</label>
+            <input type="text" name="openai_base_url" value="{{ cfg.models.openai.base_url or '' }}" class="form-input" placeholder="Leave empty for OpenAI">
+            <span class="form-hint">Custom endpoint: Ollama, Groq, Together, LM Studio, etc.</span>
+          </div>
+          {% endif %}
         </div>
-        {% if p == 'openai' %}
-        <div class="form-row">
-          <label class="form-label">Base URL</label>
-          <input type="text" name="openai_base_url" value="{{ cfg.models.openai.base_url or '' }}" class="form-input" placeholder="Leave empty for OpenAI">
-          <span class="form-hint">Custom endpoint: Ollama, Groq, Together, LM Studio, etc.</span>
-        </div>
-        {% endif %}
       </div>
+      {% endfor %}
     </div>
   </fieldset>
 
@@ -374,6 +365,8 @@
   (function() {
     var fields = ['weight_completion', 'weight_rewatch', 'weight_recency'];
     var warn = document.getElementById('weight-warn');
+    var providerSelect = document.getElementById('provider-select');
+    var providerPanels = document.querySelectorAll('[data-provider-panel]');
     var manualMode = document.getElementById('manual-timestamp-mode');
     var manualDate = document.getElementById('manual-timestamp-date');
     fields.forEach(function(name) {
@@ -390,6 +383,17 @@
     function syncManualTimestampInput() {
       if (!manualMode || !manualDate) return;
       manualDate.disabled = manualMode.value !== 'fixed';
+    }
+    function syncProviderPanels() {
+      if (!providerSelect) return;
+      providerPanels.forEach(function(panel) {
+        var isActive = panel.getAttribute('data-provider-panel') === providerSelect.value;
+        panel.style.display = isActive ? 'block' : 'none';
+      });
+    }
+    if (providerSelect) {
+      providerSelect.addEventListener('change', syncProviderPanels);
+      syncProviderPanels();
     }
     if (manualMode) {
       manualMode.addEventListener('change', syncManualTimestampInput);

--- a/recommender/web.py
+++ b/recommender/web.py
@@ -333,23 +333,21 @@ def help_page() -> str:
 
 
 _CONFIG_PATH = Path(__file__).parent.parent / "config.yaml"
+_DEFAULT_LLM_API_KEY_ENVS = dict(config.LLM_DEFAULT_API_KEY_ENVS)
 _SETTINGS_DEFAULTS = {
     "provider": "anthropic",
     "models": {
         "anthropic": {
             "fast": "claude-haiku-4-5-20251001",
             "reason": "claude-sonnet-4-6",
-            "api_key_env": "ANTHROPIC_API_KEY",
         },
         "gemini": {
             "fast": "gemini-2.5-flash",
             "reason": "gemini-2.5-flash",
-            "api_key_env": "GEMINI_API_KEY",
         },
         "openai": {
             "fast": "gpt-4.1-mini",
             "reason": "gpt-4.1",
-            "api_key_env": "OPENAI_API_KEY",
             "base_url": None,
         },
     },
@@ -419,7 +417,7 @@ def _save_config_yaml(cfg: dict) -> None:
     """Write config dict back to config.yaml, preserving comments where possible."""
     with open(_CONFIG_PATH, "w") as f:
         f.write("# Streamline configuration\n")
-        f.write("# Secrets (API keys) go in .env, everything else goes here.\n\n")
+        f.write("# Set API keys in the environment. .env is optional local convenience.\n\n")
         yaml.dump(cfg, f, default_flow_style=False, sort_keys=False, allow_unicode=True)
 
 
@@ -619,14 +617,20 @@ def settings_save() -> str:
     # Provider & models — all providers treated the same
     cfg["provider"] = form.get("provider", "anthropic")
     cfg.setdefault("models", {})
-    default_key_envs = {"anthropic": "ANTHROPIC_API_KEY", "gemini": "GEMINI_API_KEY", "openai": "OPENAI_API_KEY"}
     for p in ["anthropic", "gemini", "openai"]:
         existing = cfg["models"].get(p, {})
-        cfg["models"][p] = {
+        provider_cfg = {
             "fast": (form.get(f"{p}_fast") or existing.get("fast", "")).strip(),
             "reason": (form.get(f"{p}_reason") or existing.get("reason", "")).strip(),
-            "api_key_env": (form.get(f"{p}_api_key_env") or existing.get("api_key_env") or default_key_envs.get(p, "")).strip(),
         }
+        submitted_api_key_env = form.get(f"{p}_api_key_env")
+        if submitted_api_key_env is None:
+            api_key_env = str(existing.get("api_key_env") or "").strip()
+        else:
+            api_key_env = submitted_api_key_env.strip()
+        if api_key_env and api_key_env != _DEFAULT_LLM_API_KEY_ENVS.get(p, ""):
+            provider_cfg["api_key_env"] = api_key_env
+        cfg["models"][p] = provider_cfg
     # base_url only relevant for openai provider
     base_url = (form.get("openai_base_url") or "").strip()
     cfg["models"]["openai"]["base_url"] = base_url if base_url else None

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,3 +1,6 @@
+import os
+import shutil
+import subprocess
 import sys
 from pathlib import Path
 from unittest.mock import MagicMock, patch
@@ -46,6 +49,28 @@ def test_main_exits_without_anthropic_key(monkeypatch):
         assert exc_info.value.code == 1
     finally:
         config.ANTHROPIC_API_KEY = original
+
+
+def test_create_client_reads_configured_api_key_name_only_from_environment(monkeypatch):
+    import config
+    from recommender.llm import create_client
+
+    original_models = config.LLM_MODELS
+    monkeypatch.setattr(
+        config,
+        "LLM_MODELS",
+        {
+            **original_models,
+            "anthropic": {
+                **original_models["anthropic"],
+                "api_key_env": "WATCH_REGION",
+            },
+        },
+    )
+    monkeypatch.delenv("WATCH_REGION", raising=False)
+
+    with pytest.raises(RuntimeError, match="WATCH_REGION not set"):
+        create_client("anthropic")
 
 
 def test_load_context_exits_if_no_watch_index(tmp_path, monkeypatch):
@@ -115,8 +140,14 @@ def _settings_form_data(web, raw_cfg: dict | None = None, **overrides):
         "provider": cfg["provider"],
         "anthropic_fast": cfg["models"]["anthropic"]["fast"],
         "anthropic_reason": cfg["models"]["anthropic"]["reason"],
+        "anthropic_api_key_env": cfg["models"]["anthropic"].get("api_key_env", ""),
         "gemini_fast": cfg["models"]["gemini"]["fast"],
         "gemini_reason": cfg["models"]["gemini"]["reason"],
+        "gemini_api_key_env": cfg["models"]["gemini"].get("api_key_env", ""),
+        "openai_fast": cfg["models"]["openai"]["fast"],
+        "openai_reason": cfg["models"]["openai"]["reason"],
+        "openai_api_key_env": cfg["models"]["openai"].get("api_key_env", ""),
+        "openai_base_url": cfg["models"]["openai"].get("base_url") or "",
         "llm_timeout_fast": str(cfg["llm"]["timeout_fast"]),
         "llm_timeout_reason": str(cfg["llm"]["timeout_reason"]),
         "llm_timeout_profile_batch": str(cfg["llm"]["timeout_profile_batch"]),
@@ -228,3 +259,126 @@ def test_settings_save_rebuilds_profile_after_setup_only_change(tmp_path, monkey
 
     assert post_response.status_code == 302
     assert refresh_calls == [(True, False)]
+
+
+def test_settings_page_shows_default_api_key_env_as_placeholder(tmp_path, monkeypatch):
+    raw_cfg = {"provider": "gemini"}
+    client, _, _, _ = _settings_test_client(tmp_path, monkeypatch, raw_cfg)
+
+    response = client.get("/settings")
+    body = response.get_data(as_text=True)
+
+    assert response.status_code == 200
+    assert 'name="gemini_api_key_env"' in body
+    assert 'placeholder="GEMINI_API_KEY"' in body
+    assert 'value="GEMINI_API_KEY"' not in body
+
+
+def test_settings_page_renders_provider_panels_for_client_side_switching(tmp_path, monkeypatch):
+    raw_cfg = {"provider": "anthropic"}
+    client, _, _, _ = _settings_test_client(tmp_path, monkeypatch, raw_cfg)
+
+    response = client.get("/settings")
+    body = response.get_data(as_text=True)
+
+    assert response.status_code == 200
+    assert 'data-provider-panel="anthropic"' in body
+    assert 'data-provider-panel="gemini"' in body
+    assert 'data-provider-panel="openai"' in body
+
+
+def test_settings_save_omits_default_api_key_env_names(tmp_path, monkeypatch):
+    raw_cfg = {
+        "provider": "anthropic",
+        "models": {
+            "anthropic": {"api_key_env": "ANTHROPIC_API_KEY"},
+            "gemini": {"api_key_env": "GEMINI_API_KEY"},
+            "openai": {"api_key_env": "OPENAI_API_KEY"},
+        },
+    }
+    client, config_path, _, web = _settings_test_client(tmp_path, monkeypatch, raw_cfg)
+
+    post_response = client.post("/settings", data=_settings_form_data(web, raw_cfg))
+
+    assert post_response.status_code == 302
+    saved_cfg = yaml.safe_load(config_path.read_text())
+    assert "api_key_env" not in saved_cfg["models"]["anthropic"]
+    assert "api_key_env" not in saved_cfg["models"]["gemini"]
+    assert "api_key_env" not in saved_cfg["models"]["openai"]
+
+
+def test_settings_save_preserves_custom_api_key_env_override(tmp_path, monkeypatch):
+    raw_cfg = {
+        "provider": "openai",
+        "models": {
+            "openai": {
+                "fast": "gpt-4.1-mini",
+                "reason": "gpt-4.1",
+                "api_key_env": "STREAMLINE_OPENAI_KEY",
+            },
+        },
+    }
+    client, config_path, _, web = _settings_test_client(tmp_path, monkeypatch, raw_cfg)
+
+    post_response = client.post("/settings", data=_settings_form_data(web, raw_cfg))
+
+    assert post_response.status_code == 302
+    saved_cfg = yaml.safe_load(config_path.read_text())
+    assert saved_cfg["models"]["openai"]["api_key_env"] == "STREAMLINE_OPENAI_KEY"
+
+
+def test_settings_save_clears_custom_api_key_env_override(tmp_path, monkeypatch):
+    raw_cfg = {
+        "provider": "openai",
+        "models": {
+            "openai": {
+                "fast": "gpt-4.1-mini",
+                "reason": "gpt-4.1",
+                "api_key_env": "STREAMLINE_OPENAI_KEY",
+            },
+        },
+    }
+    client, config_path, _, web = _settings_test_client(tmp_path, monkeypatch, raw_cfg)
+
+    post_response = client.post(
+        "/settings",
+        data=_settings_form_data(web, raw_cfg, openai_api_key_env=""),
+    )
+
+    assert post_response.status_code == 302
+    saved_cfg = yaml.safe_load(config_path.read_text())
+    assert "api_key_env" not in saved_cfg["models"]["openai"]
+
+
+def test_recommend_web_uses_runtime_provider_for_api_key_check(tmp_path, monkeypatch):
+    repo_root = Path(__file__).resolve().parent.parent
+    script_path = tmp_path / "recommend-web"
+    shutil.copy(repo_root / "recommend-web", script_path)
+
+    activate_path = tmp_path / "venv" / "bin"
+    activate_path.mkdir(parents=True)
+    (activate_path / "activate").write_text("# recommend-web test activation\n")
+
+    cfg = yaml.safe_load((repo_root / "config.yaml").read_text())
+    cfg["provider"] = "openai"
+    (tmp_path / "config.yaml").write_text(yaml.safe_dump(cfg, sort_keys=False))
+
+    env = os.environ.copy()
+    env["STREAMLINE_PORT"] = "5157"
+    env["TMDB_API_KEY"] = "tmdb"
+    env["ANTHROPIC_API_KEY"] = "anthropic"
+    env["LLM_PROVIDER"] = "anthropic"
+    env.pop("OPENAI_API_KEY", None)
+
+    result = subprocess.run(
+        ["bash", str(script_path), "start"],
+        cwd=tmp_path,
+        env=env,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert result.returncode == 1
+    assert "taste profile not found" in result.stderr
+    assert "OPENAI_API_KEY" not in result.stderr


### PR DESCRIPTION
## Summary
- All providers use standard env vars by default (no config needed for typical setup)
- `api_key_env` is optional override for non-standard var names (Groq, DashScope, etc.)
- Settings page shows only active provider's models — clean, focused
- `.env` documented as optional convenience across all docs
- New tests for settings and provider config

## Tested with
- Anthropic (Claude) — existing setup
- OpenAI (GPT-4.1) — via OPENAI_API_KEY
- Groq (Llama 3.3) — via GROQ_API_KEY + base_url
- DashScope (Qwen3-max) — via DASHSCOPE_API_KEY + base_url
- ZhipuAI (GLM) — via ZHIPUAI_API_KEY + base_url
- Full A/B taste profile build: Qwen vs Anthropic (2128 titles, 11 batches)

## Test plan
- [x] 86+ tests pass
- [x] Verified 5 providers work via OpenAI client
- [x] Full profile build with Qwen completed successfully