### PR TITLE
feat: add Apple TV ingestion and unify external provider zip inputs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ __pycache__/
 *.pyc
 .env
 .envrc
+config.local.yaml
 .web.pid
 .web.log
 .superpowers/

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
-data/
+data*
 recommender/cache/
 __pycache__/
 *.pyc

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,48 @@
+# Repository Guidelines
+
+## Project Structure & Module Organization
+
+Core application code lives in `recommender/`. Key areas:
+- `recommender/ingestion/` parses provider exports and manual lists.
+- `recommender/query_engine.py`, `tmdb_client.py`, and `taste_profile_builder.py` drive recommendation logic.
+- `recommender/templates/` and `recommender/static/` back the Flask web UI.
+- `recommender/cache/` stores generated artifacts such as `watch_index.json` and `taste_profile.txt`.
+
+Tests live in `tests/`, with ingestion-specific coverage under `tests/ingestion/`. Entry points are `./recommend` for CLI/setup and `./recommend-web` for the web app. Shared defaults live in `config.yaml`; machine-local overrides belong in `config.local.yaml`.
+
+## Build, Test, and Development Commands
+
+Use the local virtualenv first:
+
+```bash
+python3 -m venv venv
+source venv/bin/activate
+pip install -r requirements.txt
+```
+
+Key commands:
+- `./recommend setup` rebuilds watch history, TMDB enrichment, and taste profile artifacts.
+- `./recommend setup --ingest-only` validates configured provider exports without rebuilding caches.
+- `./recommend "good British crime drama"` runs a CLI recommendation query.
+- `./recommend-web start` launches the Flask UI on `http://localhost:5050`.
+- `pytest -q` runs the full test suite.
+
+## Coding Style & Naming Conventions
+
+Target Python 3.10+. Use 4-space indentation, type hints where the module already uses them, and `snake_case` for functions, variables, and test names. Keep changes direct and consistent with existing patterns. Prefer editing existing files over adding new ones. Comments should explain intent or constraints, not restate obvious code.
+
+## Testing Guidelines
+
+Pytest is the test framework. Name tests `test_<behavior>()` and keep provider-parser coverage in `tests/ingestion/`. When changing ingestion or setup logic, run the affected subset first, then `pytest -q`. For user-facing query or web changes, add or update tests in `tests/test_main.py` and related modules.
+
+## Commit & Pull Request Guidelines
+
+Recent history uses conventional prefixes such as `feat:`, `fix:`, and `refactor:` with imperative summaries. Keep commits scoped to one logical change. PRs should include:
+- a concise summary of behavior changes
+- validation commands and results
+- config or migration notes if setup behavior changes
+- screenshots only for visible web UI changes
+
+## Security & Configuration Tips
+
+Never commit secrets or personal watch-history paths. Keep API keys in the environment or `.env`, and keep machine-specific provider zips in `config.local.yaml`, not `config.yaml`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -21,6 +21,7 @@ python3 -m pytest tests/test_query_engine.py -v
 ./recommend setup                              # first-time offline setup
 ./recommend setup --refresh-data               # re-fetch TMDB + rebuild all
 ./recommend setup --refresh-profile            # rebuild taste profile only
+./recommend setup --ingest-only                # validate configured provider zips
 ./recommend --debug "spy thriller"             # full pipeline trace
 ./recommend --provider gemini "spy thriller"   # use Gemini instead of default
 ./recommend --liked "Title"                    # feedback
@@ -76,6 +77,6 @@ All under `recommender/cache/`: `tmdb/`, `enrichments/` (+ index.json), `provide
   - `scoring.*` — engagement weights (completion/rewatch/recency), fallback runtimes
   - `manual.*` — synthetic timestamp and durations for manual list titles
   - Top-level: `default_top_n`, `min_vote_count`, `recency_half_life_days`, `watch_region`, `streaming_platforms`
-  - Data paths: `platform_paths.*`, `overrides_path`
+  - Data paths: `platform_paths.*` (exact `.zip` file paths for netflix/prime/apple_tv; null to disable), `overrides_path`
 - `models.<provider>.api_key_env` is optional. Use it only for non-standard environment variable names.
 - **`config.py`** — thin loader, reads settings from `config.yaml` and secrets from the environment. All values have sensible defaults.

--- a/README.md
+++ b/README.md
@@ -101,8 +101,9 @@ Everything goes through `./recommend`:
 ./recommend "paranoid spy thriller like The Night Manager"
 ./recommend "give me 5 feel-good Bollywood comedies"
 ./recommend "why not Slow Horses?"              # explains why a title wasn't recommended
+./recommend "I started Severance and stopped. Should I keep going?"
 
-# Interactive mode (conversational — supports "more like that", refinements)
+# Interactive mode (supports "what else?", "more like #2", and follow-up refinements)
 ./recommend
 
 # Setup
@@ -120,6 +121,8 @@ Everything goes through `./recommend`:
 ./recommend -n 5 "dark thriller"                # override result count
 ./recommend --provider gemini "spy thriller"     # use Gemini instead of default
 ```
+
+The built-in Help page is the canonical query guide. After starting the web UI, see `/help#query-guide` for supported recommendation queries, abandoned-watch queries, conversational refinements, and command-style inputs.
 
 Each query prints token usage and estimated cost at the end.
 

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Streamline ingests your real watch history from Netflix, Prime Video, and manual
 - **Streaming availability** — annotated results with platform filtering (Netflix, Prime, etc.)
 - **Quality filters** — configurable minimum rating, release year, and vote count
 - **Title intelligence** — guessit classification, rapidfuzz dedup, manual overrides, IMDB/TMDB links
-- **Fully configurable** — all settings editable from the web UI or `config.yaml`
+- **Fully configurable** — shared settings in `config.yaml`, local watch-history overrides in `config.local.yaml`
 
 ## How It Works
 
@@ -83,7 +83,7 @@ ANTHROPIC_API_KEY=your_key_here
 GEMINI_API_KEY=your_key_here          # optional
 EOF
 
-# 3. Add your watch history under data/ (see Watch History Sources below)
+# 3. Copy config.local.example.yaml to config.local.yaml and set provider zip paths
 
 # 4. Run offline setup
 ./recommend setup
@@ -144,11 +144,12 @@ Port and host are configurable via `STREAMLINE_PORT` and `STREAMLINE_HOST` envir
 
 ## Configuration
 
-Settings live in two places:
+Settings live in a few places:
 
 - **Environment variables** — secrets only (`TMDB_API_KEY`, `ANTHROPIC_API_KEY`, `GEMINI_API_KEY`, `OPENAI_API_KEY`)
 - **`.env`** — optional local convenience for setting those environment variables (gitignored)
-- **`config.yaml`** — everything else (editable from the Settings page or by hand)
+- **`config.yaml`** — shared repo defaults and app settings
+- **`config.local.yaml`** — local overrides such as watch-history zip paths, loaded after `config.yaml`
 
 ### LLM Providers
 
@@ -165,7 +166,7 @@ models:
     reason: gemini-2.5-pro
 ```
 
-Switch providers by changing `provider:` in config.yaml or per-query with `--provider gemini`.
+Switch providers by changing `provider:` in config or per-query with `--provider gemini`.
 
 By default, each provider reads its API key from the standard environment variable name:
 
@@ -173,7 +174,7 @@ By default, each provider reads its API key from the standard environment variab
 - Gemini: `GEMINI_API_KEY`
 - OpenAI / compatible: `OPENAI_API_KEY`
 
-Only add `models.<provider>.api_key_env` in `config.yaml` when you need a non-standard variable name.
+Only add `models.<provider>.api_key_env` in config when you need a non-standard variable name.
 
 ### Quality Filters
 
@@ -199,7 +200,7 @@ When TMDB can't match a title, create `data/overrides.json`:
 <details>
 <summary><strong>Full Settings Reference</strong></summary>
 
-All settings in `config.yaml`:
+All shared settings in `config.yaml`:
 
 **LLM:**
 | Setting | Default | Description |
@@ -235,13 +236,17 @@ All settings in `config.yaml`:
 
 ## Watch History Sources
 
-Place exported CSV files under `data/`:
+Keep shared settings in `config.yaml` and machine-specific watch-history paths in
+`config.local.yaml`. Start by copying `config.local.example.yaml`.
 
 | Platform | Path | How to export |
 |----------|------|---------------|
-| Netflix | `data/netflix/.../ViewingActivity.csv` | Account Settings > Download your data |
-| Prime Video | `data/prime_video/.../Viewing History.csv` | Account > Digital content > Request your data |
+| Netflix | `platform_paths.netflix: data/netflix/<export>.zip` | Account Settings > Download your data |
+| Prime Video | `platform_paths.prime: data/prime_video/Prime Video.zip` | Account > Digital content > Request your data |
+| Apple TV | `platform_paths.apple_tv: data/AppleTV/Apple Media Services Information Part 1 of 2.zip` | Apple privacy export |
 | Manual | `data/manual/tv.csv` / `movies.csv` | One title per line |
+
+`config.local.yaml` is gitignored and loaded after `config.yaml`, so local provider paths stay out of the shared repo config.
 
 Movie titles may include a trailing year (`Zodiac 2007`) which is stripped automatically.
 

--- a/config.local.example.yaml
+++ b/config.local.example.yaml
@@ -1,0 +1,8 @@
+# Local Streamline overrides.
+# Copy this file to config.local.yaml and update the provider paths for your machine.
+# config.local.yaml is gitignored and loaded after config.yaml.
+
+platform_paths:
+  netflix: data/netflix/export.zip
+  prime: data/prime_video/Prime Video.zip
+  apple_tv: data/AppleTV/Apple Media Services Information Part 1 of 2.zip

--- a/config.py
+++ b/config.py
@@ -1,7 +1,8 @@
 """Configuration loader.
 
-Reads non-secret settings from config.yaml and secrets from the environment.
-All module-level attributes are available as before for backward compat.
+Reads non-secret settings from config.yaml plus optional local overrides from
+config.local.yaml. Secrets continue to come from the environment. All
+module-level attributes are available as before for backward compat.
 """
 
 import os
@@ -11,13 +12,28 @@ import yaml
 
 _ROOT = Path(__file__).parent
 
-# Load config.yaml
 _CONFIG_PATH = _ROOT / "config.yaml"
-if _CONFIG_PATH.exists():
-    with open(_CONFIG_PATH) as f:
-        _cfg = yaml.safe_load(f) or {}
-else:
-    _cfg = {}
+_LOCAL_CONFIG_PATH = _ROOT / "config.local.yaml"
+
+
+def _load_yaml(path: Path) -> dict:
+    if not path.exists():
+        return {}
+    with open(path) as f:
+        return yaml.safe_load(f) or {}
+
+
+def _merge_dicts(base: dict, override: dict) -> dict:
+    merged = dict(base)
+    for key, value in override.items():
+        if isinstance(merged.get(key), dict) and isinstance(value, dict):
+            merged[key] = _merge_dicts(merged[key], value)
+        else:
+            merged[key] = value
+    return merged
+
+
+_cfg = _merge_dicts(_load_yaml(_CONFIG_PATH), _load_yaml(_LOCAL_CONFIG_PATH))
 
 # ── Logging ──
 LOG_LEVEL = os.environ.get("LOG_LEVEL", _cfg.get("log_level", "WARNING")).upper()

--- a/config.py
+++ b/config.py
@@ -138,9 +138,9 @@ def _resolve_platform_path(platform: str, default: str | None) -> str | None:
 
 
 PLATFORM_PATHS = {
-    "netflix": _resolve_platform_path("netflix", "data/netflix/ViewingActivity.csv"),
-    "prime": _resolve_platform_path("prime", "data/prime_video/Viewing History.csv"),
-    "apple_tv": _resolve_platform_path("apple_tv", None),
+    "netflix": _resolve_platform_path("netflix", "data/netflix/export.zip"),
+    "prime": _resolve_platform_path("prime", "data/prime_video/Prime Video.zip"),
+    "apple_tv": _resolve_platform_path("apple_tv", "data/AppleTV/Apple Media Services Information Part 1 of 2.zip"),
     "disney": None,
     "hbo": None,
 }

--- a/config.py
+++ b/config.py
@@ -122,8 +122,9 @@ def _resolve_platform_path(platform: str, default: str | None) -> str | None:
 
 
 PLATFORM_PATHS = {
-    "netflix": _resolve_platform_path("netflix", "data/netflix/ViewingActivity.csv"),
-    "prime": _resolve_platform_path("prime", "data/prime_video/Viewing History.csv"),
+    "netflix": _resolve_platform_path("netflix", None),
+    "prime": _resolve_platform_path("prime", None),
+    "apple_tv": _resolve_platform_path("apple_tv", None),
     "disney": None,
     "hbo": None,
 }

--- a/config.py
+++ b/config.py
@@ -122,8 +122,8 @@ def _resolve_platform_path(platform: str, default: str | None) -> str | None:
 
 
 PLATFORM_PATHS = {
-    "netflix": _resolve_platform_path("netflix", None),
-    "prime": _resolve_platform_path("prime", None),
+    "netflix": _resolve_platform_path("netflix", "data/netflix/ViewingActivity.csv"),
+    "prime": _resolve_platform_path("prime", "data/prime_video/Viewing History.csv"),
     "apple_tv": _resolve_platform_path("apple_tv", None),
     "disney": None,
     "hbo": None,

--- a/config.yaml
+++ b/config.yaml
@@ -1,5 +1,6 @@
 # Streamline configuration
 # Set API keys in the environment. .env is optional local convenience.
+# Put machine-specific watch-history paths in config.local.yaml.
 
 log_level: DEBUG
 provider: anthropic
@@ -47,8 +48,8 @@ manual:
 watch_region: US
 streaming_platforms: []
 platform_paths:
-  netflix: data/netflix/32ff724d-ecfe-44b4-8f11-00113e65599f.zip
-  prime: data/prime_video/Prime Video.zip
+  netflix:
+  prime:
   apple_tv:
 manual_tv_path: data/manual/tv.csv
 manual_movies_path: data/manual/movies.csv

--- a/config.yaml
+++ b/config.yaml
@@ -49,7 +49,7 @@ streaming_platforms: []
 platform_paths:
   netflix: data/netflix/32ff724d-ecfe-44b4-8f11-00113e65599f.zip
   prime: data/prime_video/Prime Video.zip
-  apple_tv: data/AppleTV/Apple Media Services Information Part 1 of 2.zip
+  apple_tv:
 manual_tv_path: data/manual/tv.csv
 manual_movies_path: data/manual/movies.csv
 overrides_path: data/overrides.json

--- a/config.yaml
+++ b/config.yaml
@@ -47,8 +47,9 @@ manual:
 watch_region: US
 streaming_platforms: []
 platform_paths:
-  netflix: data/netflix/2468198246996321264/CONTENT_INTERACTION/ViewingActivity.csv
-  prime: data/prime_video/Your Prime Video Viewing Activity/Viewing History.csv
+  netflix: data/netflix/32ff724d-ecfe-44b4-8f11-00113e65599f.zip
+  prime: data/prime_video/Prime Video.zip
+  apple_tv: data/AppleTV/Apple Media Services Information Part 1 of 2.zip
 manual_tv_path: data/manual/tv.csv
 manual_movies_path: data/manual/movies.csv
 overrides_path: data/overrides.json

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -59,8 +59,9 @@ Watch history CSVs                           User query (natural language)
 
 | Module | Source | Key fields |
 |--------|--------|------------|
-| `netflix.py` | `ViewingActivity.csv` | title, duration, timestamp, profile |
-| `prime.py` | `Viewing History.csv` | title, duration, timestamp |
+| `netflix.py` | raw Netflix export zip with `ViewingActivity.csv` inside | title, duration, timestamp, profile |
+| `prime.py` | raw Prime Video export zip with `Viewing History.csv` inside | title, duration, timestamp |
+| `apple_tv.py` | raw Apple privacy export zip with `Video Play Activity.csv` inside | title, duration, timestamp, storefront |
 | `manual.py` | `data/manual/tv.csv` + `movies.csv` | title only; synthetic duration + current timestamp |
 
 All parsers emit `WatchEvent` dataclasses (defined in `base.py`). Manual entries use `datetime.now()` as timestamp so they score competitively with platform data. Each file type deduplicates independently (TV and movie lists use separate seen sets).
@@ -197,7 +198,9 @@ recommender/cache/
 
 ## Configuration
 
-Secrets come from the environment. `config.yaml` holds tracked application settings.
+Secrets come from the environment. Shared application settings live in
+`config.yaml`, and optional machine-specific overrides live in
+`config.local.yaml`.
 
 **Environment variables**:
 - `TMDB_API_KEY` — TMDB v3 API key
@@ -207,7 +210,7 @@ Secrets come from the environment. `config.yaml` holds tracked application setti
 
 **`.env`** — optional local convenience for setting those variables (gitignored)
 
-**`config.yaml`** — all settings, organized in sections:
+**`config.yaml`** — tracked shared settings, organized in sections:
 
 | Section | Keys | Description |
 |---------|------|-------------|
@@ -219,9 +222,17 @@ Secrets come from the environment. `config.yaml` holds tracked application setti
 | *(top-level)* | `watch_region`, `streaming_platforms` | Streaming availability |
 | *(top-level)* | `platform_paths.*`, `manual_*_path`, `overrides_path` | Data file locations |
 
+**`config.local.yaml`** — optional local overrides loaded after `config.yaml`.
+Use this for machine-specific values such as `platform_paths.*` for personal
+watch-history export zips. `config.local.yaml` is gitignored; start from
+`config.local.example.yaml`.
+
 Provider API keys use the standard environment variable names by default. Add `models.<provider>.api_key_env` only when a deployment needs a non-standard variable name.
 
-`config.py` is a thin loader that reads settings from `config.yaml` and secrets from the environment. All values have sensible defaults — a minimal `config.yaml` with just `provider:` works.
+`config.py` is a thin loader that reads `config.yaml`, applies
+`config.local.yaml` overrides when present, and reads secrets from the
+environment. All values have sensible defaults — a minimal `config.yaml` with
+just `provider:` works.
 
 ### Taste Profile Batch Caching
 

--- a/recommender/ingestion/apple_tv.py
+++ b/recommender/ingestion/apple_tv.py
@@ -1,0 +1,216 @@
+"""Apple TV+ watch history ingestion.
+
+Accepts the raw Apple data export zip (e.g. "Apple Media Services Information
+Part 1 of 2.zip"). Handles the nested zip structure automatically:
+
+    outer.zip
+      -> Apple_Media_Services.zip
+        -> Stores Activity/Other Activity/Video Play Activity.csv
+"""
+
+import csv
+import logging
+import os
+import tempfile
+import zipfile
+from datetime import datetime, timedelta
+from pathlib import Path
+
+from .base import WatchEvent
+
+log = logging.getLogger("recommender.ingestion.apple_tv")
+
+MIN_WATCH_SECONDS = 5 * 60  # 5 minutes
+
+# Sub-types that are not actual episode/movie watches
+_SKIP_SUBTYPES = {"FeaturedPromo", "Preview", "Promotional", "Bonus"}
+
+_TARGET_CSV = "Video Play Activity.csv"
+
+
+def _find_and_extract_csv(zip_path: str, work_dir: str) -> str | None:
+    """Recursively extract nested zips until Video Play Activity.csv is found."""
+    to_process = [zip_path]
+    seen = set()
+
+    while to_process:
+        current = to_process.pop()
+        if current in seen:
+            continue
+        seen.add(current)
+
+        try:
+            with zipfile.ZipFile(current, "r") as zf:
+                zf.extractall(work_dir)
+        except (zipfile.BadZipFile, OSError) as exc:
+            log.debug("Skipping %s: %s", current, exc)
+            continue
+
+        # Search for the target CSV
+        for root, _dirs, files in os.walk(work_dir):
+            for fname in files:
+                full = os.path.join(root, fname)
+                if fname == _TARGET_CSV:
+                    return full
+                if fname.endswith(".zip") and full not in seen:
+                    to_process.append(full)
+
+    return None
+
+
+def _validate_zip(zip_path: str) -> Path:
+    """Validate that zip_path is an existing .zip file."""
+    p = Path(zip_path)
+    if not p.exists():
+        raise FileNotFoundError(f"Apple TV export not found: {zip_path}")
+    if p.suffix != ".zip":
+        raise ValueError(f"Apple TV path must be a .zip file, got: {zip_path}")
+    try:
+        with zipfile.ZipFile(p, "r") as zf:
+            zf.namelist()
+    except (zipfile.BadZipFile, OSError) as exc:
+        raise ValueError(f"Invalid zip file: {zip_path} ({exc})") from exc
+    return p
+
+
+def _classify(row: dict) -> tuple[str, str]:
+    """Return (content_type, series_name) from a Video Play Activity row.
+
+    TV episodes have Content Episode Name (the show) plus a season or episode.
+    Movies have Content Episode Name as the movie title with no season/episode.
+    """
+    show = row.get("Content Episode Name", "").strip()
+    season = row.get("Content Season Name", "").strip()
+    ep_num = row.get("Episode Number", "").strip()
+
+    if not show:
+        return "movie", row.get("Content Title", "").strip() or "Unknown"
+
+    # Has season or episode number -> TV
+    if season or (ep_num and ep_num not in ("", "0", "0.0")):
+        return "tv", show
+
+    # No season/episode info -> likely a movie or standalone
+    return "movie", show
+
+
+def _build_title(row: dict, content_type: str, series_name: str) -> str:
+    """Build a human-readable title string for the watch event."""
+    if content_type == "movie":
+        return series_name
+
+    season = row.get("Content Season Name", "").strip()
+    ep_title = row.get("Content Title", "").strip()
+    ep_num = row.get("Episode Number", "").strip()
+
+    parts = [series_name]
+    if season:
+        parts.append(season)
+    if ep_num and ep_num not in ("", "0", "0.0"):
+        # Normalize "3.0" -> "3"
+        try:
+            parts.append(f"E{int(float(ep_num))}")
+        except ValueError:
+            parts.append(f"E{ep_num}")
+    if ep_title and ep_title != series_name:
+        parts.append(ep_title)
+    return ": ".join(parts)
+
+
+def _parse_csv(csv_path: str) -> list[WatchEvent]:
+    """Parse Video Play Activity.csv into WatchEvents.
+
+    Apple logs multiple stop events per playback session (scrub, pause, unknown,
+    etc.) with identical start times and durations. We dedup by keeping the
+    entry with the highest watched duration per (timestamp, series, episode).
+    """
+    # First pass: collect candidates keyed for dedup
+    best: dict[tuple, dict] = {}  # (timestamp_str, series, ep_title) -> row data
+
+    with open(csv_path, newline="", encoding="utf-8") as f:
+        reader = csv.DictReader(f)
+        for row in reader:
+            if row.get("Action Type", "").strip() != "stop":
+                continue
+
+            sub_type = row.get("Content Sub-Type", "").strip()
+            if sub_type in _SKIP_SUBTYPES:
+                continue
+
+            try:
+                watched_ms = int(row.get("Feature Play Duration", "0") or "0")
+            except ValueError:
+                watched_ms = 0
+            if watched_ms / 1000 < MIN_WATCH_SECONDS:
+                continue
+
+            ts_str = row.get("UTC Start Time", "").strip()
+            if not ts_str:
+                ts_str = row.get("UTC End Time", "").strip()
+            if not ts_str:
+                continue
+
+            show = row.get("Content Episode Name", "").strip()
+            ep_title = row.get("Content Title", "").strip()
+            key = (ts_str[:19], show, ep_title)
+
+            prev = best.get(key)
+            if prev is None or watched_ms > prev["watched_ms"]:
+                best[key] = {"row": row, "watched_ms": watched_ms, "ts_str": ts_str}
+
+    # Second pass: convert deduplicated rows into WatchEvents
+    events = []
+    for entry in best.values():
+        row = entry["row"]
+        watched_ms = entry["watched_ms"]
+        ts_str = entry["ts_str"]
+
+        try:
+            total_ms = int(row.get("Content Length MS", "0") or "0")
+        except ValueError:
+            total_ms = 0
+
+        try:
+            timestamp = datetime.strptime(ts_str[:19], "%Y-%m-%dT%H:%M:%S")
+        except ValueError:
+            continue
+
+        content_type, series_name = _classify(row)
+        title = _build_title(row, content_type, series_name)
+
+        events.append(WatchEvent(
+            platform="apple_tv",
+            title=title,
+            content_type=content_type,
+            series_name=series_name,
+            watched_duration=timedelta(milliseconds=watched_ms),
+            total_duration=timedelta(milliseconds=total_ms) if total_ms else None,
+            timestamp=timestamp,
+            profile="",
+        ))
+
+    return events
+
+
+def parse(zip_path: str) -> list[WatchEvent]:
+    """Parse Apple TV watch history from a data export zip.
+
+    Args:
+        zip_path: Path to the Apple data export .zip file.
+
+    Raises:
+        FileNotFoundError: If zip_path does not exist.
+        ValueError: If the file is not a .zip, is malformed, or lacks the expected CSV.
+    """
+    _validate_zip(zip_path)
+    log.info("Extracting Apple TV data from %s", zip_path)
+
+    with tempfile.TemporaryDirectory(prefix="apple_tv_") as work_dir:
+        csv_path = _find_and_extract_csv(zip_path, work_dir)
+        if not csv_path:
+            raise ValueError(f"{_TARGET_CSV} not found inside {zip_path}")
+        log.info("Found %s", csv_path)
+        events = _parse_csv(csv_path)
+
+    log.info("Apple TV: %d watch events parsed", len(events))
+    return events

--- a/recommender/ingestion/netflix.py
+++ b/recommender/ingestion/netflix.py
@@ -41,11 +41,10 @@ def _parse_csv(filepath: str) -> list[WatchEvent]:
 
 
 def parse(path: str) -> list[WatchEvent]:
-    """Parse Netflix watch history from a data export zip or CSV.
+    """Parse Netflix watch history from a data export zip.
 
     Args:
-        path: Path to the Netflix data export .zip file, or directly to
-              ViewingActivity.csv for backward compatibility.
+        path: Path to the Netflix data export .zip file.
 
     Raises:
         FileNotFoundError: If path does not exist.
@@ -54,11 +53,8 @@ def parse(path: str) -> list[WatchEvent]:
     p = Path(path)
     if not p.exists():
         raise FileNotFoundError(f"Netflix export not found: {path}")
-    if p.suffix == ".csv":
-        log.info("Netflix: reading %s", p)
-        return _parse_csv(str(p))
     if p.suffix != ".zip":
-        raise ValueError(f"Netflix path must be a .zip or .csv file, got: {path}")
+        raise ValueError(f"Netflix path must be a .zip file, got: {path}")
 
     with tempfile.TemporaryDirectory(prefix="netflix_") as work_dir:
         try:

--- a/recommender/ingestion/netflix.py
+++ b/recommender/ingestion/netflix.py
@@ -40,32 +40,36 @@ def _parse_csv(filepath: str) -> list[WatchEvent]:
     return events
 
 
-def parse(zip_path: str) -> list[WatchEvent]:
-    """Parse Netflix watch history from a data export zip.
+def parse(path: str) -> list[WatchEvent]:
+    """Parse Netflix watch history from a data export zip or CSV.
 
     Args:
-        zip_path: Path to the Netflix data export .zip file.
+        path: Path to the Netflix data export .zip file, or directly to
+              ViewingActivity.csv for backward compatibility.
 
     Raises:
-        FileNotFoundError: If zip_path does not exist.
-        ValueError: If the file is not a .zip or the expected CSV is missing.
+        FileNotFoundError: If path does not exist.
+        ValueError: If the file type is unsupported or the expected CSV is missing.
     """
-    p = Path(zip_path)
+    p = Path(path)
     if not p.exists():
-        raise FileNotFoundError(f"Netflix export not found: {zip_path}")
+        raise FileNotFoundError(f"Netflix export not found: {path}")
+    if p.suffix == ".csv":
+        log.info("Netflix: reading %s", p)
+        return _parse_csv(str(p))
     if p.suffix != ".zip":
-        raise ValueError(f"Netflix path must be a .zip file, got: {zip_path}")
+        raise ValueError(f"Netflix path must be a .zip or .csv file, got: {path}")
 
     with tempfile.TemporaryDirectory(prefix="netflix_") as work_dir:
         try:
-            with zipfile.ZipFile(zip_path, "r") as zf:
+            with zipfile.ZipFile(path, "r") as zf:
                 zf.extractall(work_dir)
         except zipfile.BadZipFile as exc:
-            raise ValueError(f"Invalid zip file: {zip_path} ({exc})") from exc
+            raise ValueError(f"Invalid zip file: {path} ({exc})") from exc
 
         found = list(Path(work_dir).rglob(_TARGET_CSV))
         if not found:
-            raise ValueError(f"{_TARGET_CSV} not found inside {zip_path}")
+            raise ValueError(f"{_TARGET_CSV} not found inside {path}")
 
         log.info("Netflix: reading %s", found[0])
         return _parse_csv(str(found[0]))

--- a/recommender/ingestion/netflix.py
+++ b/recommender/ingestion/netflix.py
@@ -1,22 +1,28 @@
 import csv
+import logging
+import tempfile
+import zipfile
 from datetime import datetime
+from pathlib import Path
 
 from .base import WatchEvent, classify_title, parse_duration
 
+log = logging.getLogger("recommender.ingestion.netflix")
+
 MIN_WATCH_SECONDS = 5 * 60   # 5 minutes
 
+_TARGET_CSV = "ViewingActivity.csv"
 
-def parse(filepath: str) -> list[WatchEvent]:
+
+def _parse_csv(filepath: str) -> list[WatchEvent]:
     """Parse Netflix ViewingActivity.csv into WatchEvents."""
     events = []
     with open(filepath, newline="", encoding="utf-8") as f:
         reader = csv.DictReader(f)
         for row in reader:
-            # Skip trailers and promotional content
             if row["Supplemental Video Type"].strip():
                 continue
             duration = parse_duration(row["Duration"])
-            # Skip very short watches (accidental plays)
             if duration.total_seconds() < MIN_WATCH_SECONDS:
                 continue
             timestamp = datetime.strptime(row["Start Time"], "%Y-%m-%d %H:%M:%S")
@@ -32,3 +38,34 @@ def parse(filepath: str) -> list[WatchEvent]:
                 profile=row["Profile Name"].strip(),
             ))
     return events
+
+
+def parse(zip_path: str) -> list[WatchEvent]:
+    """Parse Netflix watch history from a data export zip.
+
+    Args:
+        zip_path: Path to the Netflix data export .zip file.
+
+    Raises:
+        FileNotFoundError: If zip_path does not exist.
+        ValueError: If the file is not a .zip or the expected CSV is missing.
+    """
+    p = Path(zip_path)
+    if not p.exists():
+        raise FileNotFoundError(f"Netflix export not found: {zip_path}")
+    if p.suffix != ".zip":
+        raise ValueError(f"Netflix path must be a .zip file, got: {zip_path}")
+
+    with tempfile.TemporaryDirectory(prefix="netflix_") as work_dir:
+        try:
+            with zipfile.ZipFile(zip_path, "r") as zf:
+                zf.extractall(work_dir)
+        except zipfile.BadZipFile as exc:
+            raise ValueError(f"Invalid zip file: {zip_path} ({exc})") from exc
+
+        found = list(Path(work_dir).rglob(_TARGET_CSV))
+        if not found:
+            raise ValueError(f"{_TARGET_CSV} not found inside {zip_path}")
+
+        log.info("Netflix: reading %s", found[0])
+        return _parse_csv(str(found[0]))

--- a/recommender/ingestion/prime.py
+++ b/recommender/ingestion/prime.py
@@ -1,8 +1,14 @@
 import csv
+import logging
 import re
+import tempfile
+import zipfile
 from datetime import datetime, timedelta
+from pathlib import Path
 
 from .base import WatchEvent
+
+log = logging.getLogger("recommender.ingestion.prime")
 
 MIN_WATCH_SECONDS = 20 * 60  # 20 minutes — filters abandoned/skimmed content
 
@@ -15,6 +21,8 @@ _SEASON_RE = re.compile(
 
 _KEEP_MATERIAL = {'Feature', 'Full'}
 
+_TARGET_CSV = 'Viewing History.csv'
+
 
 def _classify(title: str) -> tuple[str, str]:
     """Return (content_type, series_name) for a Prime title.
@@ -26,9 +34,7 @@ def _classify(title: str) -> tuple[str, str]:
     """
     base = _SEASON_RE.sub('', title)
     if base == title:
-        # No season marker found — treat as movie
         return 'movie', title
-    # Season marker was present → it's a TV episode or season entry
     if '-' in base:
         series_name = base.rsplit('-', 1)[1].strip().rstrip(',')
     else:
@@ -40,7 +46,7 @@ def _clean(s: str) -> str:
     return s.strip().strip('"')
 
 
-def parse(filepath: str) -> list[WatchEvent]:
+def _parse_csv(filepath: str) -> list[WatchEvent]:
     """Parse Prime Video Viewing History CSV into WatchEvents."""
     events = []
     with open(filepath, newline='', encoding='utf-8') as f:
@@ -73,3 +79,34 @@ def parse(filepath: str) -> list[WatchEvent]:
                 profile=_clean(row['Profile Type']),
             ))
     return events
+
+
+def parse(zip_path: str) -> list[WatchEvent]:
+    """Parse Prime Video watch history from a data export zip.
+
+    Args:
+        zip_path: Path to the Prime Video data export .zip file.
+
+    Raises:
+        FileNotFoundError: If zip_path does not exist.
+        ValueError: If the file is not a .zip or the expected CSV is missing.
+    """
+    p = Path(zip_path)
+    if not p.exists():
+        raise FileNotFoundError(f'Prime Video export not found: {zip_path}')
+    if p.suffix != '.zip':
+        raise ValueError(f'Prime Video path must be a .zip file, got: {zip_path}')
+
+    with tempfile.TemporaryDirectory(prefix='prime_') as work_dir:
+        try:
+            with zipfile.ZipFile(zip_path, 'r') as zf:
+                zf.extractall(work_dir)
+        except zipfile.BadZipFile as exc:
+            raise ValueError(f'Invalid zip file: {zip_path} ({exc})') from exc
+
+        found = list(Path(work_dir).rglob(_TARGET_CSV))
+        if not found:
+            raise ValueError(f'{_TARGET_CSV} not found inside {zip_path}')
+
+        log.info('Prime Video: reading %s', found[0])
+        return _parse_csv(str(found[0]))

--- a/recommender/ingestion/prime.py
+++ b/recommender/ingestion/prime.py
@@ -82,11 +82,10 @@ def _parse_csv(filepath: str) -> list[WatchEvent]:
 
 
 def parse(path: str) -> list[WatchEvent]:
-    """Parse Prime Video watch history from a data export zip or CSV.
+    """Parse Prime Video watch history from a data export zip.
 
     Args:
-        path: Path to the Prime Video data export .zip file, or directly to
-              Viewing History.csv for backward compatibility.
+        path: Path to the Prime Video data export .zip file.
 
     Raises:
         FileNotFoundError: If path does not exist.
@@ -95,11 +94,8 @@ def parse(path: str) -> list[WatchEvent]:
     p = Path(path)
     if not p.exists():
         raise FileNotFoundError(f'Prime Video export not found: {path}')
-    if p.suffix == '.csv':
-        log.info('Prime Video: reading %s', p)
-        return _parse_csv(str(p))
     if p.suffix != '.zip':
-        raise ValueError(f'Prime Video path must be a .zip or .csv file, got: {path}')
+        raise ValueError(f'Prime Video path must be a .zip file, got: {path}')
 
     with tempfile.TemporaryDirectory(prefix='prime_') as work_dir:
         try:

--- a/recommender/ingestion/prime.py
+++ b/recommender/ingestion/prime.py
@@ -81,32 +81,36 @@ def _parse_csv(filepath: str) -> list[WatchEvent]:
     return events
 
 
-def parse(zip_path: str) -> list[WatchEvent]:
-    """Parse Prime Video watch history from a data export zip.
+def parse(path: str) -> list[WatchEvent]:
+    """Parse Prime Video watch history from a data export zip or CSV.
 
     Args:
-        zip_path: Path to the Prime Video data export .zip file.
+        path: Path to the Prime Video data export .zip file, or directly to
+              Viewing History.csv for backward compatibility.
 
     Raises:
-        FileNotFoundError: If zip_path does not exist.
-        ValueError: If the file is not a .zip or the expected CSV is missing.
+        FileNotFoundError: If path does not exist.
+        ValueError: If the file type is unsupported or the expected CSV is missing.
     """
-    p = Path(zip_path)
+    p = Path(path)
     if not p.exists():
-        raise FileNotFoundError(f'Prime Video export not found: {zip_path}')
+        raise FileNotFoundError(f'Prime Video export not found: {path}')
+    if p.suffix == '.csv':
+        log.info('Prime Video: reading %s', p)
+        return _parse_csv(str(p))
     if p.suffix != '.zip':
-        raise ValueError(f'Prime Video path must be a .zip file, got: {zip_path}')
+        raise ValueError(f'Prime Video path must be a .zip or .csv file, got: {path}')
 
     with tempfile.TemporaryDirectory(prefix='prime_') as work_dir:
         try:
-            with zipfile.ZipFile(zip_path, 'r') as zf:
+            with zipfile.ZipFile(path, 'r') as zf:
                 zf.extractall(work_dir)
         except zipfile.BadZipFile as exc:
-            raise ValueError(f'Invalid zip file: {zip_path} ({exc})') from exc
+            raise ValueError(f'Invalid zip file: {path} ({exc})') from exc
 
         found = list(Path(work_dir).rglob(_TARGET_CSV))
         if not found:
-            raise ValueError(f'{_TARGET_CSV} not found inside {zip_path}')
+            raise ValueError(f'{_TARGET_CSV} not found inside {path}')
 
         log.info('Prime Video: reading %s', found[0])
         return _parse_csv(str(found[0]))

--- a/recommender/main.py
+++ b/recommender/main.py
@@ -9,6 +9,7 @@ import config
 from recommender import feedback as fb
 from recommender.ingestion.netflix import parse as parse_netflix
 from recommender.ingestion.prime import parse as parse_prime
+from recommender.ingestion.apple_tv import parse as parse_apple_tv
 from recommender.ingestion.manual import parse as parse_manual
 from recommender.llm import create_client
 from recommender.models import Recommendation
@@ -25,10 +26,20 @@ console_out = Console()              # recommendation results
 
 def load_context(provider: str | None = None) -> RecommendContext:
     events = []
-    for platform, parser in [("netflix", parse_netflix), ("prime", parse_prime)]:
+    for platform, parser in [("netflix", parse_netflix), ("prime", parse_prime), ("apple_tv", parse_apple_tv)]:
         path = config.PLATFORM_PATHS.get(platform)
         if path:
-            events.extend(parser(path))
+            try:
+                platform_events = parser(path)
+            except (FileNotFoundError, ValueError) as exc:
+                console_err.print(f"[red]Invalid {platform} watch history:[/red] {exc}")
+                console_err.print("[yellow]Run ./recommend setup --ingest-only to validate configured provider zips.[/yellow]")
+                sys.exit(1)
+            if not platform_events:
+                console_err.print(f"[red]Invalid {platform} watch history:[/red] zip parsed but yielded 0 events")
+                console_err.print("[yellow]Run ./recommend setup --ingest-only to validate configured provider zips.[/yellow]")
+                sys.exit(1)
+            events.extend(platform_events)
     if config.MANUAL_TV_PATH and config.MANUAL_MOVIES_PATH:
         events.extend(parse_manual(config.MANUAL_TV_PATH, config.MANUAL_MOVIES_PATH))
 

--- a/recommender/main.py
+++ b/recommender/main.py
@@ -32,13 +32,12 @@ def load_context(provider: str | None = None) -> RecommendContext:
             try:
                 platform_events = parser(path)
             except (FileNotFoundError, ValueError) as exc:
-                console_err.print(f"[red]Invalid {platform} watch history:[/red] {exc}")
-                console_err.print("[yellow]Run ./recommend setup --ingest-only to validate configured provider zips.[/yellow]")
-                sys.exit(1)
-            if not platform_events:
-                console_err.print(f"[red]Invalid {platform} watch history:[/red] zip parsed but yielded 0 events")
-                console_err.print("[yellow]Run ./recommend setup --ingest-only to validate configured provider zips.[/yellow]")
-                sys.exit(1)
+                # Runtime recommendations can rely on cached watch_index/profile even
+                # when the original provider export is unavailable. Only abandoned-title
+                # queries depend on raw watch events.
+                console_err.print(f"[yellow]Skipping {platform} watch history for runtime context:[/yellow] {exc}")
+                console_err.print("[dim]Ordinary recommendations still use the cached watch index and taste profile.[/dim]")
+                continue
             events.extend(platform_events)
     if config.MANUAL_TV_PATH and config.MANUAL_MOVIES_PATH:
         events.extend(parse_manual(config.MANUAL_TV_PATH, config.MANUAL_MOVIES_PATH))

--- a/recommender/setup.py
+++ b/recommender/setup.py
@@ -86,7 +86,7 @@ def run_ingest_only() -> None:
 
     configured = sum(1 for p in _PLATFORM_PARSERS if config.PLATFORM_PATHS.get(p[0]))
     if configured == 0:
-        console.print("\n[yellow]No providers configured. Set platform_paths in config.yaml.[/yellow]")
+        console.print("\n[yellow]No providers configured. Set platform_paths in config.local.yaml or config.yaml.[/yellow]")
         sys.exit(1)
 
     console.print(f"\n  Total: {len(events)} events")

--- a/recommender/setup.py
+++ b/recommender/setup.py
@@ -36,8 +36,8 @@ def _load_all_events(strict: bool = False) -> tuple[list, bool]:
     """Load watch events from all configured platforms.
 
     Args:
-        strict: If True, any configured provider that fails or yields zero
-                events causes overall failure. If False, failures are warnings.
+        strict: If True, any configured provider that fails validation causes
+                overall failure. Empty-but-valid exports remain acceptable.
 
     Returns:
         (events, ok) — ok is False if strict=True and any provider failed.
@@ -58,8 +58,7 @@ def _load_all_events(strict: bool = False) -> tuple[list, bool]:
             ok = False
             continue
         if not platform_events:
-            console.print(f"  {platform}: [red]FAIL[/red] zip parsed but yielded 0 events")
-            ok = False
+            console.print(f"  {platform}: [green]ok[/green] 0 events (no qualifying watch activity)")
             continue
         dates = [e.timestamp for e in platform_events]
         console.print(f"  {platform}: [green]ok[/green] {len(platform_events)} events "
@@ -123,6 +122,9 @@ def run_setup(refresh_profile: bool = False, refresh_data: bool = False, provide
     events, ok = _load_all_events(strict=True)
     if not ok:
         console.print("[red]Aborting setup: one or more configured providers failed.[/red]")
+        sys.exit(1)
+    if not events:
+        console.print("[red]No watch events found. Add manual titles or provider exports with qualifying watch activity.[/red]")
         sys.exit(1)
     console.print(f"  Total: {len(events)} events")
 

--- a/recommender/setup.py
+++ b/recommender/setup.py
@@ -11,6 +11,7 @@ log = logging.getLogger("recommender.setup")
 import config
 from recommender.ingestion.netflix import parse as parse_netflix
 from recommender.ingestion.prime import parse as parse_prime
+from recommender.ingestion.apple_tv import parse as parse_apple_tv
 from recommender.ingestion.manual import parse as parse_manual
 from recommender.signals import compute_scores
 from recommender.tmdb_client import TmdbClient
@@ -22,6 +23,89 @@ from recommender import feedback as fb
 from recommender import overrides as ov
 
 console = Console(stderr=True)
+
+
+_PLATFORM_PARSERS = [
+    ("netflix", parse_netflix),
+    ("prime", parse_prime),
+    ("apple_tv", parse_apple_tv),
+]
+
+
+def _load_all_events(strict: bool = False) -> tuple[list, bool]:
+    """Load watch events from all configured platforms.
+
+    Args:
+        strict: If True, any configured provider that fails or yields zero
+                events causes overall failure. If False, failures are warnings.
+
+    Returns:
+        (events, ok) — ok is False if strict=True and any provider failed.
+    """
+    events = []
+    ok = True
+
+    for platform, parser in _PLATFORM_PARSERS:
+        path = config.PLATFORM_PATHS.get(platform)
+        if not path:
+            if strict:
+                console.print(f"  {platform}: [dim]disabled[/dim]")
+            continue
+        try:
+            platform_events = parser(path)
+        except (FileNotFoundError, ValueError) as exc:
+            console.print(f"  {platform}: [red]FAIL[/red] {exc}")
+            ok = False
+            continue
+        if not platform_events:
+            console.print(f"  {platform}: [red]FAIL[/red] zip parsed but yielded 0 events")
+            ok = False
+            continue
+        dates = [e.timestamp for e in platform_events]
+        console.print(f"  {platform}: [green]ok[/green] {len(platform_events)} events "
+                      f"({min(dates):%Y-%m-%d} to {max(dates):%Y-%m-%d})")
+        events.extend(platform_events)
+
+    # Manual ingestion (not subject to zip-only contract)
+    if config.MANUAL_TV_PATH and config.MANUAL_MOVIES_PATH:
+        try:
+            manual_events = parse_manual(config.MANUAL_TV_PATH, config.MANUAL_MOVIES_PATH)
+            events.extend(manual_events)
+            console.print(f"  manual: [green]ok[/green] {len(manual_events)} events")
+        except FileNotFoundError:
+            console.print("  manual: [yellow]skipped[/yellow] (files not found)")
+
+    return events, ok
+
+
+def run_ingest_only() -> None:
+    """Strict preflight validation of configured provider zips."""
+    from collections import defaultdict
+
+    console.print("Validating watch history sources...")
+    events, ok = _load_all_events(strict=True)
+
+    configured = sum(1 for p in _PLATFORM_PARSERS if config.PLATFORM_PATHS.get(p[0]))
+    if configured == 0:
+        console.print("\n[yellow]No providers configured. Set platform_paths in config.yaml.[/yellow]")
+        sys.exit(1)
+
+    console.print(f"\n  Total: {len(events)} events")
+
+    if events:
+        by_platform = defaultdict(list)
+        for e in events:
+            by_platform[e.platform].append(e)
+        for platform, pevents in sorted(by_platform.items()):
+            tv_titles = {e.series_name for e in pevents if e.content_type == "tv"}
+            movie_titles = {e.series_name for e in pevents if e.content_type == "movie"}
+            console.print(f"  {platform}: {len(tv_titles)} TV shows, {len(movie_titles)} movies")
+
+    if not ok:
+        console.print("\n[red]Validation failed.[/red]")
+        sys.exit(1)
+
+    console.print("\n[green]All configured providers validated.[/green]")
 
 
 def run_setup(refresh_profile: bool = False, refresh_data: bool = False, provider: str | None = None) -> None:
@@ -36,17 +120,10 @@ def run_setup(refresh_profile: bool = False, refresh_data: bool = False, provide
     console.print(f"  LLM provider: {llm.provider}")
 
     console.print("Loading watch history...")
-    events = []
-    for platform, parser in [("netflix", parse_netflix), ("prime", parse_prime)]:
-        path = config.PLATFORM_PATHS.get(platform)
-        if path:
-            platform_events = parser(path)
-            events.extend(platform_events)
-            console.print(f"  {platform}: {len(platform_events)} events")
-    if config.MANUAL_TV_PATH and config.MANUAL_MOVIES_PATH:
-        manual_events = parse_manual(config.MANUAL_TV_PATH, config.MANUAL_MOVIES_PATH)
-        events.extend(manual_events)
-        console.print(f"  manual: {len(manual_events)} events")
+    events, ok = _load_all_events(strict=True)
+    if not ok:
+        console.print("[red]Aborting setup: one or more configured providers failed.[/red]")
+        sys.exit(1)
     console.print(f"  Total: {len(events)} events")
 
 
@@ -212,6 +289,8 @@ if __name__ == "__main__":
                         help="Rebuild taste profile even if it exists")
     parser.add_argument("--refresh-data", action="store_true",
                         help="Re-fetch TMDB metadata, watch index, and enrichments")
+    parser.add_argument("--ingest-only", action="store_true",
+                        help="Load and report on ingested data without TMDB or LLM calls")
     parser.add_argument("--debug", action="store_true",
                         help="Enable debug logging")
     parser.add_argument("--provider", choices=["anthropic", "gemini", "openai"],
@@ -219,5 +298,8 @@ if __name__ == "__main__":
     args = parser.parse_args()
     from recommender.log import setup_logging
     setup_logging(level_override="DEBUG" if args.debug else None)
-    run_setup(refresh_profile=args.refresh_profile, refresh_data=args.refresh_data,
-              provider=args.provider)
+    if args.ingest_only:
+        run_ingest_only()
+    else:
+        run_setup(refresh_profile=args.refresh_profile, refresh_data=args.refresh_data,
+                  provider=args.provider)

--- a/recommender/templates/help.html
+++ b/recommender/templates/help.html
@@ -97,11 +97,12 @@
       <span class="help-heading">Configuration</span>
     </summary>
     <div class="help-body">
-      <p>Settings live in two places:</p>
+      <p>Settings live in a few places:</p>
       <ul>
         <li><strong>Environment variables</strong> — API keys only (<code>TMDB_API_KEY</code>, <code>ANTHROPIC_API_KEY</code>, <code>GEMINI_API_KEY</code>, <code>OPENAI_API_KEY</code>).</li>
         <li><strong>.env</strong> — optional local convenience for setting those variables. Gitignored.</li>
-        <li><strong>config.yaml</strong> — everything else. Editable from the <a href="/settings">Settings</a> page or by hand.</li>
+        <li><strong>config.yaml</strong> — shared repo defaults and app settings. Editable from the <a href="/settings">Settings</a> page or by hand.</li>
+        <li><strong>config.local.yaml</strong> — local overrides such as watch-history zip paths. Gitignored and loaded after <code>config.yaml</code>.</li>
       </ul>
       <p>Provider API keys use the standard variable names by default. Only set <span class="mono">api_key_env</span> when you need a custom variable name.</p>
       <p>The <a href="/settings">Settings</a> page lets you change provider, models, timeouts, scoring weights, and more — changes take effect immediately without a restart.</p>
@@ -133,7 +134,7 @@
       <span class="help-heading">Adding watch history</span>
     </summary>
     <div class="help-body">
-      <p>Set each provider path in <code>config.yaml</code> to the exact raw export zip file:</p>
+      <p>Set each provider path in <code>config.local.yaml</code> to the exact raw export zip file. Start from <code>config.local.example.yaml</code>:</p>
       <table class="help-table">
         <tr><td><strong>Netflix</strong></td><td>Account Settings &gt; Download your data &gt; Netflix export zip</td></tr>
         <tr><td><strong>Prime Video</strong></td><td>Account &gt; Digital content &gt; Request your data &gt; Prime Video export zip</td></tr>

--- a/recommender/templates/help.html
+++ b/recommender/templates/help.html
@@ -133,12 +133,14 @@
       <span class="help-heading">Adding watch history</span>
     </summary>
     <div class="help-body">
-      <p>Place exported CSV files under <code>data/</code>:</p>
+      <p>Set each provider path in <code>config.yaml</code> to the exact raw export zip file:</p>
       <table class="help-table">
-        <tr><td><strong>Netflix</strong></td><td>Account Settings > Download your data > ViewingActivity.csv</td></tr>
-        <tr><td><strong>Prime Video</strong></td><td>Account > Digital content > Request your data > Viewing History.csv</td></tr>
+        <tr><td><strong>Netflix</strong></td><td>Account Settings &gt; Download your data &gt; Netflix export zip</td></tr>
+        <tr><td><strong>Prime Video</strong></td><td>Account &gt; Digital content &gt; Request your data &gt; Prime Video export zip</td></tr>
+        <tr><td><strong>Apple TV</strong></td><td>Apple privacy export &gt; Apple Media Services Information Part 1 of 2.zip</td></tr>
         <tr><td><strong>Manual</strong></td><td><code>data/manual/tv.csv</code> and <code>data/manual/movies.csv</code> — one title per line</td></tr>
       </table>
+      <p>Run <code>./recommend setup --ingest-only</code> to validate the configured provider zips before rebuilding.</p>
       <p>After adding new data, run <code>./recommend setup --refresh-data</code> to rebuild.</p>
       <p>You can also add individual titles via CLI: <code>./recommend --add "Shetland" --type tv</code></p>
     </div>

--- a/recommender/templates/help.html
+++ b/recommender/templates/help.html
@@ -23,22 +23,39 @@
     </div>
   </details>
 
-  <!-- Searching -->
-  <details class="help-details">
+  <!-- Query guide -->
+  <details class="help-details" id="query-guide" open>
     <summary class="help-summary">
       <svg class="help-arrow" width="10" height="10" viewBox="0 0 10 10"><path d="M3 1 L7 5 L3 9" stroke="var(--teal)" stroke-width="1.5" fill="none" stroke-linecap="round" stroke-linejoin="round"/></svg>
-      <span class="help-heading">Searching</span>
+      <span class="help-heading">Query guide</span>
     </summary>
     <div class="help-body">
-      <p>Type anything in the search bar on the <a href="/">home page</a>. Some examples:</p>
+      <p>This is the canonical guide to what you can ask Streamline. These examples match the current code paths.</p>
+      <p><strong>Standard recommendation queries</strong></p>
       <ul>
         <li><strong>Genre + mood</strong> — "gritty British crime drama", "feel-good Bollywood comedy"</li>
         <li><strong>Similar to</strong> — "spy thriller like Slow Horses", "something like Fleabag but darker"</li>
-        <li><strong>Specific requests</strong> — "give me 5 underrated sci-fi movies", "short documentary series"</li>
+        <li><strong>Runtime + count</strong> — "give me 5 underrated sci-fi movies", "90-minute thriller", "short documentary series"</li>
         <li><strong>Language/region</strong> — "Hindi crime thriller", "Korean romance", "French arthouse"</li>
-        <li><strong>Platform</strong> — "what's good on Netflix right now", "best Prime Video originals"</li>
-        <li><strong>Why not?</strong> — "why not The Bear?" explains why a title wasn't recommended</li>
+        <li><strong>Platform</strong> — "what's good on Netflix right now", "best Prime Video originals", "Apple TV+ sci-fi"</li>
       </ul>
+      <p><strong>Special query modes</strong></p>
+      <ul>
+        <li><strong>Why not?</strong> — "why not Slow Horses?" explains why a title was filtered out or never surfaced.</li>
+        <li><strong>Abandoned-watch advice</strong> — "I started Severance and stopped. Should I keep going?" or "I dropped The Boys after a few episodes. Worth finishing?"</li>
+      </ul>
+      <p><strong>Interactive refinements</strong> in <code>./recommend</code></p>
+      <ul>
+        <li><strong>More options</strong> — "what else?" or "anything else?" reruns the last query without repeating prior results.</li>
+        <li><strong>Pick from a prior result</strong> — "more like #2" uses the second result from the previous turn as the new anchor title.</li>
+        <li><strong>Refine the last request</strong> — "but something British", "something lighter", "make it a movie".</li>
+      </ul>
+      <p><strong>Command-style inputs</strong> are not recommendation queries.</p>
+      <ul>
+        <li><code>+liked Title</code>, <code>+disliked Title</code>, <code>+add Title tv|movie</code> work inside interactive mode.</li>
+        <li><code>./recommend --liked "Title"</code>, <code>--disliked</code>, <code>--add</code>, and <code>--history</code> are CLI commands.</li>
+      </ul>
+      <p><strong>Runtime note</strong> — ordinary recommendations run from the cached watch index and taste profile after setup. Abandoned-watch queries depend on raw watch events, so they are less useful if your provider zips are no longer available at runtime.</p>
       <p>Results show the title, TMDB rating, genres, a personalized explanation of why it matches your taste, and where it's streaming.</p>
     </div>
   </details>
@@ -66,7 +83,7 @@
       <p>Everything goes through <code>./recommend</code>:</p>
       <table class="help-table">
         <tr><td><code>./recommend "query"</code></td><td>Single query</td></tr>
-        <tr><td><code>./recommend</code></td><td>Interactive mode (conversational, supports "more like that")</td></tr>
+        <tr><td><code>./recommend</code></td><td>Interactive mode with refinements like "what else?", "more like #2", and follow-up edits</td></tr>
         <tr><td><code>./recommend setup</code></td><td>First-time offline setup</td></tr>
         <tr><td><code>./recommend setup --refresh-data</code></td><td>Re-fetch TMDB metadata + rebuild everything</td></tr>
         <tr><td><code>./recommend setup --refresh-profile</code></td><td>Rebuild taste profile only</td></tr>
@@ -78,6 +95,7 @@
         <tr><td><code>./recommend --disliked "Title"</code></td><td>Mark a title as disliked</td></tr>
         <tr><td><code>./recommend --add "Title" --type tv</code></td><td>Add to watch history</td></tr>
       </table>
+      <p style="margin-top:1rem;">Inside interactive mode, you can also type <code>+liked Title</code>, <code>+disliked Title</code>, or <code>+add Title tv|movie</code>.</p>
 
       <p style="margin-top:1rem;">Web server:</p>
       <table class="help-table">

--- a/recommender/templates/index.html
+++ b/recommender/templates/index.html
@@ -42,6 +42,10 @@
     {% endfor %}
   </div>
 
+  <p style="margin-top:0.75rem; color:var(--muted); font-size:0.78rem;">
+    Need examples beyond the suggestion pills? See the <a href="/help#query-guide">query guide</a>.
+  </p>
+
   <script>
     // Auto-submit if arriving with ?q= param (from re-search link)
     (function() {

--- a/recommender/templates/settings.html
+++ b/recommender/templates/settings.html
@@ -5,7 +5,7 @@
 <div style="margin-bottom:2rem;">
   <span class="mono" style="font-size:0.62rem; letter-spacing:0.12em; text-transform:uppercase; color:var(--accent);">Configuration</span>
   <h1 style="font-size:clamp(2rem, 4.5vw, 3rem); margin-top:0.2rem; margin-bottom:0.5rem;">Settings</h1>
-  <p style="color:var(--muted); font-size:0.85rem;">Changes are saved to config.yaml and take effect on reload.</p>
+  <p style="color:var(--muted); font-size:0.85rem;">Changes are saved to config.yaml and take effect on reload. Local watch-history paths belong in config.local.yaml.</p>
 </div>
 
 {% if saved %}
@@ -301,7 +301,7 @@
 
   <div style="display:flex; gap:1rem; align-items:center;">
     <button type="submit" class="btn-primary" style="padding:0.75rem 2rem;">Save &amp; Reload</button>
-    <span class="mono" style="font-size:0.58rem; color:var(--muted);">Writes to config.yaml and reloads the application context.</span>
+    <span class="mono" style="font-size:0.58rem; color:var(--muted);">Writes shared settings to config.yaml. Local provider paths stay in config.local.yaml.</span>
   </div>
 
 </form>

--- a/recommender/web.py
+++ b/recommender/web.py
@@ -17,6 +17,7 @@ from markupsafe import Markup, escape
 import config
 from recommender.ingestion.netflix import parse as parse_netflix
 from recommender.ingestion.prime import parse as parse_prime
+from recommender.ingestion.apple_tv import parse as parse_apple_tv
 from recommender.ingestion.manual import parse as parse_manual
 from recommender.tmdb_client import TmdbClient
 from recommender.query_engine import RecommendContext, ask
@@ -39,13 +40,16 @@ def _get_context() -> RecommendContext:
 
 def _build_context() -> RecommendContext:
     events = []
-    for platform, parser in [("netflix", parse_netflix), ("prime", parse_prime)]:
+    for platform, parser in [("netflix", parse_netflix), ("prime", parse_prime), ("apple_tv", parse_apple_tv)]:
         path = config.PLATFORM_PATHS.get(platform)
         if path:
             try:
-                events.extend(parser(path))
-            except Exception:
-                pass
+                platform_events = parser(path)
+            except (FileNotFoundError, ValueError) as exc:
+                raise RuntimeError(f"Invalid {platform} watch history: {exc}") from exc
+            if not platform_events:
+                raise RuntimeError(f"Invalid {platform} watch history: zip parsed but yielded 0 events")
+            events.extend(platform_events)
     try:
         events.extend(parse_manual(config.MANUAL_TV_PATH, config.MANUAL_MOVIES_PATH))
     except Exception:

--- a/recommender/web.py
+++ b/recommender/web.py
@@ -46,9 +46,11 @@ def _build_context() -> RecommendContext:
             try:
                 platform_events = parser(path)
             except (FileNotFoundError, ValueError) as exc:
-                raise RuntimeError(f"Invalid {platform} watch history: {exc}") from exc
-            if not platform_events:
-                raise RuntimeError(f"Invalid {platform} watch history: zip parsed but yielded 0 events")
+                # The dashboard can render from cached artifacts after setup. Missing
+                # provider exports should only reduce abandoned-title context, not
+                # block the entire UI.
+                log.warning("Skipping %s watch history for runtime context: %s", platform, exc)
+                continue
             events.extend(platform_events)
     try:
         events.extend(parse_manual(config.MANUAL_TV_PATH, config.MANUAL_MOVIES_PATH))

--- a/recommender/web.py
+++ b/recommender/web.py
@@ -422,6 +422,7 @@ def _save_config_yaml(cfg: dict) -> None:
     with open(_CONFIG_PATH, "w") as f:
         f.write("# Streamline configuration\n")
         f.write("# Set API keys in the environment. .env is optional local convenience.\n\n")
+        f.write("# Put machine-specific watch-history paths in config.local.yaml.\n\n")
         yaml.dump(cfg, f, default_flow_style=False, sort_keys=False, allow_unicode=True)
 
 
@@ -458,7 +459,7 @@ def _reload_app_config() -> None:
     import importlib
     importlib.reload(config)
     _ctx = None  # next request will rebuild context
-    log.info("Config reloaded from config.yaml")
+    log.info("Config reloaded from config.yaml with config.local.yaml overrides if present")
 
 
 def _parse_int_field(form, key: str, default: int) -> int:

--- a/tests/TEST_PLAN.md
+++ b/tests/TEST_PLAN.md
@@ -1,0 +1,83 @@
+# Test Plan: Apple TV Ingestion + Uniform Provider Zip Validation
+
+Branch: `feat/apple-tv-ingestion`
+
+## Automated Tests
+
+### 1. Apple TV Ingestion (`recommender/ingestion/apple_tv.py`)
+
+| # | Test | Status |
+|---|------|--------|
+| 1a | Nested zip extraction — outer zip containing `Apple_Media_Services.zip` containing `Video Play Activity.csv` | TODO |
+| 1b | Zip validation — rejects non-`.zip` files (e.g. `.csv`) -> `ValueError` | TODO |
+| 1c | Zip validation — rejects missing files -> `FileNotFoundError` | TODO |
+| 1d | Zip validation — rejects corrupt zips -> `ValueError` | DONE (`test_apple_tv_parse_reports_invalid_zip`) |
+| 1e | CSV missing inside zip — valid zip but no `Video Play Activity.csv` -> `ValueError` | TODO |
+| 1f | Classification — TV episodes (has season/episode) vs movies (no season marker) via `_classify()` | TODO |
+| 1g | Title building — correct format for TV (`Show: Season: E3: Title`) and movies via `_build_title()` | TODO |
+| 1h | Dedup — multiple stop events for same (timestamp, series, ep) keeps highest duration | TODO |
+| 1i | Filtering — skips `Action Type != stop`, skip subtypes (FeaturedPromo, Preview, etc.), < 5min watches | TODO |
+| 1j | Timestamp parsing — handles `UTC Start Time`, falls back to `UTC End Time` | TODO |
+
+### 2. Netflix/Prime Provider Input Support (`netflix.py`, `prime.py`)
+
+| # | Test | Status |
+|---|------|--------|
+| 2a | Netflix zip-only contract — non-`.zip` input rejected by public `parse(path)` | TODO |
+| 2b | Netflix zip ingestion — `.zip` containing `ViewingActivity.csv` | TODO |
+| 2c | Netflix bad zip — corrupt `.zip` -> `ValueError` | TODO |
+| 2d | Netflix missing CSV in zip — valid zip, no `ViewingActivity.csv` -> `ValueError` | TODO |
+| 2e | Netflix missing file -> `FileNotFoundError` | TODO |
+| 2f | Netflix clean extraction per parse — bad zip after prior success does not reuse stale extracted CSV | TODO |
+| 2g | Prime zip-only contract — non-`.zip` input rejected by public `parse(path)` | TODO |
+| 2h | Prime zip ingestion — `.zip` containing `Viewing History.csv` | TODO |
+| 2i | Prime bad zip / missing CSV / missing file — same error cases as Netflix | TODO |
+| 2j | Prime clean extraction per parse — bad zip after prior success does not reuse stale extracted CSV | TODO |
+
+### 3. Config: `config.local.yaml` Override System (`config.py`)
+
+| # | Test | Status |
+|---|------|--------|
+| 3a | `_merge_dicts` recursive merge — nested dict keys merge, scalars override | DONE (`test_merge_dicts_applies_local_overrides_recursively`) |
+| 3b | `apple_tv` key exists in `PLATFORM_PATHS` and resolves correctly | TODO |
+| 3c | `_resolve_platform_path` with `default=None` — returns `None` when key is omitted | TODO |
+| 3d | Real loader path — `config.local.yaml` overrides `config.yaml` when both files are present | TODO |
+
+### 4. Setup: `--ingest-only` Mode (`setup.py`)
+
+| # | Test | Status |
+|---|------|--------|
+| 4a | No providers configured -> exit 1 with "No providers configured" message | DONE (`test_run_ingest_only_exits_if_no_provider_zips_are_configured`) |
+| 4b | Empty but valid export -> passes (exit 0), prints "0 events" | DONE (`test_run_ingest_only_accepts_empty_provider_export`) |
+| 4c | Mixed: one provider fails, one succeeds -> strict mode exit 1 | TODO |
+| 4d | All providers valid with events -> prints summary with TV/movie counts | TODO |
+| 4e | Full `run_setup()` with zero total events across all sources -> exit 1 with explicit "No watch events found" message | TODO |
+
+### 5. Runtime Graceful Degradation (`main.py`, `web.py`)
+
+| # | Test | Status |
+|---|------|--------|
+| 5a | CLI: configured provider missing at runtime -> warning, continues with empty events | DONE (`test_load_context_skips_invalid_configured_provider`) |
+| 5b | Web: configured provider missing at runtime -> warning logged, continues | DONE (`test_web_build_context_skips_invalid_configured_provider`) |
+| 5c | Ordinary recommendation flow still works after setup when provider zips are removed | TODO |
+
+### Existing Tests to Verify Still Pass
+
+- `tests/ingestion/test_netflix.py`
+- All existing `tests/test_main.py` tests
+
+
+## Manual Tests
+
+### 6. E2E with Real Data
+
+| # | Test | Steps | Expected |
+|---|------|-------|----------|
+| 6a | Ingest-only with real Apple TV zip | `./recommend setup --ingest-only` with `apple_tv` path set to real export zip | Prints event count, TV/movie breakdown, exits 0 |
+| 6b | Ingest-only with Netflix zip (not CSV) | `./recommend setup --ingest-only` with `netflix` path set to a `.zip` export | Prints event count, exits 0 |
+| 6c | Full setup with Apple TV configured | `./recommend setup` with `apple_tv` path set | Watch index includes Apple TV titles, enrichment runs, profile rebuilt |
+| 6d | Runtime with missing apple_tv zip | Set `apple_tv` to a non-existent zip path, run `./recommend "something"` | Warning printed, recommendations still work from cached index/profile |
+| 6e | Web UI with Apple TV configured | `./recommend-web start`, open http://localhost:5050 | Dashboard loads and derived artifacts built from Apple TV-backed setup remain usable |
+| 6f | Web UI settings page messaging | Open settings | Page says shared settings save to `config.yaml` and local watch-history paths belong in `config.local.yaml` |
+| 6g | `config.local.yaml` override | Create `config.local.yaml` with `platform_paths.apple_tv: path/to/zip`, run `./recommend setup --ingest-only` | Local override used, shared `config.yaml` unchanged |
+| 6h | Ordinary CLI query after removing provider zips | Run `./recommend setup`, move configured provider zips away, then run `./recommend "something"` | Warning printed, ordinary recommendations still work from cached watch index/profile |

--- a/tests/fixtures/netflix_sample.csv
+++ b/tests/fixtures/netflix_sample.csv
@@ -1,6 +1,0 @@
-"Duration","Start Time","Profile Name","Country","Bookmark","Latest Bookmark","Supplemental Video Type","Attributes","Device Type","Title"
-"00:45:03","2026-03-16 20:22:18","Ratna","US (United States)","00:46:54","00:46:54","","","Roku","Avatar: The Last Airbender: Book 3: Day of the Black Sun (Episode 10)"
-"00:02:06","2026-03-10 06:22:22","Ratna","US (United States)","00:02:06","00:02:06","TRAILER","","Roku","Trailer: How To Get To Heaven From Belfast"
-"00:00:09","2026-03-15 22:18:44","Ratna","US (United States)","00:00:09","00:00:09","","","Roku","Search Party: Season 1: Episode 1 (Episode 1)"
-"00:22:34","2026-03-16 19:59:39","Ratna","US (United States)","00:23:57","00:23:57","","","Roku","Avatar: The Last Airbender: Book 3: Nightmares and Daydreams (Episode 9)"
-"01:45:00","2026-03-12 14:00:00","Ratna","US (United States)","01:45:00","01:45:00","","","Roku","14 Peaks: Nothing Is Impossible"

--- a/tests/ingestion/test_apple_tv.py
+++ b/tests/ingestion/test_apple_tv.py
@@ -1,0 +1,299 @@
+"""Tests for Apple TV ingestion (tests/TEST_PLAN.md section 1)."""
+import csv
+import io
+import zipfile
+from datetime import datetime, timedelta
+
+import pytest
+
+from recommender.ingestion.apple_tv import _build_title, _classify, parse
+
+_APPLE_TV_FIELDS = [
+    "Action Type",
+    "Content Sub-Type",
+    "Feature Play Duration",
+    "UTC Start Time",
+    "UTC End Time",
+    "Content Episode Name",
+    "Content Title",
+    "Content Season Name",
+    "Episode Number",
+    "Content Length MS",
+]
+
+
+def _make_csv(rows: list[dict]) -> bytes:
+    buf = io.StringIO()
+    writer = csv.DictWriter(buf, fieldnames=_APPLE_TV_FIELDS, extrasaction="ignore")
+    writer.writeheader()
+    for row in rows:
+        writer.writerow({f: row.get(f, "") for f in _APPLE_TV_FIELDS})
+    return buf.getvalue().encode()
+
+
+def _make_zip(contents: dict[str, bytes]) -> bytes:
+    buf = io.BytesIO()
+    with zipfile.ZipFile(buf, "w") as zf:
+        for name, data in contents.items():
+            zf.writestr(name, data)
+    return buf.getvalue()
+
+
+def _stop_row(**kwargs) -> dict:
+    defaults = {
+        "Action Type": "stop",
+        "Content Sub-Type": "",
+        "Feature Play Duration": "600000",
+        "UTC Start Time": "2026-01-01T10:00:00",
+        "UTC End Time": "",
+        "Content Episode Name": "",
+        "Content Title": "The Movie",
+        "Content Season Name": "",
+        "Episode Number": "",
+        "Content Length MS": "0",
+    }
+    defaults.update(kwargs)
+    return defaults
+
+
+def _simple_zip(tmp_path, rows: list[dict]) -> str:
+    """Write a flat zip with Video Play Activity.csv and return its path."""
+    csv_bytes = _make_csv(rows)
+    zip_bytes = _make_zip({"Video Play Activity.csv": csv_bytes})
+    p = tmp_path / "export.zip"
+    p.write_bytes(zip_bytes)
+    return str(p)
+
+
+# ── 1a: Nested zip extraction ──────────────────────────────────────────────
+
+def test_nested_zip_extraction(tmp_path):
+    """Outer zip containing Apple_Media_Services.zip containing the CSV."""
+    csv_bytes = _make_csv([
+        _stop_row(**{
+            "Content Episode Name": "Breaking Bad",
+            "Content Title": "Pilot",
+            "Content Season Name": "Season 1",
+            "Episode Number": "1.0",
+        })
+    ])
+    inner_zip = _make_zip({"Stores Activity/Other Activity/Video Play Activity.csv": csv_bytes})
+    outer_zip = _make_zip({"Apple_Media_Services.zip": inner_zip})
+    zip_path = tmp_path / "Apple_Media_Services_Information_Part_1_of_2.zip"
+    zip_path.write_bytes(outer_zip)
+
+    events = parse(str(zip_path))
+    assert len(events) == 1
+    assert events[0].platform == "apple_tv"
+    assert events[0].series_name == "Breaking Bad"
+
+
+# ── 1b: Zip validation — rejects non-.zip files ────────────────────────────
+
+def test_parse_rejects_non_zip_extension(tmp_path):
+    csv_file = tmp_path / "export.csv"
+    csv_file.write_text("not a zip")
+    with pytest.raises(ValueError, match=r"\.zip"):
+        parse(str(csv_file))
+
+
+# ── 1c: Zip validation — rejects missing files ─────────────────────────────
+
+def test_parse_raises_file_not_found(tmp_path):
+    with pytest.raises(FileNotFoundError):
+        parse(str(tmp_path / "nonexistent.zip"))
+
+
+# ── 1e: CSV missing inside zip ─────────────────────────────────────────────
+
+def test_parse_raises_if_no_csv_in_zip(tmp_path):
+    zip_bytes = _make_zip({"other_file.txt": b"no csv here"})
+    zip_path = tmp_path / "export.zip"
+    zip_path.write_bytes(zip_bytes)
+    with pytest.raises(ValueError, match="Video Play Activity.csv"):
+        parse(str(zip_path))
+
+
+# ── 1f: Classification — TV episodes vs movies ─────────────────────────────
+
+def test_classify_tv_episode_with_season():
+    content_type, series_name = _classify({
+        "Content Episode Name": "Breaking Bad",
+        "Content Season Name": "Season 1",
+        "Episode Number": "1.0",
+        "Content Title": "Pilot",
+    })
+    assert content_type == "tv"
+    assert series_name == "Breaking Bad"
+
+
+def test_classify_tv_episode_with_episode_number_only():
+    content_type, series_name = _classify({
+        "Content Episode Name": "Severance",
+        "Content Season Name": "",
+        "Episode Number": "2.0",
+        "Content Title": "Half Loop",
+    })
+    assert content_type == "tv"
+    assert series_name == "Severance"
+
+
+def test_classify_movie_no_show_name():
+    content_type, series_name = _classify({
+        "Content Episode Name": "",
+        "Content Season Name": "",
+        "Episode Number": "",
+        "Content Title": "Inception",
+    })
+    assert content_type == "movie"
+    assert series_name == "Inception"
+
+
+def test_classify_standalone_no_season_or_episode():
+    """Show name present but no season/episode -> treated as movie."""
+    content_type, series_name = _classify({
+        "Content Episode Name": "Ted Lasso Special",
+        "Content Season Name": "",
+        "Episode Number": "0",
+        "Content Title": "Behind the Scenes",
+    })
+    assert content_type == "movie"
+    assert series_name == "Ted Lasso Special"
+
+
+# ── 1g: Title building ─────────────────────────────────────────────────────
+
+def test_build_title_movie():
+    title = _build_title(
+        {"Content Season Name": "", "Content Title": "Inception", "Episode Number": ""},
+        "movie",
+        "Inception",
+    )
+    assert title == "Inception"
+
+
+def test_build_title_tv_with_season_and_episode():
+    title = _build_title(
+        {"Content Season Name": "Season 1", "Content Title": "Pilot", "Episode Number": "1.0"},
+        "tv",
+        "Breaking Bad",
+    )
+    assert title == "Breaking Bad: Season 1: E1: Pilot"
+
+
+def test_build_title_tv_episode_title_same_as_show_is_omitted():
+    title = _build_title(
+        {"Content Season Name": "Season 1", "Content Title": "Breaking Bad", "Episode Number": "1.0"},
+        "tv",
+        "Breaking Bad",
+    )
+    assert title == "Breaking Bad: Season 1: E1"
+
+
+def test_build_title_tv_no_season_no_episode():
+    title = _build_title(
+        {"Content Season Name": "", "Content Title": "Filler", "Episode Number": ""},
+        "tv",
+        "Some Show",
+    )
+    assert title == "Some Show: Filler"
+
+
+# ── 1h: Dedup — keeps highest duration ─────────────────────────────────────
+
+def test_dedup_keeps_highest_duration_for_same_event(tmp_path):
+    rows = [
+        _stop_row(**{
+            "Feature Play Duration": "600000",
+            "UTC Start Time": "2026-01-01T10:00:00",
+            "Content Episode Name": "Breaking Bad",
+            "Content Title": "Pilot",
+            "Content Season Name": "Season 1",
+            "Episode Number": "1.0",
+        }),
+        _stop_row(**{
+            "Feature Play Duration": "900000",
+            "UTC Start Time": "2026-01-01T10:00:00",
+            "Content Episode Name": "Breaking Bad",
+            "Content Title": "Pilot",
+            "Content Season Name": "Season 1",
+            "Episode Number": "1.0",
+        }),
+    ]
+    events = parse(_simple_zip(tmp_path, rows))
+    assert len(events) == 1
+    assert events[0].watched_duration == timedelta(milliseconds=900000)
+
+
+def test_dedup_keeps_distinct_events_at_different_timestamps(tmp_path):
+    rows = [
+        _stop_row(**{
+            "Feature Play Duration": "600000",
+            "UTC Start Time": "2026-01-01T10:00:00",
+            "Content Episode Name": "Breaking Bad",
+            "Content Title": "Pilot",
+        }),
+        _stop_row(**{
+            "Feature Play Duration": "600000",
+            "UTC Start Time": "2026-01-02T10:00:00",
+            "Content Episode Name": "Breaking Bad",
+            "Content Title": "Pilot",
+        }),
+    ]
+    events = parse(_simple_zip(tmp_path, rows))
+    assert len(events) == 2
+
+
+# ── 1i: Filtering ──────────────────────────────────────────────────────────
+
+def test_skips_non_stop_action_type(tmp_path):
+    rows = [_stop_row(**{"Action Type": "play"})]
+    assert parse(_simple_zip(tmp_path, rows)) == []
+
+
+def test_skips_featured_promo_subtype(tmp_path):
+    rows = [_stop_row(**{"Content Sub-Type": "FeaturedPromo"})]
+    assert parse(_simple_zip(tmp_path, rows)) == []
+
+
+def test_skips_preview_subtype(tmp_path):
+    rows = [_stop_row(**{"Content Sub-Type": "Preview"})]
+    assert parse(_simple_zip(tmp_path, rows)) == []
+
+
+def test_skips_watch_under_five_minutes(tmp_path):
+    rows = [_stop_row(**{"Feature Play Duration": "240000"})]  # 4 minutes
+    assert parse(_simple_zip(tmp_path, rows)) == []
+
+
+def test_includes_watch_at_exactly_five_minutes(tmp_path):
+    rows = [_stop_row(**{"Feature Play Duration": "300000"})]  # exactly 5 min
+    events = parse(_simple_zip(tmp_path, rows))
+    assert len(events) == 1
+
+
+# ── 1j: Timestamp parsing ──────────────────────────────────────────────────
+
+def test_timestamp_uses_utc_start_time(tmp_path):
+    rows = [_stop_row(**{
+        "UTC Start Time": "2026-03-15T08:30:00",
+        "UTC End Time": "2026-03-15T08:45:00",
+    })]
+    events = parse(_simple_zip(tmp_path, rows))
+    assert len(events) == 1
+    assert events[0].timestamp == datetime(2026, 3, 15, 8, 30, 0)
+
+
+def test_timestamp_falls_back_to_utc_end_time_when_start_missing(tmp_path):
+    rows = [_stop_row(**{
+        "UTC Start Time": "",
+        "UTC End Time": "2026-03-15T09:00:00",
+    })]
+    events = parse(_simple_zip(tmp_path, rows))
+    assert len(events) == 1
+    assert events[0].timestamp == datetime(2026, 3, 15, 9, 0, 0)
+
+
+def test_skips_row_with_no_timestamp(tmp_path):
+    rows = [_stop_row(**{"UTC Start Time": "", "UTC End Time": ""})]
+    assert parse(_simple_zip(tmp_path, rows)) == []

--- a/tests/ingestion/test_netflix.py
+++ b/tests/ingestion/test_netflix.py
@@ -1,6 +1,6 @@
 import os
 from datetime import timedelta, datetime
-from recommender.ingestion.netflix import parse
+from recommender.ingestion.netflix import _parse_csv as parse
 
 FIXTURE = os.path.join(os.path.dirname(__file__), "../fixtures/netflix_sample.csv")
 

--- a/tests/ingestion/test_netflix.py
+++ b/tests/ingestion/test_netflix.py
@@ -1,53 +1,153 @@
-import os
-from datetime import timedelta, datetime
-from recommender.ingestion.netflix import _parse_csv as parse
+import csv
+import io
+import zipfile
+from datetime import datetime, timedelta
 
-FIXTURE = os.path.join(os.path.dirname(__file__), "../fixtures/netflix_sample.csv")
+import pytest
 
+from recommender.ingestion.netflix import parse
 
-def test_skips_trailers():
-    events = parse(FIXTURE)
-    titles = [e.title for e in events]
-    assert not any("TRAILER" in t or "Trailer:" in t for t in titles)
-
-
-def test_skips_short_watches():
-    events = parse(FIXTURE)
-    titles = [e.title for e in events]
-    assert not any("Search Party" in t for t in titles)
-
-
-def test_tv_event_classification():
-    events = parse(FIXTURE)
-    tv_events = [e for e in events if e.content_type == "tv"]
-    assert len(tv_events) == 2
-    assert all(e.series_name == "Avatar: The Last Airbender" for e in tv_events)
+_NETFLIX_FIELDS = [
+    "Duration",
+    "Start Time",
+    "Profile Name",
+    "Country",
+    "Bookmark",
+    "Latest Bookmark",
+    "Supplemental Video Type",
+    "Attributes",
+    "Device Type",
+    "Title",
+]
 
 
-def test_movie_event_classification():
-    events = parse(FIXTURE)
-    movie_events = [e for e in events if e.content_type == "movie"]
-    assert len(movie_events) == 1
-    assert movie_events[0].title == "14 Peaks: Nothing Is Impossible"
+def _make_netflix_csv(rows: list[dict]) -> bytes:
+    buf = io.StringIO()
+    writer = csv.DictWriter(buf, fieldnames=_NETFLIX_FIELDS, extrasaction="ignore")
+    writer.writeheader()
+    for row in rows:
+        writer.writerow({field: row.get(field, "") for field in _NETFLIX_FIELDS})
+    return buf.getvalue().encode()
 
 
-def test_duration_parsed():
-    events = parse(FIXTURE)
-    avatar = next(e for e in events if "Book 3: Day of" in e.title)
-    assert avatar.watched_duration == timedelta(hours=0, minutes=45, seconds=3)
+def _make_zip(contents: dict[str, bytes]) -> bytes:
+    buf = io.BytesIO()
+    with zipfile.ZipFile(buf, "w") as zf:
+        for name, data in contents.items():
+            zf.writestr(name, data)
+    return buf.getvalue()
 
 
-def test_timestamp_parsed():
-    events = parse(FIXTURE)
-    avatar = next(e for e in events if "Book 3: Day of" in e.title)
-    assert avatar.timestamp == datetime(2026, 3, 16, 20, 22, 18)
+def _row(**kwargs) -> dict:
+    defaults = {
+        "Duration": "01:30:00",
+        "Start Time": "2026-01-01 12:00:00",
+        "Profile Name": "Main",
+        "Country": "US",
+        "Bookmark": "01:30:00",
+        "Latest Bookmark": "01:30:00",
+        "Supplemental Video Type": "",
+        "Attributes": "",
+        "Device Type": "Roku",
+        "Title": "Inception",
+    }
+    defaults.update(kwargs)
+    return defaults
 
 
-def test_platform_set():
-    events = parse(FIXTURE)
-    assert all(e.platform == "netflix" for e in events)
+def _write_export_zip(tmp_path, rows: list[dict], member_name: str = "ViewingActivity.csv") -> str:
+    csv_bytes = _make_netflix_csv(rows)
+    zip_bytes = _make_zip({member_name: csv_bytes})
+    export_path = tmp_path / "netflix_export.zip"
+    export_path.write_bytes(zip_bytes)
+    return str(export_path)
 
 
-def test_total_duration_none():
-    events = parse(FIXTURE)
-    assert all(e.total_duration is None for e in events)
+def test_parse_zip_skips_trailers_and_short_watches(tmp_path):
+    export_path = _write_export_zip(
+        tmp_path,
+        [
+            _row(Title="Inception"),
+            _row(Title="Trailer: Inception", **{"Supplemental Video Type": "Trailer"}),
+            _row(Title="Search Party", Duration="00:04:59"),
+        ],
+    )
+
+    events = parse(export_path)
+
+    assert [event.title for event in events] == ["Inception"]
+
+
+def test_parse_zip_classifies_tv_and_movies(tmp_path):
+    export_path = _write_export_zip(
+        tmp_path,
+        [
+            _row(Title="14 Peaks: Nothing Is Impossible"),
+            _row(
+                Title="Avatar: The Last Airbender: Book 3: Day of Black Sun: Part 1: The Invasion (Episode 1)",
+                Duration="00:45:03",
+                **{"Start Time": "2026-03-16 20:22:18"},
+            ),
+        ],
+    )
+
+    events = parse(export_path)
+
+    movie_event = next(event for event in events if event.content_type == "movie")
+    tv_event = next(event for event in events if event.content_type == "tv")
+    assert movie_event.title == "14 Peaks: Nothing Is Impossible"
+    assert tv_event.series_name == "Avatar: The Last Airbender"
+    assert tv_event.watched_duration == timedelta(minutes=45, seconds=3)
+    assert tv_event.timestamp == datetime(2026, 3, 16, 20, 22, 18)
+
+
+def test_parse_zip_sets_platform_and_total_duration_none(tmp_path):
+    export_path = _write_export_zip(tmp_path, [_row(Title="Inception"), _row(Title="Interstellar")])
+
+    events = parse(export_path)
+
+    assert all(event.platform == "netflix" for event in events)
+    assert all(event.total_duration is None for event in events)
+
+
+def test_parse_raises_for_non_zip_extension(tmp_path):
+    export_path = tmp_path / "netflix_export.csv"
+    export_path.write_text("not a zip")
+
+    with pytest.raises(ValueError, match=r"\.zip file"):
+        parse(str(export_path))
+
+
+def test_parse_raises_for_missing_file(tmp_path):
+    with pytest.raises(FileNotFoundError):
+        parse(str(tmp_path / "missing.zip"))
+
+
+def test_parse_raises_for_corrupt_zip(tmp_path):
+    export_path = tmp_path / "corrupt.zip"
+    export_path.write_text("not a zip archive")
+
+    with pytest.raises(ValueError, match="Invalid zip file"):
+        parse(str(export_path))
+
+
+def test_parse_raises_when_csv_missing_from_zip(tmp_path):
+    export_path = tmp_path / "netflix_export.zip"
+    export_path.write_bytes(_make_zip({"SomeOtherFile.csv": b"wrong file"}))
+
+    with pytest.raises(ValueError, match="ViewingActivity.csv"):
+        parse(str(export_path))
+
+
+def test_clean_extraction_bad_zip_after_prior_success_does_not_reuse_stale_csv(tmp_path):
+    good_export = tmp_path / "good.zip"
+    good_export.write_bytes(_make_zip({"ViewingActivity.csv": _make_netflix_csv([_row(Title="Inception")])}))
+
+    events = parse(str(good_export))
+    assert len(events) == 1
+
+    bad_export = tmp_path / "bad.zip"
+    bad_export.write_text("corrupt")
+
+    with pytest.raises(ValueError, match="Invalid zip file"):
+        parse(str(bad_export))

--- a/tests/ingestion/test_prime.py
+++ b/tests/ingestion/test_prime.py
@@ -1,0 +1,145 @@
+import csv
+import io
+import zipfile
+from datetime import datetime, timedelta
+
+import pytest
+
+from recommender.ingestion.prime import parse
+
+_PRIME_FIELDS = [
+    "Material Type Description",
+    "Seconds Viewed",
+    "Playback Start Datetime (UTC)",
+    "Title",
+    "Profile Type",
+]
+
+
+def _make_prime_csv(rows: list[dict]) -> bytes:
+    buf = io.StringIO()
+    writer = csv.DictWriter(buf, fieldnames=_PRIME_FIELDS, extrasaction="ignore")
+    writer.writeheader()
+    for row in rows:
+        writer.writerow({field: row.get(field, "") for field in _PRIME_FIELDS})
+    return buf.getvalue().encode()
+
+
+def _make_zip(contents: dict[str, bytes]) -> bytes:
+    buf = io.BytesIO()
+    with zipfile.ZipFile(buf, "w") as zf:
+        for name, data in contents.items():
+            zf.writestr(name, data)
+    return buf.getvalue()
+
+
+def _row(**kwargs) -> dict:
+    defaults = {
+        "Material Type Description": "Feature",
+        "Seconds Viewed": "2400",
+        "Playback Start Datetime (UTC)": "2026-01-01T10:00:00Z",
+        "Title": "Dune",
+        "Profile Type": "adult",
+    }
+    defaults.update(kwargs)
+    return defaults
+
+
+def _write_export_zip(tmp_path, rows: list[dict], member_name: str = "Viewing History.csv") -> str:
+    csv_bytes = _make_prime_csv(rows)
+    zip_bytes = _make_zip({member_name: csv_bytes})
+    export_path = tmp_path / "prime_export.zip"
+    export_path.write_bytes(zip_bytes)
+    return str(export_path)
+
+
+def test_parse_zip_skips_non_feature_material_and_short_watches(tmp_path):
+    export_path = _write_export_zip(
+        tmp_path,
+        [
+            _row(Title="Dune"),
+            _row(Title="Short Clip", **{"Material Type Description": "Trailer"}),
+            _row(Title="Too Short", **{"Seconds Viewed": "1199"}),
+        ],
+    )
+
+    events = parse(export_path)
+
+    assert [event.title for event in events] == ["Dune"]
+
+
+def test_parse_zip_classifies_tv_and_movies(tmp_path):
+    export_path = _write_export_zip(
+        tmp_path,
+        [
+            _row(Title="Dune"),
+            _row(
+                Title="Pilot - The Boys, Season 1",
+                **{
+                    "Seconds Viewed": "2700",
+                    "Playback Start Datetime (UTC)": "2026-02-01T12:00:00Z",
+                },
+            ),
+        ],
+    )
+
+    events = parse(export_path)
+
+    movie_event = next(event for event in events if event.content_type == "movie")
+    tv_event = next(event for event in events if event.content_type == "tv")
+    assert movie_event.title == "Dune"
+    assert tv_event.series_name == "The Boys"
+    assert tv_event.watched_duration == timedelta(seconds=2700)
+    assert tv_event.timestamp == datetime(2026, 2, 1, 12, 0, 0)
+
+
+def test_parse_zip_sets_platform_and_total_duration_none(tmp_path):
+    export_path = _write_export_zip(tmp_path, [_row(Title="Dune"), _row(Title="Arrival")])
+
+    events = parse(export_path)
+
+    assert all(event.platform == "prime" for event in events)
+    assert all(event.total_duration is None for event in events)
+
+
+def test_parse_raises_for_non_zip_extension(tmp_path):
+    export_path = tmp_path / "prime_export.csv"
+    export_path.write_text("not a zip")
+
+    with pytest.raises(ValueError, match=r"\.zip file"):
+        parse(str(export_path))
+
+
+def test_parse_raises_for_missing_file(tmp_path):
+    with pytest.raises(FileNotFoundError):
+        parse(str(tmp_path / "missing.zip"))
+
+
+def test_parse_raises_for_corrupt_zip(tmp_path):
+    export_path = tmp_path / "bad.zip"
+    export_path.write_text("not a zip")
+
+    with pytest.raises(ValueError, match="Invalid zip file"):
+        parse(str(export_path))
+
+
+def test_parse_raises_for_missing_csv_in_zip(tmp_path):
+    export_path = tmp_path / "prime_export.zip"
+    export_path.write_bytes(_make_zip({"other.txt": b"no csv"}))
+
+    with pytest.raises(ValueError, match="Viewing History.csv"):
+        parse(str(export_path))
+
+
+def test_clean_extraction_bad_zip_after_prior_success_does_not_reuse_stale_csv(tmp_path):
+    good_export = tmp_path / "good.zip"
+    good_export.write_bytes(_make_zip({"Viewing History.csv": _make_prime_csv([_row(Title="Good Film")])}))
+
+    events = parse(str(good_export))
+    assert len(events) == 1
+
+    bad_export = tmp_path / "bad.zip"
+    bad_export.write_text("corrupt")
+
+    with pytest.raises(ValueError, match="Invalid zip file"):
+        parse(str(bad_export))

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -131,6 +131,26 @@ def test_resolve_platform_path_allows_explicit_disable(monkeypatch):
     assert config._resolve_platform_path('netflix', 'data/netflix/export.zip') is None
 
 
+def test_merge_dicts_applies_local_overrides_recursively():
+    import config
+
+    base = {
+        "platform_paths": {"netflix": None, "prime": None},
+        "models": {"openai": {"fast": "base-fast"}},
+    }
+    local = {
+        "platform_paths": {"netflix": "data/netflix/export.zip"},
+        "models": {"openai": {"reason": "local-reason"}},
+    }
+
+    merged = config._merge_dicts(base, local)
+
+    assert merged["platform_paths"]["netflix"] == "data/netflix/export.zip"
+    assert merged["platform_paths"]["prime"] is None
+    assert merged["models"]["openai"]["fast"] == "base-fast"
+    assert merged["models"]["openai"]["reason"] == "local-reason"
+
+
 def test_run_ingest_only_exits_if_no_provider_zips_are_configured(monkeypatch, capsys):
     import config
     import recommender.setup as setup

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -467,7 +467,11 @@ def test_recommend_web_uses_runtime_provider_for_api_key_check(tmp_path, monkeyp
 
     activate_path = tmp_path / "venv" / "bin"
     activate_path.mkdir(parents=True)
-    (activate_path / "activate").write_text("# recommend-web test activation\n")
+    current_python_bin = Path(sys.executable).parent
+    (activate_path / "activate").write_text(
+        f'export PATH="{current_python_bin}:$PATH"\n'
+        f'export VIRTUAL_ENV="{current_python_bin.parent}"\n'
+    )
 
     cfg = yaml.safe_load((repo_root / "config.yaml").read_text())
     cfg["provider"] = "openai"
@@ -492,3 +496,176 @@ def test_recommend_web_uses_runtime_provider_for_api_key_check(tmp_path, monkeyp
     assert result.returncode == 1
     assert "taste profile not found" in result.stderr
     assert "OPENAI_API_KEY" not in result.stderr
+
+
+# ── 3b: apple_tv key in PLATFORM_PATHS ────────────────────────────────────
+
+def test_apple_tv_key_present_in_platform_paths():
+    import config
+    assert "apple_tv" in config.PLATFORM_PATHS
+
+
+# ── 3c: _resolve_platform_path with default=None ─────────────────────────
+
+def test_resolve_platform_path_with_none_default_returns_none_when_key_missing(monkeypatch):
+    import config
+    monkeypatch.setattr(config, "_paths", {})
+    assert config._resolve_platform_path("apple_tv", None) is None
+
+
+# ── 3d: config.local.yaml overrides config.yaml when both present ─────────
+
+def test_local_config_overrides_base_config_when_both_files_present(tmp_path):
+    import config
+
+    base_file = tmp_path / "config.yaml"
+    base_file.write_text(
+        "provider: anthropic\nplatform_paths:\n  netflix: data/netflix/export.zip\n"
+    )
+    local_file = tmp_path / "config.local.yaml"
+    local_file.write_text(
+        "platform_paths:\n  apple_tv: /path/to/apple_export.zip\n"
+    )
+
+    base = config._load_yaml(base_file)
+    local = config._load_yaml(local_file)
+    merged = config._merge_dicts(base, local)
+
+    assert merged["provider"] == "anthropic"
+    assert merged["platform_paths"]["netflix"] == "data/netflix/export.zip"
+    assert merged["platform_paths"]["apple_tv"] == "/path/to/apple_export.zip"
+
+
+# ── 4c: Mixed: one provider fails, one succeeds -> strict mode exit 1 ──────
+
+def test_run_ingest_only_exits_if_one_provider_fails_in_strict_mode(monkeypatch, capsys):
+    import config
+    import recommender.setup as setup
+    from datetime import datetime, timedelta
+    from recommender.ingestion.base import WatchEvent
+
+    def _ok_parser(_path):
+        return [WatchEvent(
+            platform="netflix",
+            title="Succession",
+            content_type="tv",
+            series_name="Succession",
+            watched_duration=timedelta(hours=1),
+            total_duration=None,
+            timestamp=datetime(2026, 1, 1),
+            profile="",
+        )]
+
+    def _fail_parser(_path):
+        raise ValueError("corrupt zip")
+
+    monkeypatch.setattr(config, "PLATFORM_PATHS", {
+        "netflix": "/tmp/netflix.zip",
+        "prime": "/tmp/prime.zip",
+        "apple_tv": None,
+    })
+    monkeypatch.setattr(config, "MANUAL_TV_PATH", None)
+    monkeypatch.setattr(config, "MANUAL_MOVIES_PATH", None)
+    monkeypatch.setattr(setup, "_PLATFORM_PARSERS", [
+        ("netflix", _ok_parser),
+        ("prime", _fail_parser),
+    ])
+
+    with pytest.raises(SystemExit) as exc_info:
+        setup.run_ingest_only()
+
+    assert exc_info.value.code == 1
+    assert "FAIL" in capsys.readouterr().err
+
+
+# ── 4d: All providers valid with events -> prints TV/movie breakdown ────────
+
+def test_run_ingest_only_prints_tv_and_movie_summary(monkeypatch, capsys):
+    import config
+    import recommender.setup as setup
+    from datetime import datetime, timedelta
+    from recommender.ingestion.base import WatchEvent
+
+    def _parser(_path):
+        return [
+            WatchEvent(
+                platform="netflix",
+                title="Succession: Season 1: Episode 1 (Episode 1)",
+                content_type="tv",
+                series_name="Succession",
+                watched_duration=timedelta(hours=1),
+                total_duration=None,
+                timestamp=datetime(2026, 1, 1),
+                profile="",
+            ),
+            WatchEvent(
+                platform="netflix",
+                title="Inception",
+                content_type="movie",
+                series_name="Inception",
+                watched_duration=timedelta(hours=2),
+                total_duration=None,
+                timestamp=datetime(2026, 1, 2),
+                profile="",
+            ),
+        ]
+
+    monkeypatch.setattr(config, "PLATFORM_PATHS", {"netflix": "/tmp/export.zip", "prime": None, "apple_tv": None})
+    monkeypatch.setattr(config, "MANUAL_TV_PATH", None)
+    monkeypatch.setattr(config, "MANUAL_MOVIES_PATH", None)
+    monkeypatch.setattr(setup, "_PLATFORM_PARSERS", [("netflix", _parser)])
+
+    setup.run_ingest_only()
+
+    err = capsys.readouterr().err
+    assert "TV shows" in err
+    assert "movies" in err
+
+
+# ── 4e: run_setup() with zero total events -> exit 1 ──────────────────────
+
+def test_run_setup_exits_with_no_watch_events_message(monkeypatch, capsys):
+    import config
+    import recommender.setup as setup
+
+    monkeypatch.setattr(config, "PLATFORM_PATHS", {"netflix": "/tmp/export.zip", "prime": None, "apple_tv": None})
+    monkeypatch.setattr(config, "MANUAL_TV_PATH", None)
+    monkeypatch.setattr(config, "MANUAL_MOVIES_PATH", None)
+    monkeypatch.setattr(config, "TMDB_API_KEY", "fake-tmdb-key")
+    monkeypatch.setattr(setup, "_PLATFORM_PARSERS", [("netflix", lambda _path: [])])
+    class _FakeLLM:
+        provider = "anthropic"
+    monkeypatch.setattr(setup, "create_client", lambda _provider=None: _FakeLLM())
+
+    with pytest.raises(SystemExit) as exc_info:
+        setup.run_setup()
+
+    assert exc_info.value.code == 1
+    assert "No watch events found" in capsys.readouterr().err
+
+
+# ── 5c: Ordinary recommendation flow still works after provider zips removed
+
+def test_load_context_works_with_no_configured_providers(monkeypatch, tmp_path):
+    """After provider zips are removed, load_context returns cached index/profile."""
+    import config
+    import json
+    from recommender import main as main_module
+
+    index_path = tmp_path / "watch_index.json"
+    index_path.write_text(json.dumps([{"tmdb_id": 1, "title": "succession", "content_type": "tv"}]))
+    profile_path = tmp_path / "profile.txt"
+    profile_path.write_text("taste profile")
+
+    monkeypatch.setattr(config, "PLATFORM_PATHS", {"netflix": None, "prime": None, "apple_tv": None})
+    monkeypatch.setattr(config, "MANUAL_TV_PATH", None)
+    monkeypatch.setattr(config, "MANUAL_MOVIES_PATH", None)
+    monkeypatch.setattr(config, "WATCH_INDEX_PATH", str(index_path))
+    monkeypatch.setattr(config, "TASTE_PROFILE_PATH", str(profile_path))
+    monkeypatch.setattr(config, "TMDB_API_KEY", "tmdb")
+    monkeypatch.setattr(main_module, "create_client", lambda _provider=None: object())
+
+    ctx = main_module.load_context()
+
+    assert ctx.events == []
+    assert ctx.taste_profile == "taste profile"

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -96,19 +96,28 @@ def test_load_context_exits_if_no_taste_profile(tmp_path, monkeypatch):
         load_context()
 
 
-def test_load_context_exits_on_invalid_configured_provider(monkeypatch, capsys):
+def test_load_context_skips_invalid_configured_provider(monkeypatch, capsys, tmp_path):
     import config
+    import json
+    from recommender import main as main_module
+
+    index_path = tmp_path / 'watch_index.json'
+    index_path.write_text(json.dumps([{"tmdb_id": 0, "title": "downton abbey", "content_type": "tv"}]))
+    profile_path = tmp_path / 'profile.txt'
+    profile_path.write_text('taste profile')
 
     monkeypatch.setattr(config, 'PLATFORM_PATHS', {'netflix': '/tmp/missing.zip', 'prime': None, 'apple_tv': None})
     monkeypatch.setattr(config, 'MANUAL_TV_PATH', None)
     monkeypatch.setattr(config, 'MANUAL_MOVIES_PATH', None)
+    monkeypatch.setattr(config, 'WATCH_INDEX_PATH', str(index_path))
+    monkeypatch.setattr(config, 'TASTE_PROFILE_PATH', str(profile_path))
+    monkeypatch.setattr(config, 'TMDB_API_KEY', 'tmdb')
+    monkeypatch.setattr(main_module, 'create_client', lambda _provider=None: object())
 
-    with pytest.raises(SystemExit) as exc_info:
-        from recommender.main import load_context
-        load_context()
+    ctx = main_module.load_context()
 
-    assert exc_info.value.code == 1
-    assert 'Invalid netflix watch history' in capsys.readouterr().err
+    assert ctx.events == []
+    assert 'Skipping netflix watch history for runtime context' in capsys.readouterr().err
 
 
 def test_resolve_platform_path_uses_default_when_key_missing(monkeypatch):
@@ -167,16 +176,44 @@ def test_run_ingest_only_exits_if_no_provider_zips_are_configured(monkeypatch, c
     assert 'No providers configured' in capsys.readouterr().err
 
 
-def test_web_build_context_raises_on_invalid_configured_provider(monkeypatch):
+def test_web_build_context_skips_invalid_configured_provider(monkeypatch, tmp_path):
     import config
     from recommender import web
+    import json
+
+    index_path = tmp_path / 'watch_index.json'
+    index_path.write_text(json.dumps([{"tmdb_id": 0, "title": "downton abbey", "content_type": "tv"}]))
+    profile_path = tmp_path / 'profile.txt'
+    profile_path.write_text('taste profile')
 
     monkeypatch.setattr(config, 'PLATFORM_PATHS', {'netflix': '/tmp/missing.zip', 'prime': None, 'apple_tv': None})
     monkeypatch.setattr(config, 'MANUAL_TV_PATH', None)
     monkeypatch.setattr(config, 'MANUAL_MOVIES_PATH', None)
+    monkeypatch.setattr(config, 'WATCH_INDEX_PATH', str(index_path))
+    monkeypatch.setattr(config, 'TASTE_PROFILE_PATH', str(profile_path))
+    monkeypatch.setattr(config, 'TMDB_API_KEY', 'tmdb')
+    monkeypatch.setattr(web, 'create_client', lambda: object())
+    warnings = []
+    monkeypatch.setattr(web.log, 'warning', lambda message, *args: warnings.append(message % args))
 
-    with pytest.raises(RuntimeError, match='Invalid netflix watch history'):
-        web._build_context()
+    ctx = web._build_context()
+
+    assert ctx.events == []
+    assert any('Skipping netflix watch history for runtime context' in message for message in warnings)
+
+
+def test_run_ingest_only_accepts_empty_provider_export(monkeypatch, capsys):
+    import config
+    import recommender.setup as setup
+
+    monkeypatch.setattr(config, 'PLATFORM_PATHS', {'netflix': '/tmp/export.zip', 'prime': None, 'apple_tv': None})
+    monkeypatch.setattr(config, 'MANUAL_TV_PATH', None)
+    monkeypatch.setattr(config, 'MANUAL_MOVIES_PATH', None)
+    monkeypatch.setattr(setup, '_PLATFORM_PARSERS', [('netflix', lambda _path: [])])
+
+    setup.run_ingest_only()
+
+    assert 'netflix:' in capsys.readouterr().err
 
 
 def test_apple_tv_parse_reports_invalid_zip(tmp_path):

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -96,24 +96,77 @@ def test_load_context_exits_if_no_taste_profile(tmp_path, monkeypatch):
         load_context()
 
 
+def test_load_context_exits_on_invalid_configured_provider(monkeypatch, capsys):
+    import config
+
+    monkeypatch.setattr(config, 'PLATFORM_PATHS', {'netflix': '/tmp/missing.zip', 'prime': None, 'apple_tv': None})
+    monkeypatch.setattr(config, 'MANUAL_TV_PATH', None)
+    monkeypatch.setattr(config, 'MANUAL_MOVIES_PATH', None)
+
+    with pytest.raises(SystemExit) as exc_info:
+        from recommender.main import load_context
+        load_context()
+
+    assert exc_info.value.code == 1
+    assert 'Invalid netflix watch history' in capsys.readouterr().err
+
+
 def test_resolve_platform_path_uses_default_when_key_missing(monkeypatch):
     import config
 
     monkeypatch.setattr(config, '_paths', {})
 
-    resolved = config._resolve_platform_path('netflix', 'data/netflix/ViewingActivity.csv')
+    resolved = config._resolve_platform_path('netflix', 'data/netflix/export.zip')
 
-    assert resolved == str(config._ROOT / 'data/netflix/ViewingActivity.csv')
+    assert resolved == str(config._ROOT / 'data/netflix/export.zip')
 
 
 def test_resolve_platform_path_allows_explicit_disable(monkeypatch):
     import config
 
     monkeypatch.setattr(config, '_paths', {'netflix': None})
-    assert config._resolve_platform_path('netflix', 'data/netflix/ViewingActivity.csv') is None
+    assert config._resolve_platform_path('netflix', 'data/netflix/export.zip') is None
 
     monkeypatch.setattr(config, '_paths', {'netflix': ''})
-    assert config._resolve_platform_path('netflix', 'data/netflix/ViewingActivity.csv') is None
+    assert config._resolve_platform_path('netflix', 'data/netflix/export.zip') is None
+
+
+def test_run_ingest_only_exits_if_no_provider_zips_are_configured(monkeypatch, capsys):
+    import config
+    import recommender.setup as setup
+
+    monkeypatch.setattr(config, 'PLATFORM_PATHS', {'netflix': None, 'prime': None, 'apple_tv': None})
+    monkeypatch.setattr(config, 'MANUAL_TV_PATH', 'manual-tv.csv')
+    monkeypatch.setattr(config, 'MANUAL_MOVIES_PATH', 'manual-movies.csv')
+    monkeypatch.setattr(setup, 'parse_manual', lambda *_args: [object()])
+
+    with pytest.raises(SystemExit) as exc_info:
+        setup.run_ingest_only()
+
+    assert exc_info.value.code == 1
+    assert 'No providers configured' in capsys.readouterr().err
+
+
+def test_web_build_context_raises_on_invalid_configured_provider(monkeypatch):
+    import config
+    from recommender import web
+
+    monkeypatch.setattr(config, 'PLATFORM_PATHS', {'netflix': '/tmp/missing.zip', 'prime': None, 'apple_tv': None})
+    monkeypatch.setattr(config, 'MANUAL_TV_PATH', None)
+    monkeypatch.setattr(config, 'MANUAL_MOVIES_PATH', None)
+
+    with pytest.raises(RuntimeError, match='Invalid netflix watch history'):
+        web._build_context()
+
+
+def test_apple_tv_parse_reports_invalid_zip(tmp_path):
+    from recommender.ingestion.apple_tv import parse
+
+    bad_zip = tmp_path / 'bad.zip'
+    bad_zip.write_text('not a zip archive')
+
+    with pytest.raises(ValueError, match='Invalid zip file'):
+        parse(str(bad_zip))
 
 
 def _settings_test_client(tmp_path, monkeypatch, raw_cfg: dict | None = None):


### PR DESCRIPTION
## Summary

This PR does three related things as one coherent change:

- adds Apple TV as a first-class watch-history source
- standardizes all external providers on one data-input contract
- separates shared repo config from machine-local provider paths

The external-provider contract is now uniform for Netflix, Prime Video, and Apple TV:
- exact export zip path only
- no directory scanning
- no CSV entrypoint
- no stale extracted-file reuse across runs

`manual` and `plex` are outside this contract and keep their existing behavior.

## Why

Before this branch, provider ingestion had drifted into multiple incompatible shapes:
- different providers accepted different input forms
- local watch-history paths lived in tracked config
- setup validation, runtime behavior, and docs were describing different contracts
- test coverage was also mixing provider-specific patterns

That made review harder than it needed to be because there was no single answer to a basic question: "what is the supported input for an external provider?"

This PR restores that answer to one rule: raw export zip only.

## What Changed

### 1. Apple TV ingestion

- Added Apple TV ingestion in `recommender/ingestion/apple_tv.py`
- Supports Apple's nested export structure:
  - outer export zip
  - nested `Apple_Media_Services.zip`
  - nested `Video Play Activity.csv`
- Filters previews/promos and short sessions
- Deduplicates stop events for the same playback session
- Wires Apple TV events into setup and runtime contexts

### 2. Uniform zip-only provider inputs

Netflix, Prime Video, and Apple TV now all behave the same way for external watch-history data:
- input must be an exact `.zip` file path
- missing file -> `FileNotFoundError`
- wrong extension -> `ValueError`
- malformed zip -> `ValueError`
- wrong export structure -> `ValueError`

Netflix and Prime no longer expose `.csv` as a public parser input.

Extraction for Netflix and Prime uses a fresh temporary directory per parse, so stale extracted CSVs cannot be reused across runs.

### 3. Setup validation

`./recommend setup --ingest-only` is now the validation path for configured external providers.

Behavior:
- exits non-zero when any configured provider zip is invalid
- accepts valid exports that yield zero qualifying watch events
- exits non-zero when no providers are configured
- prints per-provider status and event counts

Full `./recommend setup` still requires usable watch events across all sources before rebuilding artifacts.

### 4. Runtime behavior after setup

Normal recommendation flows should not depend on keeping the raw provider archives around forever.

Current runtime behavior:
- if cached artifacts exist, ordinary CLI/web recommendations still work when provider zips are missing later
- runtime logs a warning and skips raw-event loading for that provider
- abandoned-title queries are the only path that may lose fidelity without raw events

### 5. Config split

The repo now cleanly separates shared defaults from machine-local provider paths:
- `config.yaml` is tracked shared config
- `config.local.yaml` is an ignored local override file
- `config.local.example.yaml` is the template for local provider paths

This avoids putting personal watch-history paths under ignored `data/` into shared tracked config.

### 6. Tests and docs

Tests were realigned to the same external-provider contract:
- Netflix tests use public `parse(zip_path)` only
- Prime tests use public `parse(zip_path)` only
- Apple TV tests use public `parse(zip_path)` only
- no provider test depends on a repo-local `venv`

Docs and setup messaging were updated to point users at `config.local.yaml` for local provider paths and to describe the zip-only provider contract.

## Reviewer Focus

Please review this as one change centered on consistency:

1. Apple TV is added as a new source
2. Netflix / Prime / Apple TV now share one exact input contract
3. setup validation is strict for configured provider zips
4. runtime degrades gracefully back to cached artifacts after setup
5. local provider paths are no longer tracked in shared config

The most important review questions are:
- Do all external providers now expose the same input contract?
- Are parser failure modes clear and deterministic?
- Does setup validate the right things without overreaching?
- Does runtime keep ordinary recommendations usable after setup if raw zips move away?
- Is the config split between shared defaults and local machine state clean?

## Validation

Ran locally:

- `source venv/bin/activate && pytest -q` -> `136 passed`
- `source venv/bin/activate && python -m recommender.setup --ingest-only` -> passed

## Notes

- `manual` ingestion remains unchanged
- `plex` is unchanged and intentionally outside the zip-only external-provider contract
