### PR TITLE
feat: web UI watch management (#29)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -70,7 +70,9 @@ Two-phase LLM pipeline. LLM calls use roles ("fast" for enrichment, "reason" for
 - `recommender/signals.py` — Scoring: completion (50%) + rewatch (30%) + true half-life recency decay (20%).
 - `recommender/query_engine.py` — Full online pipeline. "Why not X?" trace mode, conversational context, platform filtering.
 - `recommender/overrides.py` — Title override system (data/overrides.json). Auto-detects changes and triggers rebuild.
-- `recommender/feedback.py` — Liked/disliked ratings, title additions. Score multipliers applied at profile rebuild.
+- `recommender/feedback.py` — (Deprecated) Original JSON-based feedback storage. Migrated to `user_store.py` SQLite tables.
+- `recommender/user_store.py` — SQLite storage for watchlist (`saved_titles`), ratings (`title_ratings`), and manual archive additions (`manual_archive_entries`). Migration from `feedback.json`.
+- `recommender/user_state.py` — `UserStateIndex` snapshot for TMDB-ID-first matching in query filtering and UI rendering.
 - `recommender/web.py` — Flask web UI with HTMX search, poster grid, taste profile clusters.
 - `recommender/main.py` — Rich CLI with spinners, panels, stderr/stdout separation, REPL with inline feedback, usage stats.
 
@@ -81,7 +83,7 @@ Two-phase LLM pipeline. LLM calls use roles ("fast" for enrichment, "reason" for
 - `UsageStats` — accumulated token counts and cost per query
 
 ### Cache Layout
-All under `recommender/cache/`: `tmdb/`, `enrichments/` (+ index.json), `providers/`, `watch_index.json`, `taste_profile.txt` (+ timestamped backups), `feedback.json`.
+All under `recommender/cache/`: `tmdb/`, `enrichments/` (+ index.json), `providers/`, `watch_index.json`, `taste_profile.txt` (+ timestamped backups), `feedback.json`. User-managed state (watchlist, ratings, manual archive) lives in the same SQLite database as imported watch events (`events.db`).
 
 ## Configuration
 

--- a/recommender/history.py
+++ b/recommender/history.py
@@ -88,38 +88,60 @@ def _write_raw_to_file(history_file, entries: list[dict]) -> None:
     os.fsync(history_file.fileno())
 
 
+def _serialize_result(r) -> dict:
+    """Serialize a result for storage — accepts enriched dicts or Recommendation objects."""
+    if isinstance(r, dict):
+        return {
+            "title": r["title"],
+            "content_type": r["content_type"],
+            "score": round(r.get("score") or 0, 3),
+            "vote_average": r.get("vote_average") or 0,
+            "genres": r.get("genres") or [],
+            "explanation": r.get("explanation") or "",
+            "streaming_providers": (r.get("streaming_providers") or [])[:4],
+            "tmdb_id": r.get("tmdb_id"),
+            "poster": r.get("poster"),
+            "tmdb_url": r.get("tmdb_url") or "",
+            "imdb_url": r.get("imdb_url") or "",
+        }
+    # Raw Recommendation object
+    return {
+        "title": r.title,
+        "content_type": r.content_type,
+        "score": round(r.score, 3),
+        "vote_average": r.vote_average,
+        "genres": getattr(r, "genres", []),
+        "explanation": r.explanation,
+        "streaming_providers": r.streaming_providers[:4],
+        "tmdb_id": None,
+        "poster": None,
+        "tmdb_url": "",
+        "imdb_url": "",
+    }
+
+
 def record(
     query: str,
-    results: list[Recommendation],
+    results: list,
     provider: str,
     usage_summary: str,
 ) -> None:
-    """Append a query + results to history, capped at MAX_ENTRIES."""
+    """Append a query + results to history, capped at MAX_ENTRIES.
+
+    ``results`` may be enriched dicts (from web.py) or raw Recommendation objects.
+    """
     def append_entry(history_file) -> None:
         entries = _load_raw_from_file(history_file)
-
         entry = {
             "timestamp": datetime.now(timezone.utc).isoformat(),
             "query": query,
             "provider": provider,
-            "results": [
-                {
-                    "title": r.title,
-                    "content_type": r.content_type,
-                    "score": round(r.score, 3),
-                    "vote_average": r.vote_average,
-                    "explanation": r.explanation,
-                    "streaming_providers": r.streaming_providers[:4],
-                }
-                for r in results
-            ],
+            "results": [_serialize_result(r) for r in results],
             "usage": usage_summary,
         }
         entries.append(entry)
-
         if len(entries) > MAX_ENTRIES:
             entries[:] = entries[-MAX_ENTRIES:]
-
         _write_raw_to_file(history_file, entries)
 
     _with_locked_history_file(append_entry)

--- a/recommender/llm.py
+++ b/recommender/llm.py
@@ -300,7 +300,10 @@ def create_client(provider: str | None = None) -> LLMClient:
         raise ValueError(f"No model config for provider '{provider}' in config.yaml")
 
     api_key_env = config.get_llm_api_key_env(provider)
-    api_key = os.environ.get(api_key_env, "")
+    if api_key_env in config.LLM_DEFAULT_API_KEY_ENVS.values():
+        api_key = getattr(config, api_key_env, os.environ.get(api_key_env, ""))
+    else:
+        api_key = os.environ.get(api_key_env, "")
     if not api_key:
         raise RuntimeError(f"{api_key_env} not set. Export it or add to .env.")
 

--- a/recommender/main.py
+++ b/recommender/main.py
@@ -6,7 +6,8 @@ from rich.console import Console
 from rich.panel import Panel
 
 import config
-from recommender import feedback as fb
+from recommender import user_store
+from recommender.user_state import UserStateIndex
 from recommender.event_store import load_events
 from recommender.llm import create_client
 from recommender.models import Recommendation
@@ -45,7 +46,7 @@ def load_context(provider: str | None = None) -> RecommendContext:
         console_err.print(f"[red]Error: {exc}[/red]")
         sys.exit(1)
 
-    return RecommendContext(
+    ctx = RecommendContext(
         taste_profile=profile_path.read_text(),
         watch_index=wi.load(config.WATCH_INDEX_PATH),
         tmdb_client=TmdbClient(api_key=config.TMDB_API_KEY, cache_dir=config.CACHE_DIR),
@@ -55,7 +56,9 @@ def load_context(provider: str | None = None) -> RecommendContext:
         providers_cache_dir=config.PROVIDERS_CACHE_DIR,
         watch_region=config.WATCH_REGION,
         streaming_platforms=list(config.STREAMING_PLATFORMS),
+        user_state=UserStateIndex.load(config.EVENT_DB_PATH),
     )
+    return ctx
 
 
 def print_recommendations(results: list[Recommendation], query: str) -> None:
@@ -84,9 +87,13 @@ def _handle_feedback_command(line: str) -> bool:
     for prefix in ("+liked ", "+loved ", "+like "):
         if line.lower().startswith(prefix):
             title = line[len(prefix):].strip()
-            data = fb.load(config.FEEDBACK_PATH)
-            fb.add_rating(data, title, "liked")
-            fb.save(data, config.FEEDBACK_PATH)
+            user_store.ensure_user_store(config.EVENT_DB_PATH, config.FEEDBACK_PATH)
+            try:
+                ct = user_store.resolve_rating_content_type(config.EVENT_DB_PATH, title)
+            except ValueError as exc:
+                console_out.print(f"[red]{exc}[/red]")
+                return True
+            user_store.rate_title(config.EVENT_DB_PATH, title, ct, "liked")
             console_out.print(f"[green]Marked as liked:[/green] {title}")
             console_out.print("[dim]Run --refresh-profile to update your taste profile.[/dim]")
             return True
@@ -95,9 +102,13 @@ def _handle_feedback_command(line: str) -> bool:
     for prefix in ("-disliked ", "+disliked ", "-dislike ", "+dislike "):
         if line.lower().startswith(prefix):
             title = line[len(prefix):].strip()
-            data = fb.load(config.FEEDBACK_PATH)
-            fb.add_rating(data, title, "disliked")
-            fb.save(data, config.FEEDBACK_PATH)
+            user_store.ensure_user_store(config.EVENT_DB_PATH, config.FEEDBACK_PATH)
+            try:
+                ct = user_store.resolve_rating_content_type(config.EVENT_DB_PATH, title)
+            except ValueError as exc:
+                console_out.print(f"[red]{exc}[/red]")
+                return True
+            user_store.rate_title(config.EVENT_DB_PATH, title, ct, "disliked")
             console_out.print(f"[yellow]Marked as disliked:[/yellow] {title}")
             console_out.print("[dim]Run --refresh-profile to update your taste profile.[/dim]")
             return True
@@ -110,9 +121,8 @@ def _handle_feedback_command(line: str) -> bool:
             title, ct = parts[0].strip(), parts[1].lower()
         else:
             title, ct = rest, "tv"
-        data = fb.load(config.FEEDBACK_PATH)
-        fb.add_addition(data, title, ct)
-        fb.save(data, config.FEEDBACK_PATH)
+        user_store.ensure_user_store(config.EVENT_DB_PATH, config.FEEDBACK_PATH)
+        user_store.add_to_archive(config.EVENT_DB_PATH, title, ct, source="cli")
         console_out.print(f"[green]Added to watch history:[/green] {title} ({ct})")
         console_out.print("[dim]Run --refresh-profile to update your taste profile.[/dim]")
         return True
@@ -159,17 +169,22 @@ def main() -> None:
 
     # Handle feedback-only invocations (no API keys needed).
     if args.liked or args.disliked or args.add:
-        data = fb.load(config.FEEDBACK_PATH)
-        if args.liked:
-            fb.add_rating(data, args.liked, "liked")
-            console_out.print(f"[green]Marked as liked:[/green] {args.liked}")
-        if args.disliked:
-            fb.add_rating(data, args.disliked, "disliked")
-            console_out.print(f"[yellow]Marked as disliked:[/yellow] {args.disliked}")
+        user_store.ensure_user_store(config.EVENT_DB_PATH, config.FEEDBACK_PATH)
+        try:
+            if args.liked:
+                ct = user_store.resolve_rating_content_type(config.EVENT_DB_PATH, args.liked)
+                user_store.rate_title(config.EVENT_DB_PATH, args.liked, ct, "liked")
+                console_out.print(f"[green]Marked as liked:[/green] {args.liked}")
+            if args.disliked:
+                ct = user_store.resolve_rating_content_type(config.EVENT_DB_PATH, args.disliked)
+                user_store.rate_title(config.EVENT_DB_PATH, args.disliked, ct, "disliked")
+                console_out.print(f"[yellow]Marked as disliked:[/yellow] {args.disliked}")
+        except ValueError as exc:
+            console_out.print(f"[red]{exc}[/red]")
+            return
         if args.add:
-            fb.add_addition(data, args.add, args.type)
+            user_store.add_to_archive(config.EVENT_DB_PATH, args.add, args.type, source="cli")
             console_out.print(f"[green]Added to watch history:[/green] {args.add} ({args.type})")
-        fb.save(data, config.FEEDBACK_PATH)
         console_out.print("[dim]Run python -m recommender.setup --refresh-profile to update your taste profile.[/dim]")
         return
 
@@ -208,6 +223,7 @@ def main() -> None:
         if not line or line.lower() == "exit":
             break
         if _handle_feedback_command(line):
+            ctx.user_state = UserStateIndex.load(config.EVENT_DB_PATH)
             continue
         # Create conv_ctx before ask() so ask() can write the real parsed intent into it
         # on the very first turn — otherwise "what else?" on turn 2 reuses a placeholder.

--- a/recommender/main.py
+++ b/recommender/main.py
@@ -29,6 +29,12 @@ console_err = Console(stderr=True)   # spinners, progress, warnings
 console_out = Console()              # recommendation results
 
 
+def _load_user_state():
+    if Path(config.EVENT_DB_PATH).exists():
+        user_store.ensure_user_store(config.EVENT_DB_PATH, config.FEEDBACK_PATH)
+    return UserStateIndex.load(config.EVENT_DB_PATH)
+
+
 def load_context(provider: str | None = None) -> RecommendContext:
     index_path = Path(config.WATCH_INDEX_PATH)
     if not index_path.exists():
@@ -56,7 +62,7 @@ def load_context(provider: str | None = None) -> RecommendContext:
         providers_cache_dir=config.PROVIDERS_CACHE_DIR,
         watch_region=config.WATCH_REGION,
         streaming_platforms=list(config.STREAMING_PLATFORMS),
-        user_state=UserStateIndex.load(config.EVENT_DB_PATH),
+        user_state=_load_user_state(),
     )
     return ctx
 

--- a/recommender/query_engine.py
+++ b/recommender/query_engine.py
@@ -12,6 +12,7 @@ from .ingestion.base import WatchEvent
 from .llm import LLMClient
 from .models import Recommendation
 from .tmdb_client import TmdbClient, TmdbMetadata
+from .user_state import UserStateIndex
 from .watch_index import WatchIndex
 
 log = logging.getLogger("recommender.query")
@@ -82,6 +83,7 @@ class RecommendContext:
     providers_cache_dir: str
     watch_region: str
     streaming_platforms: list[str]
+    user_state: "UserStateIndex | None"
     _events_loader: Callable[[], list[WatchEvent]] | None
     _events_resolved: list[WatchEvent] | None
 
@@ -89,7 +91,8 @@ class RecommendContext:
                  events: list[WatchEvent] | None = None,
                  _events_loader: Callable[[], list[WatchEvent]] | None = None,
                  providers_cache_dir="", watch_region="US",
-                 streaming_platforms: list[str] | None = None):
+                 streaming_platforms: list[str] | None = None,
+                 user_state: "UserStateIndex | None" = None):
         self.taste_profile = taste_profile
         self.watch_index = watch_index
         self.tmdb_client = tmdb_client
@@ -100,6 +103,7 @@ class RecommendContext:
         self.streaming_platforms = streaming_platforms or []
         self._events_loader = _events_loader
         self._events_resolved = events  # None = lazy, list = eager
+        self.user_state = user_state
 
     @property
     def events(self) -> list[WatchEvent]:
@@ -351,6 +355,26 @@ def _handle_why_not(title: str, ctx: RecommendContext) -> list[Recommendation]:
         )]
     lines.append("  Watch index: [green]Not watched[/green] — not in watch history.")
 
+    # Step 2b: Manual archive and dismissed check
+    if ctx.user_state:
+        if ctx.user_state.is_manually_watched(meta):
+            lines.append("  User state: [yellow]WATCHED[/yellow] — manually added to archive.")
+            lines.append("  → Excluded because you marked it as watched.")
+            return [Recommendation(
+                title=meta.title, content_type=meta.content_type,
+                score=0.0, vote_average=meta.vote_average, genres=meta.genres,
+                explanation="\n".join(lines),
+            )]
+        if ctx.user_state.is_dismissed(meta):
+            lines.append("  User state: [yellow]DISMISSED[/yellow] — marked as won't watch.")
+            lines.append("  → Excluded because you dismissed this title.")
+            return [Recommendation(
+                title=meta.title, content_type=meta.content_type,
+                score=0.0, vote_average=meta.vote_average, genres=meta.genres,
+                explanation="\n".join(lines),
+            )]
+        lines.append("  User state: [green]OK[/green] — not dismissed or manually archived.")
+
     # Step 3: Popularity / vote threshold
     if meta.vote_count < config.MIN_VOTE_COUNT:
         lines.append(
@@ -482,7 +506,10 @@ def ask(
     pre_filter = len(candidates)
     candidates = [
         c for c in candidates
-        if not ctx.watch_index.is_watched(c) and c.title not in extra_excludes
+        if not ctx.watch_index.is_watched(c)
+        and c.title not in extra_excludes
+        and not (ctx.user_state and ctx.user_state.is_manually_watched(c))
+        and not (ctx.user_state and ctx.user_state.is_dismissed(c))
     ]
     log.debug("Watch filter: %d -> %d candidates (%d excluded)",
               pre_filter, len(candidates), pre_filter - len(candidates))
@@ -507,7 +534,10 @@ def ask(
     for title in suggestions:
         for ct in content_types:
             meta = ctx.tmdb_client.get_metadata(title, ct)
-            if meta and meta.tmdb_id not in seen_ids and not ctx.watch_index.is_watched(meta) and meta.title not in extra_excludes:
+            if (meta and meta.tmdb_id not in seen_ids and not ctx.watch_index.is_watched(meta)
+                    and meta.title not in extra_excludes
+                    and not (ctx.user_state and ctx.user_state.is_manually_watched(meta))
+                    and not (ctx.user_state and ctx.user_state.is_dismissed(meta))):
                 if config.MIN_RATING > 0 and meta.vote_average < config.MIN_RATING:
                     continue
                 if config.MIN_YEAR > 0 and meta.release_year and meta.release_year < config.MIN_YEAR:

--- a/recommender/setup.py
+++ b/recommender/setup.py
@@ -21,6 +21,7 @@ from recommender.taste_profile_builder import build as build_taste_profile
 from recommender.llm import create_client
 from recommender import watch_index as wi
 from recommender import feedback as fb
+from recommender import user_store
 from recommender import overrides as ov
 from recommender import event_store
 
@@ -322,16 +323,17 @@ def run_setup(refresh_profile: bool = False, refresh_data: bool = False, provide
 
     profile_path = Path(config.TASTE_PROFILE_PATH)
     if refresh_profile or not profile_path.exists():
-        feedback = fb.load(config.FEEDBACK_PATH)
-        liked_count = sum(1 for r in feedback["ratings"] if r.get("rating") == "liked")
-        disliked_count = sum(1 for r in feedback["ratings"] if r.get("rating") == "disliked")
+        user_store.ensure_user_store(config.EVENT_DB_PATH, config.FEEDBACK_PATH)
+        ratings = user_store.load_ratings(config.EVENT_DB_PATH)
+        liked_count = sum(1 for r in ratings if r["rating"] == "liked")
+        disliked_count = sum(1 for r in ratings if r["rating"] == "disliked")
         if liked_count or disliked_count:
             console.print(f"  Applying feedback: {liked_count} liked, {disliked_count} disliked titles")
 
         with console.status("[bold magenta]Building taste profile with Claude Sonnet...[/bold magenta]", spinner="dots"):
             scores = compute_scores(events, metadata, config.RECENCY_HALF_LIFE_DAYS)
-            scores = fb.apply_score_multipliers(scores, feedback)
-            negative_prefs = fb.get_disliked_titles(feedback)
+            scores = user_store.apply_rating_multipliers(scores, ratings)
+            negative_prefs = user_store.get_disliked_titles(config.EVENT_DB_PATH)
             try:
                 profile = build_taste_profile(events, scores, enrichments, llm,
                                               negative_prefs=negative_prefs or None)

--- a/recommender/setup.py
+++ b/recommender/setup.py
@@ -20,7 +20,6 @@ from recommender.enricher import enrich_batch
 from recommender.taste_profile_builder import build as build_taste_profile
 from recommender.llm import create_client
 from recommender import watch_index as wi
-from recommender import feedback as fb
 from recommender import user_store
 from recommender import overrides as ov
 from recommender import event_store

--- a/recommender/templates/_rating_prompt.html
+++ b/recommender/templates/_rating_prompt.html
@@ -1,0 +1,21 @@
+<div id="rating-{{ uid }}" style="display:inline-flex; align-items:center; gap:0.5rem;">
+  <span class="mono" style="font-size:0.6rem; color:var(--muted);">Rate?</span>
+  <form hx-post="/archive/rate" hx-target="#rating-{{ uid }}" hx-swap="outerHTML" style="margin:0; display:inline;">
+    <input type="hidden" name="_csrf_token" value="{{ csrf_token }}">
+    <input type="hidden" name="title" value="{{ title }}">
+    <input type="hidden" name="content_type" value="{{ content_type }}">
+    <input type="hidden" name="tmdb_id" value="{{ tmdb_id or '' }}">
+    <button type="submit" name="rating" value="liked" class="mono"
+      style="background:none; border:none; cursor:pointer; padding:2px 6px; font-size:0.8rem; color:var(--muted); transition:color 0.15s;"
+      onmouseover="this.style.color='var(--teal)'" onmouseout="this.style.color='var(--muted)'"
+      title="Liked">&#x1F44D;</button>
+    <button type="submit" name="rating" value="disliked" class="mono"
+      style="background:none; border:none; cursor:pointer; padding:2px 6px; font-size:0.8rem; color:var(--muted); transition:color 0.15s;"
+      onmouseover="this.style.color='var(--accent)'" onmouseout="this.style.color='var(--muted)'"
+      title="Disliked">&#x1F44E;</button>
+    <button type="submit" name="rating" value="skip" class="mono"
+      style="background:none; border:none; cursor:pointer; padding:2px 6px; font-size:0.6rem; color:var(--muted); transition:color 0.15s;"
+      onmouseover="this.style.color='var(--text)'" onmouseout="this.style.color='var(--muted)'"
+      title="Skip">skip</button>
+  </form>
+</div>

--- a/recommender/templates/_rating_prompt.html
+++ b/recommender/templates/_rating_prompt.html
@@ -5,6 +5,7 @@
     <input type="hidden" name="title" value="{{ title }}">
     <input type="hidden" name="content_type" value="{{ content_type }}">
     <input type="hidden" name="tmdb_id" value="{{ tmdb_id or '' }}">
+    {% if context %}<input type="hidden" name="context" value="{{ context }}">{% endif %}
     <button type="submit" name="rating" value="liked" class="btn-thumb btn-thumb--like" title="Liked">&#x1F44D;</button>
     <button type="submit" name="rating" value="disliked" class="btn-thumb btn-thumb--dislike" title="Disliked">&#x1F44E;</button>
     <button type="submit" name="rating" value="skip" class="btn-thumb btn-thumb--skip" title="Skip">skip</button>

--- a/recommender/templates/_rating_prompt.html
+++ b/recommender/templates/_rating_prompt.html
@@ -5,17 +5,8 @@
     <input type="hidden" name="title" value="{{ title }}">
     <input type="hidden" name="content_type" value="{{ content_type }}">
     <input type="hidden" name="tmdb_id" value="{{ tmdb_id or '' }}">
-    <button type="submit" name="rating" value="liked" class="mono"
-      style="background:none; border:none; cursor:pointer; padding:2px 6px; font-size:0.8rem; color:var(--muted); transition:color 0.15s;"
-      onmouseover="this.style.color='var(--teal)'" onmouseout="this.style.color='var(--muted)'"
-      title="Liked">&#x1F44D;</button>
-    <button type="submit" name="rating" value="disliked" class="mono"
-      style="background:none; border:none; cursor:pointer; padding:2px 6px; font-size:0.8rem; color:var(--muted); transition:color 0.15s;"
-      onmouseover="this.style.color='var(--accent)'" onmouseout="this.style.color='var(--muted)'"
-      title="Disliked">&#x1F44E;</button>
-    <button type="submit" name="rating" value="skip" class="mono"
-      style="background:none; border:none; cursor:pointer; padding:2px 6px; font-size:0.6rem; color:var(--muted); transition:color 0.15s;"
-      onmouseover="this.style.color='var(--text)'" onmouseout="this.style.color='var(--muted)'"
-      title="Skip">skip</button>
+    <button type="submit" name="rating" value="liked" class="btn-thumb btn-thumb--like" title="Liked">&#x1F44D;</button>
+    <button type="submit" name="rating" value="disliked" class="btn-thumb btn-thumb--dislike" title="Disliked">&#x1F44E;</button>
+    <button type="submit" name="rating" value="skip" class="btn-thumb btn-thumb--skip" title="Skip">skip</button>
   </form>
 </div>

--- a/recommender/templates/_rating_prompt.html
+++ b/recommender/templates/_rating_prompt.html
@@ -6,8 +6,8 @@
     <input type="hidden" name="content_type" value="{{ content_type }}">
     <input type="hidden" name="tmdb_id" value="{{ tmdb_id or '' }}">
     {% if context %}<input type="hidden" name="context" value="{{ context }}">{% endif %}
-    <button type="submit" name="rating" value="liked" class="btn-thumb btn-thumb--like" title="Liked">&#x1F44D;</button>
-    <button type="submit" name="rating" value="disliked" class="btn-thumb btn-thumb--dislike" title="Disliked">&#x1F44E;</button>
+    <button type="submit" name="rating" value="liked" class="btn-thumb btn-thumb--like" title="Liked">liked</button>
+    <button type="submit" name="rating" value="disliked" class="btn-thumb btn-thumb--dislike" title="Disliked">disliked</button>
     <button type="submit" name="rating" value="skip" class="btn-thumb btn-thumb--skip" title="Skip">skip</button>
   </form>
 </div>

--- a/recommender/templates/_rating_state.html
+++ b/recommender/templates/_rating_state.html
@@ -5,30 +5,14 @@
     <input type="hidden" name="content_type" value="{{ content_type }}">
     <input type="hidden" name="tmdb_id" value="{{ tmdb_id or '' }}">
     {% if current_rating == "liked" %}
-    <button type="submit" name="rating" value="clear" class="mono"
-      style="background:none; border:none; cursor:pointer; padding:2px 4px; font-size:0.8rem; color:var(--teal);"
-      title="Remove rating">&#x1F44D;</button>
-    <button type="submit" name="rating" value="disliked" class="mono"
-      style="background:none; border:none; cursor:pointer; padding:2px 4px; font-size:0.8rem; color:var(--muted); transition:color 0.15s;"
-      onmouseover="this.style.color='var(--accent)'" onmouseout="this.style.color='var(--muted)'"
-      title="Disliked">&#x1F44E;</button>
+    <button type="submit" name="rating" value="clear" class="btn-thumb btn-thumb--liked" title="Remove rating">&#x1F44D;</button>
+    <button type="submit" name="rating" value="disliked" class="btn-thumb btn-thumb--dislike" title="Disliked">&#x1F44E;</button>
     {% elif current_rating == "disliked" %}
-    <button type="submit" name="rating" value="liked" class="mono"
-      style="background:none; border:none; cursor:pointer; padding:2px 4px; font-size:0.8rem; color:var(--muted); transition:color 0.15s;"
-      onmouseover="this.style.color='var(--teal)'" onmouseout="this.style.color='var(--muted)'"
-      title="Liked">&#x1F44D;</button>
-    <button type="submit" name="rating" value="clear" class="mono"
-      style="background:none; border:none; cursor:pointer; padding:2px 4px; font-size:0.8rem; color:var(--accent);"
-      title="Remove rating">&#x1F44E;</button>
+    <button type="submit" name="rating" value="liked" class="btn-thumb btn-thumb--like" title="Liked">&#x1F44D;</button>
+    <button type="submit" name="rating" value="clear" class="btn-thumb btn-thumb--disliked" title="Remove rating">&#x1F44E;</button>
     {% else %}
-    <button type="submit" name="rating" value="liked" class="mono"
-      style="background:none; border:none; cursor:pointer; padding:2px 4px; font-size:0.8rem; color:var(--muted); transition:color 0.15s;"
-      onmouseover="this.style.color='var(--teal)'" onmouseout="this.style.color='var(--muted)'"
-      title="Liked">&#x1F44D;</button>
-    <button type="submit" name="rating" value="disliked" class="mono"
-      style="background:none; border:none; cursor:pointer; padding:2px 4px; font-size:0.8rem; color:var(--muted); transition:color 0.15s;"
-      onmouseover="this.style.color='var(--accent)'" onmouseout="this.style.color='var(--muted)'"
-      title="Disliked">&#x1F44E;</button>
+    <button type="submit" name="rating" value="liked" class="btn-thumb btn-thumb--like" title="Liked">&#x1F44D;</button>
+    <button type="submit" name="rating" value="disliked" class="btn-thumb btn-thumb--dislike" title="Disliked">&#x1F44E;</button>
     {% endif %}
   </form>
 </span>

--- a/recommender/templates/_rating_state.html
+++ b/recommender/templates/_rating_state.html
@@ -1,0 +1,34 @@
+<span id="rating-{{ uid }}" style="display:inline-flex; align-items:center; gap:0.3rem;">
+  <form hx-post="/archive/rate" hx-target="#rating-{{ uid }}" hx-swap="outerHTML" style="margin:0; display:inline-flex; gap:2px;">
+    <input type="hidden" name="_csrf_token" value="{{ csrf_token }}">
+    <input type="hidden" name="title" value="{{ title }}">
+    <input type="hidden" name="content_type" value="{{ content_type }}">
+    <input type="hidden" name="tmdb_id" value="{{ tmdb_id or '' }}">
+    {% if current_rating == "liked" %}
+    <button type="submit" name="rating" value="clear" class="mono"
+      style="background:none; border:none; cursor:pointer; padding:2px 4px; font-size:0.8rem; color:var(--teal);"
+      title="Remove rating">&#x1F44D;</button>
+    <button type="submit" name="rating" value="disliked" class="mono"
+      style="background:none; border:none; cursor:pointer; padding:2px 4px; font-size:0.8rem; color:var(--muted); transition:color 0.15s;"
+      onmouseover="this.style.color='var(--accent)'" onmouseout="this.style.color='var(--muted)'"
+      title="Disliked">&#x1F44E;</button>
+    {% elif current_rating == "disliked" %}
+    <button type="submit" name="rating" value="liked" class="mono"
+      style="background:none; border:none; cursor:pointer; padding:2px 4px; font-size:0.8rem; color:var(--muted); transition:color 0.15s;"
+      onmouseover="this.style.color='var(--teal)'" onmouseout="this.style.color='var(--muted)'"
+      title="Liked">&#x1F44D;</button>
+    <button type="submit" name="rating" value="clear" class="mono"
+      style="background:none; border:none; cursor:pointer; padding:2px 4px; font-size:0.8rem; color:var(--accent);"
+      title="Remove rating">&#x1F44E;</button>
+    {% else %}
+    <button type="submit" name="rating" value="liked" class="mono"
+      style="background:none; border:none; cursor:pointer; padding:2px 4px; font-size:0.8rem; color:var(--muted); transition:color 0.15s;"
+      onmouseover="this.style.color='var(--teal)'" onmouseout="this.style.color='var(--muted)'"
+      title="Liked">&#x1F44D;</button>
+    <button type="submit" name="rating" value="disliked" class="mono"
+      style="background:none; border:none; cursor:pointer; padding:2px 4px; font-size:0.8rem; color:var(--muted); transition:color 0.15s;"
+      onmouseover="this.style.color='var(--accent)'" onmouseout="this.style.color='var(--muted)'"
+      title="Disliked">&#x1F44E;</button>
+    {% endif %}
+  </form>
+</span>

--- a/recommender/templates/_rating_state.html
+++ b/recommender/templates/_rating_state.html
@@ -5,14 +5,14 @@
     <input type="hidden" name="content_type" value="{{ content_type }}">
     <input type="hidden" name="tmdb_id" value="{{ tmdb_id or '' }}">
     {% if current_rating == "liked" %}
-    <button type="submit" name="rating" value="clear" class="btn-thumb btn-thumb--liked" title="Remove rating">&#x1F44D;</button>
-    <button type="submit" name="rating" value="disliked" class="btn-thumb btn-thumb--dislike" title="Disliked">&#x1F44E;</button>
+    <button type="submit" name="rating" value="clear" class="btn-thumb btn-thumb--liked" title="Remove rating">liked</button>
+    <button type="submit" name="rating" value="disliked" class="btn-thumb btn-thumb--dislike" title="Disliked">disliked</button>
     {% elif current_rating == "disliked" %}
-    <button type="submit" name="rating" value="liked" class="btn-thumb btn-thumb--like" title="Liked">&#x1F44D;</button>
-    <button type="submit" name="rating" value="clear" class="btn-thumb btn-thumb--disliked" title="Remove rating">&#x1F44E;</button>
+    <button type="submit" name="rating" value="liked" class="btn-thumb btn-thumb--like" title="Liked">liked</button>
+    <button type="submit" name="rating" value="clear" class="btn-thumb btn-thumb--disliked" title="Remove rating">disliked</button>
     {% else %}
-    <button type="submit" name="rating" value="liked" class="btn-thumb btn-thumb--like" title="Liked">&#x1F44D;</button>
-    <button type="submit" name="rating" value="disliked" class="btn-thumb btn-thumb--dislike" title="Disliked">&#x1F44E;</button>
+    <button type="submit" name="rating" value="liked" class="btn-thumb btn-thumb--like" title="Liked">liked</button>
+    <button type="submit" name="rating" value="disliked" class="btn-thumb btn-thumb--dislike" title="Disliked">disliked</button>
     {% endif %}
   </form>
 </span>

--- a/recommender/templates/_results.html
+++ b/recommender/templates/_results.html
@@ -79,18 +79,6 @@
   {% endfor %}
 </div>
 
-<style>
-  .result-link {
-    font-size: 0.58rem;
-    letter-spacing: 0.06em;
-    text-transform: uppercase;
-    color: var(--muted);
-    text-decoration: none;
-    transition: color 0.15s;
-  }
-  .result-link:hover { color: var(--accent); text-decoration: none; }
-</style>
-
 {% elif query %}
 <div style="padding:3rem; text-align:center;">
   <p class="mono" style="font-size:0.7rem; letter-spacing:0.1em; text-transform:uppercase; color:var(--muted);">No results for "{{ query }}"</p>

--- a/recommender/templates/_results.html
+++ b/recommender/templates/_results.html
@@ -4,14 +4,47 @@
 </div>
 
 {% elif results %}
-<div style="display:flex; align-items:center; justify-content:space-between; margin-bottom:0.75rem;">
+<div style="display:flex; align-items:center; justify-content:space-between; margin-bottom:0.6rem;">
   <span class="mono" style="font-size:0.6rem; color:var(--muted);">{{ results|length }} results for "{{ query }}"</span>
   <button onclick="document.getElementById('results').innerHTML=''; document.getElementById('query-input').value=''; document.getElementById('query-input').focus();"
     class="btn-ghost" style="padding:3px 10px; font-size:0.55rem; cursor:pointer;">Clear</button>
 </div>
-<div style="display:flex; flex-direction:column; gap:10px;">
+
+<!-- Filter / sort bar -->
+<div id="lr-controls" style="display:flex; align-items:center; gap:0.6rem; flex-wrap:wrap; margin-bottom:0.75rem; padding:0.5rem 0.75rem; background:var(--surface); border:1px solid var(--border); border-radius:5px;">
+  <!-- Type pills -->
+  <div style="display:flex; gap:2px;">
+    <button class="lr-pill active" data-type="all" onclick="lrSetType('all')">All</button>
+    <button class="lr-pill" data-type="tv" onclick="lrSetType('tv')">TV</button>
+    <button class="lr-pill" data-type="movie" onclick="lrSetType('movie')">Film</button>
+  </div>
+  <span style="color:var(--border);">·</span>
+  <!-- Sort -->
+  <select id="lr-sort" class="input-field mono" onchange="lrApply()"
+    style="padding:3px 7px; font-size:0.6rem; border-radius:3px;">
+    <option value="score">Best match</option>
+    <option value="rating">Highest rated</option>
+    <option value="az">A → Z</option>
+  </select>
+  <span style="color:var(--border);">·</span>
+  <!-- Provider filter -->
+  <select id="lr-provider" class="input-field mono" onchange="lrApply()"
+    style="padding:3px 7px; font-size:0.6rem; border-radius:3px; display:none;">
+    <option value="">All providers</option>
+  </select>
+  <div style="flex:1;"></div>
+  <span class="mono" id="lr-count" style="font-size:0.55rem; color:var(--muted);"></span>
+</div>
+
+<div id="lr-list" style="display:flex; flex-direction:column; gap:10px;">
   {% for r in results %}
-  <div class="result-card" style="display:flex; gap:1rem; padding:1.25rem; background:var(--surface); border-radius:6px; border:1px solid var(--border); transition:border-color 0.2s;"
+  <div class="result-card lr-card"
+    data-type="{{ r.content_type }}"
+    data-rating="{{ r.vote_average }}"
+    data-score="{{ r.score }}"
+    data-title="{{ r.title | lower }}"
+    data-providers="{{ r.streaming_providers | join(',') | lower }}"
+    style="display:flex; gap:1rem; padding:1.25rem; background:var(--surface); border-radius:6px; border:1px solid var(--border); transition:border-color 0.2s;"
     onmouseover="this.style.borderColor='var(--accent)'"
     onmouseout="this.style.borderColor='var(--border)'"
   >
@@ -78,6 +111,79 @@
   </div>
   {% endfor %}
 </div>
+
+<style>
+  .lr-pill {
+    background: none; border: none; cursor: pointer;
+    font-family: 'JetBrains Mono', monospace; font-size: 0.6rem;
+    letter-spacing: 0.06em; text-transform: uppercase;
+    color: var(--muted); padding: 3px 8px; border-radius: 3px;
+    transition: color 0.15s, background 0.15s;
+  }
+  .lr-pill:hover { color: var(--text); }
+  .lr-pill.active { color: var(--accent); background: rgba(232,93,74,0.08); }
+</style>
+
+<script>
+(function() {
+  let _lrType = 'all';
+
+  window.lrSetType = function(type) {
+    _lrType = type;
+    document.querySelectorAll('.lr-pill').forEach(p =>
+      p.classList.toggle('active', p.dataset.type === type));
+    lrApply();
+  };
+
+  window.lrApply = function() {
+    const sort = document.getElementById('lr-sort').value;
+    const provider = (document.getElementById('lr-provider').value || '').toLowerCase();
+    const list = document.getElementById('lr-list');
+    const cards = [...list.querySelectorAll('.lr-card')];
+
+    cards.forEach(c => {
+      const typeOk = _lrType === 'all' || c.dataset.type === _lrType;
+      const providerOk = !provider || (c.dataset.providers || '').includes(provider);
+      c.style.display = (typeOk && providerOk) ? '' : 'none';
+    });
+
+    const visible = cards.filter(c => c.style.display !== 'none');
+    visible.sort((a, b) => {
+      if (sort === 'rating') return parseFloat(b.dataset.rating) - parseFloat(a.dataset.rating);
+      if (sort === 'az') return a.dataset.title.localeCompare(b.dataset.title);
+      return parseFloat(b.dataset.score) - parseFloat(a.dataset.score); // score (default)
+    });
+    visible.forEach(c => list.appendChild(c));
+
+    const countEl = document.getElementById('lr-count');
+    if (countEl) {
+      countEl.textContent = visible.length < cards.length
+        ? visible.length + ' of ' + cards.length + ' shown'
+        : '';
+    }
+  };
+
+  // Build provider dropdown from rendered data
+  (function() {
+    const providers = new Set();
+    document.querySelectorAll('.lr-card').forEach(c => {
+      (c.dataset.providers || '').split(',').forEach(p => {
+        const t = p.trim();
+        if (t) providers.add(t);
+      });
+    });
+    if (providers.size === 0) return;
+    const sel = document.getElementById('lr-provider');
+    [...providers].sort().forEach(p => {
+      const opt = document.createElement('option');
+      opt.value = p;
+      opt.textContent = p.charAt(0).toUpperCase() + p.slice(1);
+      sel.appendChild(opt);
+    });
+    sel.style.display = '';
+  })();
+})();
+</script>
 
 {% elif query %}
 <div style="padding:3rem; text-align:center;">

--- a/recommender/templates/_results.html
+++ b/recommender/templates/_results.html
@@ -58,6 +58,21 @@
         {% if r.imdb_url %}
         <a href="{{ r.imdb_url }}" target="_blank" rel="noopener" class="mono result-link">IMDB</a>
         {% endif %}
+        {% if not r.user_state.in_archive and not r.user_state.in_watchlist %}
+        <span id="save-{{ loop.index }}">
+          <form hx-post="/watchlist/save" hx-target="#save-{{ loop.index }}" hx-swap="outerHTML" style="margin:0; display:inline;">
+            <input type="hidden" name="_csrf_token" value="{{ csrf_token }}">
+            <input type="hidden" name="title" value="{{ r.title }}">
+            <input type="hidden" name="content_type" value="{{ r.content_type }}">
+            {% if r.tmdb_id %}<input type="hidden" name="tmdb_id" value="{{ r.tmdb_id }}">{% endif %}
+            <button type="submit" class="mono result-link" style="background:none; border:none; cursor:pointer; padding:0;">+ Save</button>
+          </form>
+        </span>
+        {% elif r.user_state.in_watchlist %}
+        <span class="mono" style="font-size:0.58rem; color:var(--teal);">Saved</span>
+        {% elif r.user_state.in_archive %}
+        <span class="mono" style="font-size:0.58rem; color:var(--muted);">Watched</span>
+        {% endif %}
       </div>
     </div>
   </div>

--- a/recommender/templates/base.html
+++ b/recommender/templates/base.html
@@ -264,6 +264,16 @@
     ::-webkit-scrollbar-thumb:hover { background: var(--muted); }
 
     @keyframes spin { to { transform: rotate(360deg); } }
+
+    .result-link {
+      font-size: 0.58rem;
+      letter-spacing: 0.06em;
+      text-transform: uppercase;
+      color: var(--muted);
+      text-decoration: none;
+      transition: color 0.15s;
+    }
+    .result-link:hover { color: var(--accent); text-decoration: none; }
   </style>
 </head>
 

--- a/recommender/templates/base.html
+++ b/recommender/templates/base.html
@@ -156,6 +156,54 @@
     }
     .btn-ghost:hover { border-color: var(--accent); color: var(--text); text-decoration: none; }
 
+    /* Thumb rating buttons */
+    .btn-thumb {
+      background: none;
+      border: none;
+      cursor: pointer;
+      padding: 2px 4px;
+      font-family: 'JetBrains Mono', monospace;
+      font-size: 0.8rem;
+      color: var(--muted);
+      transition: color 0.15s, opacity 0.15s;
+    }
+    .btn-thumb--like:hover  { color: var(--teal); }
+    .btn-thumb--dislike:hover { color: var(--accent); }
+    .btn-thumb--liked  { color: var(--teal); }
+    .btn-thumb--liked:hover  { opacity: 0.5; }
+    .btn-thumb--disliked { color: var(--accent); }
+    .btn-thumb--disliked:hover { opacity: 0.5; }
+    .btn-thumb--skip { font-size: 0.6rem; }
+    .btn-thumb--skip:hover { color: var(--text); }
+
+    /* Watchlist action buttons */
+    .wl-btn {
+      font-family: 'JetBrains Mono', monospace;
+      font-size: 0.58rem;
+      background: none;
+      cursor: pointer;
+      padding: 3px 8px;
+      border-radius: 3px;
+      transition: background 0.15s, border-color 0.15s, color 0.15s;
+    }
+    .wl-btn--watched { border: 1px solid var(--teal); color: var(--teal); }
+    .wl-btn--watched:hover { background: rgba(58,184,160,0.1); }
+    .wl-btn--dismiss { border: 1px solid var(--border); color: var(--muted); }
+    .wl-btn--dismiss:hover { border-color: var(--muted); color: var(--text); }
+    .wl-btn--remove { border: none; color: var(--muted); padding: 3px 6px; }
+    .wl-btn--remove:hover { color: var(--text); }
+
+    /* Nav count badge */
+    .nav-badge {
+      font-family: 'JetBrains Mono', monospace;
+      font-size: 0.5rem;
+      background: var(--teal);
+      color: var(--bg);
+      padding: 1px 5px;
+      border-radius: 8px;
+      line-height: 1.3;
+    }
+
     /* Badge */
     .badge {
       font-family: 'JetBrains Mono', monospace;
@@ -226,13 +274,11 @@
     <div class="nav-group" style="margin-left:0.5rem;">
       <a href="/" class="nav-link {% if request.path == '/' %}active{% endif %}">Home</a>
       <a href="/searches" class="nav-link {% if request.path == '/searches' %}active{% endif %}">Searches</a>
-      <a href="/history" class="nav-link {% if request.path.startswith('/history') or request.path.startswith('/title') %}active{% endif %}">Archive</a>
       <a href="/watchlist" class="nav-link {% if request.path == '/watchlist' %}active{% endif %}" style="display:flex; align-items:center; gap:0.3rem;">
         Watchlist
-        {% if watchlist_count %}
-        <span style="font-family:'JetBrains Mono',monospace; font-size:0.5rem; background:var(--teal); color:var(--bg); padding:1px 5px; border-radius:8px; line-height:1.3;">{{ watchlist_count }}</span>
-        {% endif %}
+        {% if watchlist_count %}<span class="nav-badge">{{ watchlist_count }}</span>{% endif %}
       </a>
+      <a href="/history" class="nav-link {% if request.path.startswith('/history') or request.path.startswith('/title') %}active{% endif %}">Archive</a>
     </div>
     <div class="nav-group-system">
       <a href="/settings" class="nav-link {% if request.path == '/settings' %}active{% endif %}">Settings</a>

--- a/recommender/templates/base.html
+++ b/recommender/templates/base.html
@@ -227,6 +227,12 @@
       <a href="/" class="nav-link {% if request.path == '/' %}active{% endif %}">Home</a>
       <a href="/searches" class="nav-link {% if request.path == '/searches' %}active{% endif %}">Searches</a>
       <a href="/history" class="nav-link {% if request.path.startswith('/history') or request.path.startswith('/title') %}active{% endif %}">Archive</a>
+      <a href="/watchlist" class="nav-link {% if request.path == '/watchlist' %}active{% endif %}" style="display:flex; align-items:center; gap:0.3rem;">
+        Watchlist
+        {% if watchlist_count %}
+        <span style="font-family:'JetBrains Mono',monospace; font-size:0.5rem; background:var(--teal); color:var(--bg); padding:1px 5px; border-radius:8px; line-height:1.3;">{{ watchlist_count }}</span>
+        {% endif %}
+      </a>
     </div>
     <div class="nav-group-system">
       <a href="/settings" class="nav-link {% if request.path == '/settings' %}active{% endif %}">Settings</a>

--- a/recommender/templates/history.html
+++ b/recommender/templates/history.html
@@ -28,7 +28,7 @@
       <input type="hidden" name="_csrf_token" value="{{ csrf_token }}">
       <input type="text" name="title" placeholder="Add a title you watched..."
         class="input-field" style="padding:0.5rem 0.75rem; flex:1; min-width:180px;">
-      <select name="content_type" class="input-field" style="padding:0.5rem 0.75rem; font-family:'JetBrains Mono',monospace; font-size:0.72rem;">
+      <select name="content_type" class="input-field mono" style="padding:0.5rem 0.75rem; font-size:0.72rem;">
         <option value="tv">TV</option>
         <option value="movie">Film</option>
       </select>

--- a/recommender/templates/history.html
+++ b/recommender/templates/history.html
@@ -6,33 +6,44 @@
   <span class="mono" style="font-size:0.62rem; letter-spacing:0.12em; text-transform:uppercase; color:var(--teal);">Collection</span>
   <h1 style="font-size:clamp(2rem, 4.5vw, 3rem); margin-top:0.2rem; margin-bottom:1.25rem;">Archive</h1>
 
+  <!-- Filter row -->
   <form method="get" action="/history" id="filter-form" style="display:flex; gap:0.5rem; flex-wrap:wrap; align-items:center;">
     <input
       type="text" name="q" value="{{ q }}" placeholder="Search titles..."
       class="input-field"
       style="padding:0.6rem 1rem; flex:1; min-width:180px;"
     >
-    <select name="type" class="input-field" style="padding:0.6rem 0.75rem; font-family:'JetBrains Mono',monospace; font-size:0.72rem;">
+    <select name="type" class="input-field mono" style="padding:0.6rem 0.75rem; font-size:0.72rem;">
       <option value="" {% if not ct_filter %}selected{% endif %}>All</option>
       <option value="tv" {% if ct_filter == 'tv' %}selected{% endif %}>TV</option>
       <option value="movie" {% if ct_filter == 'movie' %}selected{% endif %}>Film</option>
+    </select>
+    <select name="sort" class="input-field mono" style="padding:0.6rem 0.75rem; font-size:0.72rem;">
+      <option value="az" {% if sort == 'az' %}selected{% endif %}>A → Z</option>
+      <option value="za" {% if sort == 'za' %}selected{% endif %}>Z → A</option>
     </select>
     <button type="submit" class="btn-primary" style="padding:0.6rem 1.1rem;">Filter</button>
     {% if q or ct_filter %}
     <a href="/history" class="btn-ghost" style="padding:0.6rem 0.9rem;">Clear</a>
     {% endif %}
+    <!-- Add watched toggle — inline at end of filter row -->
+    <button type="button" id="add-toggle" onclick="toggleAddForm()"
+      class="btn-ghost"
+      style="padding:0.6rem 0.9rem; margin-left:auto;">+ Add watched</button>
   </form>
 
-  <div style="margin-top:0.75rem; padding:0.75rem 1rem; background:var(--surface); border:1px solid var(--border); border-radius:6px;">
+  <!-- Collapsible Add Title form -->
+  <div id="add-form-wrapper" style="display:none; margin-top:0.5rem; padding:0.75rem 1rem; background:var(--surface); border:1px solid var(--border); border-radius:6px;">
     <form hx-post="/archive/add" hx-target="#add-result" hx-swap="innerHTML" style="display:flex; gap:0.5rem; align-items:center; flex-wrap:wrap;">
       <input type="hidden" name="_csrf_token" value="{{ csrf_token }}">
-      <input type="text" name="title" placeholder="Add a title you watched..."
+      <input type="text" name="title" placeholder="Title you watched..." id="add-title-input"
         class="input-field" style="padding:0.5rem 0.75rem; flex:1; min-width:180px;">
       <select name="content_type" class="input-field mono" style="padding:0.5rem 0.75rem; font-size:0.72rem;">
         <option value="tv">TV</option>
         <option value="movie">Film</option>
       </select>
       <button type="submit" class="btn-primary" style="padding:0.5rem 1rem;">Add</button>
+      <button type="button" onclick="toggleAddForm()" class="btn-ghost" style="padding:0.5rem 0.75rem;">Cancel</button>
       <span id="add-result" style="display:inline;"></span>
     </form>
   </div>
@@ -174,6 +185,18 @@
 </style>
 
 <script>
+function toggleAddForm() {
+  const wrapper = document.getElementById('add-form-wrapper');
+  const btn = document.getElementById('add-toggle');
+  const open = wrapper.style.display !== 'none';
+  wrapper.style.display = open ? 'none' : '';
+  btn.style.color = open ? '' : 'var(--teal)';
+  btn.style.borderColor = open ? '' : 'var(--teal)';
+  if (!open) {
+    setTimeout(() => document.getElementById('add-title-input').focus(), 50);
+  }
+}
+
 function setView(mode) {
   document.querySelectorAll('.archive-view').forEach(el => el.style.display = 'none');
   document.getElementById('view-' + mode).style.display = '';

--- a/recommender/templates/history.html
+++ b/recommender/templates/history.html
@@ -23,6 +23,20 @@
     {% endif %}
   </form>
 
+  <div style="margin-top:0.75rem; padding:0.75rem 1rem; background:var(--surface); border:1px solid var(--border); border-radius:6px;">
+    <form hx-post="/archive/add" hx-target="#add-result" hx-swap="innerHTML" style="display:flex; gap:0.5rem; align-items:center; flex-wrap:wrap;">
+      <input type="hidden" name="_csrf_token" value="{{ csrf_token }}">
+      <input type="text" name="title" placeholder="Add a title you watched..."
+        class="input-field" style="padding:0.5rem 0.75rem; flex:1; min-width:180px;">
+      <select name="content_type" class="input-field" style="padding:0.5rem 0.75rem; font-family:'JetBrains Mono',monospace; font-size:0.72rem;">
+        <option value="tv">TV</option>
+        <option value="movie">Film</option>
+      </select>
+      <button type="submit" class="btn-primary" style="padding:0.5rem 1rem;">Add</button>
+      <span id="add-result" style="display:inline;"></span>
+    </form>
+  </div>
+
   <div style="display:flex; align-items:center; justify-content:space-between; margin-top:0.75rem;">
     <p class="mono" style="font-size:0.6rem; letter-spacing:0.1em; text-transform:uppercase; color:var(--muted);">{{ total }} titles</p>
 
@@ -71,6 +85,10 @@
       {% if item.description %}
       <p style="font-size:0.78rem; color:var(--muted); line-height:1.45; overflow:hidden; display:-webkit-box; -webkit-line-clamp:1; -webkit-box-orient:vertical; margin-top:0.1rem;">{{ item.description }}</p>
       {% endif %}
+      {% set uid = "hist-" ~ loop.index %}
+      {% with title=item.title, content_type=item.content_type, tmdb_id=item.tmdb_id, current_rating=item.rating, uid=uid %}
+      {% include "_rating_state.html" %}
+      {% endwith %}
     </div>
   </div>
   {% else %}

--- a/recommender/templates/searches.html
+++ b/recommender/templates/searches.html
@@ -15,7 +15,36 @@
 </div>
 {% endif %}
 
-<div style="display:flex; flex-direction:column; gap:6px;">
+{% if entries %}
+<!-- Filter / sort controls -->
+<div style="display:flex; align-items:center; gap:0.6rem; flex-wrap:wrap; margin-bottom:1rem; padding:0.6rem 0.9rem; background:var(--surface); border:1px solid var(--border); border-radius:6px;">
+  <!-- Type filter pills -->
+  <div style="display:flex; gap:2px;">
+    <button class="sh-pill active" data-type="all" onclick="setTypeFilter('all')">All</button>
+    <button class="sh-pill" data-type="tv" onclick="setTypeFilter('tv')">TV</button>
+    <button class="sh-pill" data-type="movie" onclick="setTypeFilter('movie')">Film</button>
+  </div>
+  <span style="color:var(--border);">·</span>
+  <!-- Min rating -->
+  <label class="mono" style="font-size:0.58rem; color:var(--muted); display:flex; align-items:center; gap:0.3rem;">
+    <span style="color:var(--accent2);">★</span>
+    <input type="range" id="sh-rating" min="0" max="10" step="0.5" value="0"
+      oninput="setMinRating(this.value)"
+      style="width:80px; accent-color:var(--accent2); cursor:pointer;">
+    <span id="sh-rating-val" style="min-width:2ch;">0+</span>
+  </label>
+  <span style="color:var(--border);">·</span>
+  <!-- Provider filter -->
+  <select id="sh-provider" class="input-field mono" onchange="setProvider(this.value)"
+    style="padding:3px 6px; font-size:0.6rem; border-radius:3px; display:none;">
+    <option value="">All providers</option>
+  </select>
+  <div style="flex:1;"></div>
+  <span class="mono" id="sh-summary" style="font-size:0.55rem; color:var(--muted);"></span>
+</div>
+{% endif %}
+
+<div id="sh-list" style="display:flex; flex-direction:column; gap:6px;">
 {% for entry in entries %}
   <details class="search-details" id="q-{{ loop.index }}" style="background:var(--surface); border-radius:6px; overflow:hidden;">
     <summary style="
@@ -66,13 +95,37 @@
       {% set entry_idx = loop.index %}
       {% for r in entry.results %}
       {% set save_id = "save-" ~ entry_idx ~ "-" ~ loop.index %}
-      <div style="display:flex; gap:0.85rem; padding:0.65rem 1.25rem 0.65rem 2.75rem; transition:background 0.15s;{% if not loop.last %} border-bottom:1px solid rgba(53,47,64,0.5);{% endif %}"
+      <div class="sh-result"
+        data-type="{{ r.content_type }}"
+        data-rating="{{ r.vote_average }}"
+        data-providers="{{ r.streaming_providers | join(',') | lower }}"
+        style="display:flex; gap:0.85rem; padding:0.65rem 1.25rem 0.65rem 1rem; transition:background 0.15s;{% if not loop.last %} border-bottom:1px solid rgba(53,47,64,0.5);{% endif %}"
         onmouseover="this.style.background='var(--surface2)'"
         onmouseout="this.style.background='transparent'"
       >
+        <!-- Poster (new entries only) -->
+        {% if r.poster %}
+        <div style="flex-shrink:0; width:38px; height:57px; overflow:hidden; border-radius:3px;">
+          {% if r.tmdb_url %}
+          <a href="{{ r.tmdb_url }}" target="_blank" rel="noopener">
+            <img src="{{ r.poster }}" alt="{{ r.title }}" style="width:100%; height:100%; object-fit:cover;">
+          </a>
+          {% else %}
+          <img src="{{ r.poster }}" alt="{{ r.title }}" style="width:100%; height:100%; object-fit:cover;">
+          {% endif %}
+        </div>
+        {% endif %}
+
         <div style="flex:1; min-width:0;">
           <div style="display:flex; align-items:center; gap:0.5rem; margin-bottom:0.2rem;">
+            {% if r.tmdb_url %}
+            <a href="{{ r.tmdb_url }}" target="_blank" rel="noopener" style="text-decoration:none;">
+              <span style="font-family:'DM Serif Display',serif; font-size:0.95rem; color:var(--text); transition:color 0.15s;"
+                onmouseover="this.style.color='var(--accent)'" onmouseout="this.style.color='var(--text)'">{{ r.title }}</span>
+            </a>
+            {% else %}
             <span style="font-family:'DM Serif Display',serif; font-size:0.95rem; color:var(--text);">{{ r.title }}</span>
+            {% endif %}
             <span class="badge {{ 'badge-tv' if r.content_type == 'tv' else 'badge-movie' }}" style="font-size:0.5rem;">{{ r.content_type }}</span>
             <span class="mono" style="font-size:0.58rem; color:var(--accent2);">★ {{ "%.1f"|format(r.vote_average) }}</span>
           </div>
@@ -80,6 +133,12 @@
           <div style="display:flex; align-items:center; gap:0.75rem; margin-top:0.2rem; flex-wrap:wrap;">
             {% if r.streaming_providers %}
             <span class="mono" style="font-size:0.55rem; color:var(--muted);">{{ r.streaming_providers | join("  ·  ") }}</span>
+            {% endif %}
+            {% if r.tmdb_url %}
+            <a href="{{ r.tmdb_url }}" target="_blank" rel="noopener" class="mono result-link" style="font-size:0.55rem;">TMDB</a>
+            {% endif %}
+            {% if r.imdb_url %}
+            <a href="{{ r.imdb_url }}" target="_blank" rel="noopener" class="mono result-link" style="font-size:0.55rem;">IMDB</a>
             {% endif %}
             {% if r.user_state.in_archive %}
             <span class="mono" style="font-size:0.55rem; color:var(--muted);">Watched</span>
@@ -134,6 +193,83 @@
   .search-details summary:hover { background: var(--surface2); }
   .search-details[open] .search-arrow { transform: rotate(90deg); }
   .search-details.htmx-swapping { opacity: 0; transition: opacity 0.3s ease; }
+  .sh-pill {
+    background: none; border: none; cursor: pointer;
+    font-family: 'JetBrains Mono', monospace; font-size: 0.6rem;
+    letter-spacing: 0.06em; text-transform: uppercase;
+    color: var(--muted); padding: 3px 8px; border-radius: 3px;
+    transition: color 0.15s, background 0.15s;
+  }
+  .sh-pill:hover { color: var(--text); }
+  .sh-pill.active { color: var(--accent); background: rgba(232,93,74,0.08); }
 </style>
+
+<script>
+let _shType = 'all', _shMinRating = 0, _shProvider = '';
+
+function setTypeFilter(type) {
+  _shType = type;
+  document.querySelectorAll('.sh-pill').forEach(p =>
+    p.classList.toggle('active', p.dataset.type === type));
+  _shApply();
+}
+
+function setMinRating(val) {
+  _shMinRating = parseFloat(val);
+  document.getElementById('sh-rating-val').textContent = val > 0 ? val + '+' : '0+';
+  _shApply();
+}
+
+function setProvider(val) {
+  _shProvider = val.toLowerCase();
+  _shApply();
+}
+
+function _shApply() {
+  let visibleEntries = 0;
+  document.querySelectorAll('.search-details').forEach(detail => {
+    const rows = detail.querySelectorAll('.sh-result');
+    let visibleRows = 0;
+    rows.forEach(row => {
+      const typeOk = _shType === 'all' || row.dataset.type === _shType;
+      const ratingOk = parseFloat(row.dataset.rating || 0) >= _shMinRating;
+      const providerOk = !_shProvider || (row.dataset.providers || '').includes(_shProvider);
+      const show = typeOk && ratingOk && providerOk;
+      row.style.display = show ? '' : 'none';
+      if (show) visibleRows++;
+    });
+    // Hide the whole entry if all its results are filtered out
+    detail.style.display = (rows.length === 0 || visibleRows > 0) ? '' : 'none';
+    if (detail.style.display !== 'none') visibleEntries++;
+  });
+
+  const summary = document.getElementById('sh-summary');
+  if (summary) {
+    summary.textContent = (_shType !== 'all' || _shMinRating > 0 || _shProvider)
+      ? visibleEntries + ' matching quer' + (visibleEntries !== 1 ? 'ies' : 'y')
+      : '';
+  }
+}
+
+// Populate provider dropdown from rendered data
+(function buildProviderDropdown() {
+  const providers = new Set();
+  document.querySelectorAll('.sh-result').forEach(row => {
+    (row.dataset.providers || '').split(',').forEach(p => {
+      const t = p.trim();
+      if (t) providers.add(t);
+    });
+  });
+  if (providers.size === 0) return;
+  const sel = document.getElementById('sh-provider');
+  [...providers].sort().forEach(p => {
+    const opt = document.createElement('option');
+    opt.value = p;
+    opt.textContent = p.charAt(0).toUpperCase() + p.slice(1);
+    sel.appendChild(opt);
+  });
+  sel.style.display = '';
+})();
+</script>
 
 {% endblock %}

--- a/recommender/templates/searches.html
+++ b/recommender/templates/searches.html
@@ -85,14 +85,14 @@
             <span class="mono" style="font-size:0.55rem; color:var(--muted);">Watched</span>
             {% elif r.user_state.in_watchlist %}
             <span id="{{ save_id }}" style="display:inline-flex; align-items:center; gap:0.3rem;">
-              <span class="mono" style="font-size:0.55rem; color:var(--teal);">Saved</span>
+              <span class="mono" style="font-size:0.58rem; color:var(--teal);">Saved</span>
               <form hx-post="/watchlist/unsave" hx-target="#{{ save_id }}" hx-swap="outerHTML" style="margin:0; display:inline;">
                 <input type="hidden" name="_csrf_token" value="{{ csrf_token }}">
                 <input type="hidden" name="title" value="{{ r.title }}">
                 <input type="hidden" name="content_type" value="{{ r.content_type }}">
                 {% if r.tmdb_id %}<input type="hidden" name="tmdb_id" value="{{ r.tmdb_id }}">{% endif %}
                 <input type="hidden" name="target_id" value="{{ save_id }}">
-                <button type="submit" class="mono" style="font-size:0.55rem; background:none; border:none; cursor:pointer; color:var(--muted); padding:0 2px;" title="Remove from watchlist">&times;</button>
+                <button type="submit" class="wl-btn wl-btn--remove" title="Remove from watchlist">&times;</button>
               </form>
             </span>
             {% else %}

--- a/recommender/templates/searches.html
+++ b/recommender/templates/searches.html
@@ -63,7 +63,9 @@
 
     <div style="border-left:3px solid var(--accent); padding:0 0 0.5rem;">
       {% if entry.results %}
+      {% set entry_idx = loop.index %}
       {% for r in entry.results %}
+      {% set save_id = "save-" ~ entry_idx ~ "-" ~ loop.index %}
       <div style="display:flex; gap:0.85rem; padding:0.65rem 1.25rem 0.65rem 2.75rem; transition:background 0.15s;{% if not loop.last %} border-bottom:1px solid rgba(53,47,64,0.5);{% endif %}"
         onmouseover="this.style.background='var(--surface2)'"
         onmouseout="this.style.background='transparent'"
@@ -75,9 +77,38 @@
             <span class="mono" style="font-size:0.58rem; color:var(--accent2);">★ {{ "%.1f"|format(r.vote_average) }}</span>
           </div>
           <p style="font-size:0.8rem; color:var(--body); line-height:1.65; margin:0;">{{ r.explanation }}</p>
-          {% if r.streaming_providers %}
-          <span class="mono" style="font-size:0.55rem; color:var(--muted); margin-top:0.2rem; display:inline-block;">{{ r.streaming_providers | join("  ·  ") }}</span>
-          {% endif %}
+          <div style="display:flex; align-items:center; gap:0.75rem; margin-top:0.2rem; flex-wrap:wrap;">
+            {% if r.streaming_providers %}
+            <span class="mono" style="font-size:0.55rem; color:var(--muted);">{{ r.streaming_providers | join("  ·  ") }}</span>
+            {% endif %}
+            {% if r.user_state.in_archive %}
+            <span class="mono" style="font-size:0.55rem; color:var(--muted);">Watched</span>
+            {% elif r.user_state.in_watchlist %}
+            <span id="{{ save_id }}" style="display:inline-flex; align-items:center; gap:0.3rem;">
+              <span class="mono" style="font-size:0.55rem; color:var(--teal);">Saved</span>
+              <form hx-post="/watchlist/unsave" hx-target="#{{ save_id }}" hx-swap="outerHTML" style="margin:0; display:inline;">
+                <input type="hidden" name="_csrf_token" value="{{ csrf_token }}">
+                <input type="hidden" name="title" value="{{ r.title }}">
+                <input type="hidden" name="content_type" value="{{ r.content_type }}">
+                {% if r.tmdb_id %}<input type="hidden" name="tmdb_id" value="{{ r.tmdb_id }}">{% endif %}
+                <input type="hidden" name="target_id" value="{{ save_id }}">
+                <button type="submit" class="mono" style="font-size:0.55rem; background:none; border:none; cursor:pointer; color:var(--muted); padding:0 2px;" title="Remove from watchlist">&times;</button>
+              </form>
+            </span>
+            {% else %}
+            <span id="{{ save_id }}">
+              <form hx-post="/watchlist/save" hx-target="#{{ save_id }}" hx-swap="outerHTML" style="margin:0; display:inline;">
+                <input type="hidden" name="_csrf_token" value="{{ csrf_token }}">
+                <input type="hidden" name="title" value="{{ r.title }}">
+                <input type="hidden" name="content_type" value="{{ r.content_type }}">
+                {% if r.tmdb_id %}<input type="hidden" name="tmdb_id" value="{{ r.tmdb_id }}">{% endif %}
+                <input type="hidden" name="mode" value="toggle">
+                <input type="hidden" name="target_id" value="{{ save_id }}">
+                <button type="submit" class="mono result-link" style="background:none; border:none; cursor:pointer; padding:0;">+ Save</button>
+              </form>
+            </span>
+            {% endif %}
+          </div>
         </div>
       </div>
       {% endfor %}

--- a/recommender/templates/title.html
+++ b/recommender/templates/title.html
@@ -36,13 +36,10 @@
     </div>
     {% endif %}
 
-    <a href="https://www.themoviedb.org/{{ 'tv' if meta.content_type == 'tv' else 'movie' }}/{{ tmdb_id }}"
-       target="_blank" rel="noopener"
-       class="mono" style="font-size:0.62rem; letter-spacing:0.08em; text-transform:uppercase; color:var(--muted); transition:color 0.15s;"
-       onmouseover="this.style.color='var(--accent)'" onmouseout="this.style.color='var(--muted)'"
-    >View on TMDB →</a>
-
-    <div style="display:flex; align-items:center; gap:0.75rem; margin-top:0.5rem;">
+    <div style="display:flex; align-items:center; gap:0.75rem; margin-top:0.5rem; flex-wrap:wrap;">
+      <a href="https://www.themoviedb.org/{{ 'tv' if meta.content_type == 'tv' else 'movie' }}/{{ tmdb_id }}"
+         target="_blank" rel="noopener" class="mono result-link">TMDB ↗</a>
+      <span style="color:var(--border);">·</span>
       {% if user_state.in_archive %}
       {% set uid = "title-" ~ tmdb_id %}
       {% with current_rating=user_state.rating, title=meta.title, content_type=meta.content_type, tmdb_id=tmdb_id %}

--- a/recommender/templates/title.html
+++ b/recommender/templates/title.html
@@ -41,6 +41,29 @@
        class="mono" style="font-size:0.62rem; letter-spacing:0.08em; text-transform:uppercase; color:var(--muted); transition:color 0.15s;"
        onmouseover="this.style.color='var(--accent)'" onmouseout="this.style.color='var(--muted)'"
     >View on TMDB →</a>
+
+    <div style="display:flex; align-items:center; gap:0.75rem; margin-top:0.5rem;">
+      {% if user_state.in_archive %}
+      {% set uid = "title-" ~ tmdb_id %}
+      {% with current_rating=user_state.rating, title=meta.title, content_type=meta.content_type, tmdb_id=tmdb_id %}
+      {% include "_rating_state.html" %}
+      {% endwith %}
+      {% elif user_state.in_watchlist %}
+      <span class="mono" style="font-size:0.62rem; color:var(--teal);">In your watchlist</span>
+      {% else %}
+      <span id="title-save">
+        <form hx-post="/watchlist/save" hx-target="#title-save" hx-swap="outerHTML" style="margin:0; display:inline;">
+          <input type="hidden" name="_csrf_token" value="{{ csrf_token }}">
+          <input type="hidden" name="title" value="{{ meta.title }}">
+          <input type="hidden" name="content_type" value="{{ meta.content_type }}">
+          <input type="hidden" name="tmdb_id" value="{{ tmdb_id }}">
+          <button type="submit" class="mono" style="font-size:0.62rem; letter-spacing:0.08em; text-transform:uppercase; background:none; border:none; cursor:pointer; padding:0; color:var(--teal); transition:opacity 0.15s;"
+            onmouseover="this.style.opacity='0.7'" onmouseout="this.style.opacity='1'"
+          >+ Save to watchlist</button>
+        </form>
+      </span>
+      {% endif %}
+    </div>
   </div>
 </div>
 

--- a/recommender/templates/watchlist.html
+++ b/recommender/templates/watchlist.html
@@ -20,7 +20,7 @@
         <input type="hidden" name="title" value="{{ item.title }}">
         <input type="hidden" name="content_type" value="{{ item.content_type }}">
         {% if item.tmdb_id %}<input type="hidden" name="tmdb_id" value="{{ item.tmdb_id }}">{% endif %}
-        <button type="submit" class="wl-btn wl-btn--watched">Watched</button>
+        <button type="submit" class="wl-btn wl-btn--watched">Mark as watched</button>
       </form>
       <form hx-post="/watchlist/dismiss" hx-target="#wl-item-{{ loop.index }}" hx-swap="outerHTML" style="margin:0; display:inline;">
         <input type="hidden" name="_csrf_token" value="{{ csrf_token }}">

--- a/recommender/templates/watchlist.html
+++ b/recommender/templates/watchlist.html
@@ -10,35 +10,40 @@
 <div style="display:flex; flex-direction:column; gap:6px;">
   {% for item in items %}
   <div id="wl-item-{{ loop.index }}" style="display:flex; align-items:center; justify-content:space-between; gap:1rem; padding:0.75rem 1rem; border-radius:6px; background:var(--surface); border:1px solid var(--border);">
-    <span style="font-family:'DM Serif Display',serif; font-size:1.05rem; color:var(--text);">{{ item.title }}</span>
-    <div style="display:flex; align-items:center; gap:0.4rem;">
+    <div style="display:flex; align-items:baseline; gap:0.5rem; min-width:0;">
+      <span style="font-family:'DM Serif Display',serif; font-size:1.05rem; color:var(--text); white-space:nowrap; overflow:hidden; text-overflow:ellipsis;">{{ item.title }}</span>
+      <span class="badge {{ 'badge-tv' if item.content_type == 'tv' else 'badge-movie' }}" style="flex-shrink:0;">{{ item.content_type }}</span>
+    </div>
+    <div style="display:flex; align-items:center; gap:0.4rem; flex-shrink:0;">
       <form hx-post="/watchlist/watched" hx-target="#wl-item-{{ loop.index }}" hx-swap="outerHTML" style="margin:0; display:inline;">
         <input type="hidden" name="_csrf_token" value="{{ csrf_token }}">
         <input type="hidden" name="title" value="{{ item.title }}">
         <input type="hidden" name="content_type" value="{{ item.content_type }}">
         {% if item.tmdb_id %}<input type="hidden" name="tmdb_id" value="{{ item.tmdb_id }}">{% endif %}
-        <button type="submit" class="mono" style="font-size:0.58rem; background:none; border:1px solid var(--teal); color:var(--teal); cursor:pointer; padding:3px 8px; border-radius:3px;">Watched</button>
+        <button type="submit" class="wl-btn wl-btn--watched">Watched</button>
       </form>
       <form hx-post="/watchlist/dismiss" hx-target="#wl-item-{{ loop.index }}" hx-swap="outerHTML" style="margin:0; display:inline;">
         <input type="hidden" name="_csrf_token" value="{{ csrf_token }}">
         <input type="hidden" name="title" value="{{ item.title }}">
         <input type="hidden" name="content_type" value="{{ item.content_type }}">
         {% if item.tmdb_id %}<input type="hidden" name="tmdb_id" value="{{ item.tmdb_id }}">{% endif %}
-        <button type="submit" class="mono" style="font-size:0.58rem; background:none; border:1px solid var(--border); color:var(--muted); cursor:pointer; padding:3px 8px; border-radius:3px;">Won't watch</button>
+        <button type="submit" class="wl-btn wl-btn--dismiss">Won't watch</button>
       </form>
       <form hx-post="/watchlist/remove" hx-target="#wl-item-{{ loop.index }}" hx-swap="outerHTML" style="margin:0; display:inline;">
         <input type="hidden" name="_csrf_token" value="{{ csrf_token }}">
         <input type="hidden" name="title" value="{{ item.title }}">
         <input type="hidden" name="content_type" value="{{ item.content_type }}">
-        <button type="submit" class="mono" style="font-size:0.58rem; background:none; border:none; color:var(--muted); cursor:pointer; padding:3px 6px;">x</button>
+        <button type="submit" class="wl-btn wl-btn--remove" title="Remove">×</button>
       </form>
     </div>
   </div>
   {% endfor %}
 </div>
 {% else %}
-<div style="padding:4rem; text-align:center;">
-  <p class="mono" style="font-size:0.68rem; color:var(--muted);">No titles saved yet</p>
+<div style="padding:4rem 2rem; text-align:center; border:1px dashed var(--border); border-radius:8px;">
+  <p class="mono" style="font-size:0.68rem; color:var(--muted); letter-spacing:0.08em;">Nothing saved yet</p>
+  <p style="font-size:0.85rem; color:var(--muted); margin-top:0.5rem;">Search for something and use <span class="mono" style="font-size:0.75rem; color:var(--body);">+ Save</span> to add it here.</p>
+  <a href="/" class="btn-ghost" style="display:inline-block; margin-top:1.25rem; padding:0.5rem 1.1rem;">Go to search</a>
 </div>
 {% endif %}
 {% endblock %}

--- a/recommender/templates/watchlist.html
+++ b/recommender/templates/watchlist.html
@@ -59,6 +59,7 @@
         <input type="hidden" name="_csrf_token" value="{{ csrf_token }}">
         <input type="hidden" name="title" value="{{ item.title }}">
         <input type="hidden" name="content_type" value="{{ item.content_type }}">
+        {% if item.tmdb_id %}<input type="hidden" name="tmdb_id" value="{{ item.tmdb_id }}">{% endif %}
         <button type="submit" class="wl-btn wl-btn--remove" title="Remove">&times;</button>
       </form>
     </div>

--- a/recommender/templates/watchlist.html
+++ b/recommender/templates/watchlist.html
@@ -16,6 +16,7 @@
     <select class="input-field mono" id="wl-sort" onchange="setSort(this.value)" style="padding:4px 8px; font-size:0.65rem; border-radius:3px;">
       <option value="newest">Newest first</option>
       <option value="oldest">Oldest first</option>
+      <option value="rating">Highest rated</option>
       <option value="az">A → Z</option>
       <option value="za">Z → A</option>
     </select>
@@ -33,6 +34,7 @@
     data-type="{{ item.content_type }}"
     data-title="{{ item.title | lower }}"
     data-saved="{{ item.saved_at or '' }}"
+    data-rating="{{ item.vote_average }}"
     style="display:flex; align-items:center; justify-content:space-between; gap:1rem; padding:0.75rem 1rem; border-radius:6px; background:var(--surface); border:1px solid var(--border);">
     <div style="display:flex; align-items:baseline; gap:0.5rem; min-width:0;">
       <span style="font-family:'DM Serif Display',serif; font-size:1.05rem; color:var(--text); white-space:nowrap; overflow:hidden; text-overflow:ellipsis;">{{ item.title }}</span>
@@ -127,6 +129,7 @@ function _apply(sortVal) {
     if (sort === 'za') return b.dataset.title.localeCompare(a.dataset.title);
     if (sort === 'newest') return (b.dataset.saved || '').localeCompare(a.dataset.saved || '');
     if (sort === 'oldest') return (a.dataset.saved || '').localeCompare(b.dataset.saved || '');
+    if (sort === 'rating') return parseFloat(b.dataset.rating || 0) - parseFloat(a.dataset.rating || 0);
     return 0;
   });
   visible.forEach(el => list.appendChild(el));

--- a/recommender/templates/watchlist.html
+++ b/recommender/templates/watchlist.html
@@ -1,15 +1,39 @@
 {% extends "base.html" %}
 {% block title %}Streamline — Watchlist{% endblock %}
 {% block content %}
-<div style="margin-bottom:2rem;">
+<div style="margin-bottom:1.5rem;">
   <span class="mono" style="font-size:0.62rem; letter-spacing:0.12em; text-transform:uppercase; color:var(--teal);">Queue</span>
   <h1 style="font-size:clamp(2rem, 4.5vw, 3rem); margin-top:0.2rem; margin-bottom:1.25rem;">Watchlist</h1>
-  <p class="mono" style="font-size:0.6rem; letter-spacing:0.1em; text-transform:uppercase; color:var(--muted);">{{ items|length }} titles</p>
+
+  <div style="display:flex; align-items:center; gap:0.75rem; flex-wrap:wrap;">
+    <!-- Type filter pills -->
+    <div style="display:flex; gap:2px; background:var(--surface); border:1px solid var(--border); border-radius:4px; padding:2px;">
+      <button class="wl-pill active" data-type="all" onclick="setFilter('all')">All</button>
+      <button class="wl-pill" data-type="tv" onclick="setFilter('tv')">TV</button>
+      <button class="wl-pill" data-type="movie" onclick="setFilter('movie')">Film</button>
+    </div>
+    <!-- Sort -->
+    <select class="input-field mono" id="wl-sort" onchange="setSort(this.value)" style="padding:4px 8px; font-size:0.65rem; border-radius:3px;">
+      <option value="newest">Newest first</option>
+      <option value="oldest">Oldest first</option>
+      <option value="az">A → Z</option>
+      <option value="za">Z → A</option>
+    </select>
+    <div style="flex:1;"></div>
+    <span class="mono" id="wl-count" style="font-size:0.6rem; letter-spacing:0.1em; text-transform:uppercase; color:var(--muted);">{{ items|length }} titles</span>
+    <a href="/watchlist/export" class="btn-ghost" style="padding:4px 10px; font-size:0.6rem; letter-spacing:0.06em;">Export CSV</a>
+  </div>
 </div>
+
 {% if items %}
-<div style="display:flex; flex-direction:column; gap:6px;">
+<div id="wl-list" style="display:flex; flex-direction:column; gap:6px;">
   {% for item in items %}
-  <div id="wl-item-{{ loop.index }}" style="display:flex; align-items:center; justify-content:space-between; gap:1rem; padding:0.75rem 1rem; border-radius:6px; background:var(--surface); border:1px solid var(--border);">
+  <div id="wl-item-{{ loop.index }}"
+    class="wl-item"
+    data-type="{{ item.content_type }}"
+    data-title="{{ item.title | lower }}"
+    data-saved="{{ item.saved_at or '' }}"
+    style="display:flex; align-items:center; justify-content:space-between; gap:1rem; padding:0.75rem 1rem; border-radius:6px; background:var(--surface); border:1px solid var(--border);">
     <div style="display:flex; align-items:baseline; gap:0.5rem; min-width:0;">
       <span style="font-family:'DM Serif Display',serif; font-size:1.05rem; color:var(--text); white-space:nowrap; overflow:hidden; text-overflow:ellipsis;">{{ item.title }}</span>
       <span class="badge {{ 'badge-tv' if item.content_type == 'tv' else 'badge-movie' }}" style="flex-shrink:0;">{{ item.content_type }}</span>
@@ -33,12 +57,17 @@
         <input type="hidden" name="_csrf_token" value="{{ csrf_token }}">
         <input type="hidden" name="title" value="{{ item.title }}">
         <input type="hidden" name="content_type" value="{{ item.content_type }}">
-        <button type="submit" class="wl-btn wl-btn--remove" title="Remove">×</button>
+        <button type="submit" class="wl-btn wl-btn--remove" title="Remove">&times;</button>
       </form>
     </div>
   </div>
   {% endfor %}
 </div>
+
+<div id="wl-empty" style="display:none; padding:4rem 2rem; text-align:center; border:1px dashed var(--border); border-radius:8px;">
+  <p class="mono" style="font-size:0.68rem; color:var(--muted); letter-spacing:0.08em;">No titles match this filter</p>
+</div>
+
 {% else %}
 <div style="padding:4rem 2rem; text-align:center; border:1px dashed var(--border); border-radius:8px;">
   <p class="mono" style="font-size:0.68rem; color:var(--muted); letter-spacing:0.08em;">Nothing saved yet</p>
@@ -46,4 +75,67 @@
   <a href="/" class="btn-ghost" style="display:inline-block; margin-top:1.25rem; padding:0.5rem 1.1rem;">Go to search</a>
 </div>
 {% endif %}
+
+<style>
+  .wl-pill {
+    background: none;
+    border: none;
+    color: var(--muted);
+    font-family: 'JetBrains Mono', monospace;
+    font-size: 0.62rem;
+    letter-spacing: 0.06em;
+    text-transform: uppercase;
+    padding: 4px 10px;
+    border-radius: 3px;
+    cursor: pointer;
+    transition: color 0.15s, background 0.15s;
+  }
+  .wl-pill:hover { color: var(--text); }
+  .wl-pill.active { color: var(--teal); background: rgba(58,184,160,0.1); }
+</style>
+
+<script>
+let _filter = 'all';
+
+function setFilter(type) {
+  _filter = type;
+  document.querySelectorAll('.wl-pill').forEach(p =>
+    p.classList.toggle('active', p.dataset.type === type));
+  _apply();
+}
+
+function setSort(val) {
+  _apply(val);
+}
+
+function _apply(sortVal) {
+  const sort = sortVal || document.getElementById('wl-sort').value;
+  const list = document.getElementById('wl-list');
+  if (!list) return;
+
+  const items = [...list.querySelectorAll('.wl-item')];
+
+  items.forEach(el => {
+    const show = _filter === 'all' || el.dataset.type === _filter;
+    el.style.display = show ? '' : 'none';
+  });
+
+  const visible = items.filter(el => el.style.display !== 'none');
+
+  visible.sort((a, b) => {
+    if (sort === 'az') return a.dataset.title.localeCompare(b.dataset.title);
+    if (sort === 'za') return b.dataset.title.localeCompare(a.dataset.title);
+    if (sort === 'newest') return (b.dataset.saved || '').localeCompare(a.dataset.saved || '');
+    if (sort === 'oldest') return (a.dataset.saved || '').localeCompare(b.dataset.saved || '');
+    return 0;
+  });
+  visible.forEach(el => list.appendChild(el));
+
+  const countEl = document.getElementById('wl-count');
+  if (countEl) countEl.textContent = visible.length + ' title' + (visible.length !== 1 ? 's' : '');
+
+  const emptyEl = document.getElementById('wl-empty');
+  if (emptyEl) emptyEl.style.display = visible.length === 0 ? '' : 'none';
+}
+</script>
 {% endblock %}

--- a/recommender/templates/watchlist.html
+++ b/recommender/templates/watchlist.html
@@ -1,0 +1,44 @@
+{% extends "base.html" %}
+{% block title %}Streamline — Watchlist{% endblock %}
+{% block content %}
+<div style="margin-bottom:2rem;">
+  <span class="mono" style="font-size:0.62rem; letter-spacing:0.12em; text-transform:uppercase; color:var(--teal);">Queue</span>
+  <h1 style="font-size:clamp(2rem, 4.5vw, 3rem); margin-top:0.2rem; margin-bottom:1.25rem;">Watchlist</h1>
+  <p class="mono" style="font-size:0.6rem; letter-spacing:0.1em; text-transform:uppercase; color:var(--muted);">{{ items|length }} titles</p>
+</div>
+{% if items %}
+<div style="display:flex; flex-direction:column; gap:6px;">
+  {% for item in items %}
+  <div id="wl-item-{{ loop.index }}" style="display:flex; align-items:center; justify-content:space-between; gap:1rem; padding:0.75rem 1rem; border-radius:6px; background:var(--surface); border:1px solid var(--border);">
+    <span style="font-family:'DM Serif Display',serif; font-size:1.05rem; color:var(--text);">{{ item.title }}</span>
+    <div style="display:flex; align-items:center; gap:0.4rem;">
+      <form hx-post="/watchlist/watched" hx-target="#wl-item-{{ loop.index }}" hx-swap="outerHTML" style="margin:0; display:inline;">
+        <input type="hidden" name="_csrf_token" value="{{ csrf_token }}">
+        <input type="hidden" name="title" value="{{ item.title }}">
+        <input type="hidden" name="content_type" value="{{ item.content_type }}">
+        {% if item.tmdb_id %}<input type="hidden" name="tmdb_id" value="{{ item.tmdb_id }}">{% endif %}
+        <button type="submit" class="mono" style="font-size:0.58rem; background:none; border:1px solid var(--teal); color:var(--teal); cursor:pointer; padding:3px 8px; border-radius:3px;">Watched</button>
+      </form>
+      <form hx-post="/watchlist/dismiss" hx-target="#wl-item-{{ loop.index }}" hx-swap="outerHTML" style="margin:0; display:inline;">
+        <input type="hidden" name="_csrf_token" value="{{ csrf_token }}">
+        <input type="hidden" name="title" value="{{ item.title }}">
+        <input type="hidden" name="content_type" value="{{ item.content_type }}">
+        {% if item.tmdb_id %}<input type="hidden" name="tmdb_id" value="{{ item.tmdb_id }}">{% endif %}
+        <button type="submit" class="mono" style="font-size:0.58rem; background:none; border:1px solid var(--border); color:var(--muted); cursor:pointer; padding:3px 8px; border-radius:3px;">Won't watch</button>
+      </form>
+      <form hx-post="/watchlist/remove" hx-target="#wl-item-{{ loop.index }}" hx-swap="outerHTML" style="margin:0; display:inline;">
+        <input type="hidden" name="_csrf_token" value="{{ csrf_token }}">
+        <input type="hidden" name="title" value="{{ item.title }}">
+        <input type="hidden" name="content_type" value="{{ item.content_type }}">
+        <button type="submit" class="mono" style="font-size:0.58rem; background:none; border:none; color:var(--muted); cursor:pointer; padding:3px 6px;">x</button>
+      </form>
+    </div>
+  </div>
+  {% endfor %}
+</div>
+{% else %}
+<div style="padding:4rem; text-align:center;">
+  <p class="mono" style="font-size:0.68rem; color:var(--muted);">No titles saved yet</p>
+</div>
+{% endif %}
+{% endblock %}

--- a/recommender/tmdb_client.py
+++ b/recommender/tmdb_client.py
@@ -206,6 +206,16 @@ class TmdbClient:
             pass
         return '', title
 
+    def get_cached_by_id(self, tmdb_id: int, content_type: str) -> TmdbMetadata | None:
+        """Return metadata from local cache by TMDB ID, without making any API calls.
+
+        Returns None if the title is not in the cache.
+        """
+        cached = self._load_cache(content_type, tmdb_id)
+        if cached:
+            return self._parse_metadata(cached, content_type)
+        return None
+
     def get_metadata(self, title: str, content_type: str) -> TmdbMetadata | None:
         """Fetch and cache metadata for a single title. Returns None if not found.
 

--- a/recommender/user_state.py
+++ b/recommender/user_state.py
@@ -97,7 +97,7 @@ class UserStateIndex:
         return self.get_rating(meta) is not None
 
     def get_rating(self, meta) -> str | None:
-        if meta.tmdb_id and meta.tmdb_id in self._ratings_by_tmdb:
-            return self._ratings_by_tmdb[meta.tmdb_id]
+        if meta.tmdb_id is not None:
+            return self._ratings_by_tmdb.get(meta.tmdb_id)
         key = (_normalize(meta.title), meta.content_type)
         return self._ratings_by_title.get(key)

--- a/recommender/user_state.py
+++ b/recommender/user_state.py
@@ -1,0 +1,103 @@
+"""Snapshot of user-managed state for query filtering and UI rendering."""
+
+import re
+import sqlite3
+from dataclasses import dataclass, field
+from pathlib import Path
+
+
+def _normalize(title: str) -> str:
+    """Same normalization as watch_index and user_store."""
+    title = title.lower()
+    title = re.sub(r'\s*\([^)]*\)', '', title)
+    return title.strip()
+
+
+@dataclass
+class UserStateIndex:
+    """Immutable snapshot. Build a new instance to see mutations."""
+
+    # manual_archive: TMDB IDs and (normalized_title, content_type) tuples
+    _archive_tmdb_ids: set[int] = field(default_factory=set)
+    _archive_titles: set[tuple[str, str]] = field(default_factory=set)
+
+    # dismissed: same dual-key pattern
+    _dismissed_tmdb_ids: set[int] = field(default_factory=set)
+    _dismissed_titles: set[tuple[str, str]] = field(default_factory=set)
+
+    # watchlist: same dual-key pattern
+    _watchlist_tmdb_ids: set[int] = field(default_factory=set)
+    _watchlist_titles: set[tuple[str, str]] = field(default_factory=set)
+
+    # ratings: keyed by tmdb_id or (normalized_title, content_type)
+    _ratings_by_tmdb: dict[int, str] = field(default_factory=dict)
+    _ratings_by_title: dict[tuple[str, str], str] = field(default_factory=dict)
+
+    @classmethod
+    def load(cls, db_path: str) -> "UserStateIndex":
+        """Build a snapshot from the current SQLite state."""
+        idx = cls()
+        if not Path(db_path).exists():
+            return idx
+
+        conn = sqlite3.connect(db_path)
+        try:
+            # Manual archive
+            for row in conn.execute(
+                "SELECT tmdb_id, normalized_title, content_type FROM manual_archive_entries"
+            ).fetchall():
+                tmdb_id, norm, ct = row
+                if tmdb_id is not None:
+                    idx._archive_tmdb_ids.add(tmdb_id)
+                idx._archive_titles.add((norm, ct))
+
+            # Saved titles (watchlist + dismissed)
+            for row in conn.execute(
+                "SELECT tmdb_id, normalized_title, content_type, status FROM saved_titles"
+            ).fetchall():
+                tmdb_id, norm, ct, status = row
+                if status == "dismissed":
+                    if tmdb_id is not None:
+                        idx._dismissed_tmdb_ids.add(tmdb_id)
+                    idx._dismissed_titles.add((norm, ct))
+                elif status == "watchlist":
+                    if tmdb_id is not None:
+                        idx._watchlist_tmdb_ids.add(tmdb_id)
+                    idx._watchlist_titles.add((norm, ct))
+
+            # Ratings
+            for row in conn.execute(
+                "SELECT tmdb_id, normalized_title, content_type, rating FROM title_ratings"
+            ).fetchall():
+                tmdb_id, norm, ct, rating = row
+                if tmdb_id is not None:
+                    idx._ratings_by_tmdb[tmdb_id] = rating
+                idx._ratings_by_title[(norm, ct)] = rating
+
+        finally:
+            conn.close()
+
+        return idx
+
+    def _match_tmdb_first(self, meta, tmdb_set: set, title_set: set) -> bool:
+        if meta.tmdb_id is not None:
+            return meta.tmdb_id in tmdb_set
+        return (_normalize(meta.title), meta.content_type) in title_set
+
+    def is_manually_watched(self, meta) -> bool:
+        return self._match_tmdb_first(meta, self._archive_tmdb_ids, self._archive_titles)
+
+    def is_dismissed(self, meta) -> bool:
+        return self._match_tmdb_first(meta, self._dismissed_tmdb_ids, self._dismissed_titles)
+
+    def is_in_watchlist(self, meta) -> bool:
+        return self._match_tmdb_first(meta, self._watchlist_tmdb_ids, self._watchlist_titles)
+
+    def has_rating(self, meta) -> bool:
+        return self.get_rating(meta) is not None
+
+    def get_rating(self, meta) -> str | None:
+        if meta.tmdb_id and meta.tmdb_id in self._ratings_by_tmdb:
+            return self._ratings_by_tmdb[meta.tmdb_id]
+        key = (_normalize(meta.title), meta.content_type)
+        return self._ratings_by_title.get(key)

--- a/recommender/user_state.py
+++ b/recommender/user_state.py
@@ -49,7 +49,8 @@ class UserStateIndex:
                 tmdb_id, norm, ct = row
                 if tmdb_id is not None:
                     idx._archive_tmdb_ids.add(tmdb_id)
-                idx._archive_titles.add((norm, ct))
+                else:
+                    idx._archive_titles.add((norm, ct))
 
             # Saved titles (watchlist + dismissed)
             for row in conn.execute(
@@ -59,11 +60,13 @@ class UserStateIndex:
                 if status == "dismissed":
                     if tmdb_id is not None:
                         idx._dismissed_tmdb_ids.add(tmdb_id)
-                    idx._dismissed_titles.add((norm, ct))
+                    else:
+                        idx._dismissed_titles.add((norm, ct))
                 elif status == "watchlist":
                     if tmdb_id is not None:
                         idx._watchlist_tmdb_ids.add(tmdb_id)
-                    idx._watchlist_titles.add((norm, ct))
+                    else:
+                        idx._watchlist_titles.add((norm, ct))
 
             # Ratings
             for row in conn.execute(
@@ -80,8 +83,8 @@ class UserStateIndex:
         return idx
 
     def _match_tmdb_first(self, meta, tmdb_set: set, title_set: set) -> bool:
-        if meta.tmdb_id is not None:
-            return meta.tmdb_id in tmdb_set
+        if meta.tmdb_id is not None and meta.tmdb_id in tmdb_set:
+            return True
         return (_normalize(meta.title), meta.content_type) in title_set
 
     def is_manually_watched(self, meta) -> bool:

--- a/recommender/user_store.py
+++ b/recommender/user_store.py
@@ -139,7 +139,7 @@ def resolve_rating_content_type(db_path: str, title: str,
 
         try:
             events = load_events(db_path)
-        except Exception:
+        except sqlite3.OperationalError:
             events = []
         event_matches = {
             event.content_type

--- a/recommender/user_store.py
+++ b/recommender/user_store.py
@@ -1,9 +1,13 @@
 """SQLite user store for watchlist, ratings, and manual archive entries."""
 
+import json as _json
+import logging
 import re
 import sqlite3
 from datetime import datetime, timezone
 from pathlib import Path
+
+log = logging.getLogger("recommender.user_store")
 
 _SCHEMA = """
 CREATE TABLE IF NOT EXISTS saved_titles (
@@ -133,9 +137,13 @@ def resolve_rating_content_type(db_path: str, title: str,
             if len(rows) == 1:
                 return rows[0][0]
 
+        try:
+            events = load_events(db_path)
+        except Exception:
+            events = []
         event_matches = {
             event.content_type
-            for event in load_events(db_path)
+            for event in events
             if _normalize(event.series_name if event.content_type == "tv" else event.title) == norm
         }
         if len(event_matches) == 1:
@@ -478,5 +486,107 @@ def list_manual_archive(db_path: str) -> list[dict]:
             }
             for r in rows
         ]
+    finally:
+        conn.close()
+
+
+def ensure_user_store(db_path: str, feedback_path: str) -> None:
+    """Create tables/indexes and run one-time migration from feedback.json if needed."""
+    init_db(db_path)
+
+    fp = Path(feedback_path)
+    if not fp.exists():
+        return
+
+    conn = _connect(db_path)
+    try:
+        # Check for migration marker
+        marker = conn.execute(
+            "SELECT value FROM user_store_meta WHERE key = 'feedback_migrated'"
+        ).fetchone()
+
+        if marker:
+            # Marker exists — just retry the rename if JSON still present
+            fp.rename(str(fp) + ".migrated")
+            log.info("Renamed leftover %s after prior migration", feedback_path)
+            return
+
+        # Check for existing rows (conflict guard)
+        row_count = 0
+        for table in ("saved_titles", "title_ratings", "manual_archive_entries"):
+            row_count += conn.execute(f"SELECT COUNT(*) FROM {table}").fetchone()[0]
+
+        if row_count > 0:
+            raise RuntimeError(
+                f"User-store tables already contain {row_count} rows but "
+                f"{feedback_path} has not been migrated. Cannot safely proceed. "
+                "Remove the JSON file manually if the data has already been migrated."
+            )
+
+        # Load and import feedback.json
+        data = _json.loads(fp.read_text())
+
+        with conn:
+            for entry in data.get("ratings", []):
+                title = entry["title"]
+                rating = entry.get("rating", "liked")
+                tmdb_id = entry.get("tmdb_id")
+                ct = entry.get("content_type") or resolve_rating_content_type(db_path, title, tmdb_id=tmdb_id)
+                ts = entry.get("timestamp", _now_iso())
+                norm = _normalize(title)
+                if tmdb_id is not None:
+                    conn.execute(
+                        "INSERT INTO title_ratings "
+                        "(title, normalized_title, content_type, tmdb_id, rating, rated_at, updated_at) "
+                        "VALUES (?, ?, ?, ?, ?, ?, ?) "
+                        "ON CONFLICT (content_type, tmdb_id) WHERE tmdb_id IS NOT NULL "
+                        "DO UPDATE SET rating=excluded.rating, updated_at=excluded.updated_at",
+                        (title, norm, ct, tmdb_id, rating, ts, ts),
+                    )
+                else:
+                    conn.execute(
+                        "INSERT INTO title_ratings "
+                        "(title, normalized_title, content_type, tmdb_id, rating, rated_at, updated_at) "
+                        "VALUES (?, ?, ?, NULL, ?, ?, ?) "
+                        "ON CONFLICT (content_type, normalized_title) WHERE tmdb_id IS NULL "
+                        "DO UPDATE SET rating=excluded.rating, updated_at=excluded.updated_at",
+                        (title, norm, ct, rating, ts, ts),
+                    )
+
+            for entry in data.get("additions", []):
+                title = entry["title"]
+                tmdb_id = entry.get("tmdb_id")
+                ct = entry.get("content_type") or resolve_rating_content_type(db_path, title, tmdb_id=tmdb_id)
+                ts = entry.get("timestamp", _now_iso())
+                norm = _normalize(title)
+                if tmdb_id is not None:
+                    conn.execute(
+                        "INSERT INTO manual_archive_entries "
+                        "(title, normalized_title, content_type, tmdb_id, watched_at, source) "
+                        "VALUES (?, ?, ?, ?, ?, 'feedback_migration') "
+                        "ON CONFLICT (content_type, tmdb_id) WHERE tmdb_id IS NOT NULL "
+                        "DO UPDATE SET watched_at=excluded.watched_at, source=excluded.source",
+                        (title, norm, ct, tmdb_id, ts),
+                    )
+                else:
+                    conn.execute(
+                        "INSERT INTO manual_archive_entries "
+                        "(title, normalized_title, content_type, tmdb_id, watched_at, source) "
+                        "VALUES (?, ?, ?, NULL, ?, 'feedback_migration') "
+                        "ON CONFLICT (content_type, normalized_title) WHERE tmdb_id IS NULL "
+                        "DO UPDATE SET watched_at=excluded.watched_at, source=excluded.source",
+                        (title, norm, ct, ts),
+                    )
+
+            # Write migration marker inside the transaction
+            conn.execute(
+                "INSERT OR REPLACE INTO user_store_meta (key, value) "
+                "VALUES ('feedback_migrated', '1')"
+            )
+
+        # Rename after successful transaction
+        fp.rename(str(fp) + ".migrated")
+        log.info("Migrated %s to SQLite and renamed to %s.migrated", feedback_path, feedback_path)
+
     finally:
         conn.close()

--- a/recommender/user_store.py
+++ b/recommender/user_store.py
@@ -216,6 +216,8 @@ def remove_saved_title(db_path: str, title: str, content_type: str) -> None:
 
 def list_saved_titles(db_path: str, status: str | None = None) -> list[dict]:
     """Return saved titles, optionally filtered by status."""
+    if not Path(db_path).exists():
+        return []
     conn = _connect(db_path)
     try:
         if status:

--- a/recommender/user_store.py
+++ b/recommender/user_store.py
@@ -386,6 +386,81 @@ def add_to_archive(db_path: str, title: str, content_type: str,
         conn.close()
 
 
+def mark_watched_from_watchlist(db_path: str, title: str, content_type: str,
+                                rating: str | None = None,
+                                tmdb_id: int | None = None) -> None:
+    """Atomic: remove from saved_titles, add to manual_archive, optionally rate.
+
+    If any step fails, the entire transaction rolls back.
+    """
+    now = _now_iso()
+    norm = _normalize(title)
+    conn = _connect(db_path)
+    try:
+        with conn:
+            # Delete from saved_titles
+            if tmdb_id is not None:
+                conn.execute(
+                    "DELETE FROM saved_titles WHERE content_type = ? AND tmdb_id = ?",
+                    (content_type, tmdb_id),
+                )
+            else:
+                conn.execute(
+                    "DELETE FROM saved_titles "
+                    "WHERE content_type = ? AND normalized_title = ? AND tmdb_id IS NULL",
+                    (content_type, norm),
+                )
+
+            # Upsert manual archive entry
+            _reconcile_identity(conn, "manual_archive_entries", title, content_type, tmdb_id)
+            if tmdb_id is not None:
+                conn.execute(
+                    "INSERT INTO manual_archive_entries "
+                    "(title, normalized_title, content_type, tmdb_id, watched_at, source) "
+                    "VALUES (?, ?, ?, ?, ?, 'web') "
+                    "ON CONFLICT (content_type, tmdb_id) WHERE tmdb_id IS NOT NULL "
+                    "DO UPDATE SET title=excluded.title, normalized_title=excluded.normalized_title, "
+                    "watched_at=excluded.watched_at, source=excluded.source",
+                    (title, norm, content_type, tmdb_id, now),
+                )
+            else:
+                conn.execute(
+                    "INSERT INTO manual_archive_entries "
+                    "(title, normalized_title, content_type, tmdb_id, watched_at, source) "
+                    "VALUES (?, ?, ?, NULL, ?, 'web') "
+                    "ON CONFLICT (content_type, normalized_title) WHERE tmdb_id IS NULL "
+                    "DO UPDATE SET title=excluded.title, watched_at=excluded.watched_at, "
+                    "source=excluded.source",
+                    (title, norm, content_type, now),
+                )
+
+            # Optional rating
+            if rating and rating != "clear":
+                _reconcile_identity(conn, "title_ratings", title, content_type, tmdb_id)
+                if tmdb_id is not None:
+                    conn.execute(
+                        "INSERT INTO title_ratings "
+                        "(title, normalized_title, content_type, tmdb_id, rating, rated_at, updated_at) "
+                        "VALUES (?, ?, ?, ?, ?, ?, ?) "
+                        "ON CONFLICT (content_type, tmdb_id) WHERE tmdb_id IS NOT NULL "
+                        "DO UPDATE SET title=excluded.title, normalized_title=excluded.normalized_title, "
+                        "rating=excluded.rating, updated_at=excluded.updated_at",
+                        (title, norm, content_type, tmdb_id, rating, now, now),
+                    )
+                else:
+                    conn.execute(
+                        "INSERT INTO title_ratings "
+                        "(title, normalized_title, content_type, tmdb_id, rating, rated_at, updated_at) "
+                        "VALUES (?, ?, ?, NULL, ?, ?, ?) "
+                        "ON CONFLICT (content_type, normalized_title) WHERE tmdb_id IS NULL "
+                        "DO UPDATE SET title=excluded.title, rating=excluded.rating, "
+                        "updated_at=excluded.updated_at",
+                        (title, norm, content_type, rating, now, now),
+                    )
+    finally:
+        conn.close()
+
+
 def list_manual_archive(db_path: str) -> list[dict]:
     """Return all manual archive entries."""
     if not Path(db_path).exists():

--- a/recommender/user_store.py
+++ b/recommender/user_store.py
@@ -1,0 +1,405 @@
+"""SQLite user store for watchlist, ratings, and manual archive entries."""
+
+import re
+import sqlite3
+from datetime import datetime, timezone
+from pathlib import Path
+
+_SCHEMA = """
+CREATE TABLE IF NOT EXISTS saved_titles (
+    id               INTEGER PRIMARY KEY AUTOINCREMENT,
+    title            TEXT NOT NULL,
+    normalized_title TEXT NOT NULL,
+    content_type     TEXT NOT NULL CHECK (content_type IN ('tv', 'movie')),
+    tmdb_id          INTEGER,
+    status           TEXT NOT NULL CHECK (status IN ('watchlist', 'dismissed')),
+    saved_at         TEXT NOT NULL,
+    updated_at       TEXT NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS title_ratings (
+    id               INTEGER PRIMARY KEY AUTOINCREMENT,
+    title            TEXT NOT NULL,
+    normalized_title TEXT NOT NULL,
+    content_type     TEXT NOT NULL CHECK (content_type IN ('tv', 'movie')),
+    tmdb_id          INTEGER,
+    rating           TEXT NOT NULL CHECK (rating IN ('liked', 'disliked')),
+    rated_at         TEXT NOT NULL,
+    updated_at       TEXT NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS manual_archive_entries (
+    id               INTEGER PRIMARY KEY AUTOINCREMENT,
+    title            TEXT NOT NULL,
+    normalized_title TEXT NOT NULL,
+    content_type     TEXT NOT NULL CHECK (content_type IN ('tv', 'movie')),
+    tmdb_id          INTEGER,
+    watched_at       TEXT NOT NULL,
+    source           TEXT NOT NULL CHECK (source IN ('web', 'cli', 'feedback_migration'))
+);
+
+CREATE TABLE IF NOT EXISTS user_store_meta (
+    key   TEXT PRIMARY KEY,
+    value TEXT NOT NULL
+);
+"""
+
+_INDEXES = """
+CREATE UNIQUE INDEX IF NOT EXISTS saved_titles_tmdb_unique
+ON saved_titles (content_type, tmdb_id)
+WHERE tmdb_id IS NOT NULL;
+
+CREATE UNIQUE INDEX IF NOT EXISTS saved_titles_title_unique
+ON saved_titles (content_type, normalized_title)
+WHERE tmdb_id IS NULL;
+
+CREATE UNIQUE INDEX IF NOT EXISTS title_ratings_tmdb_unique
+ON title_ratings (content_type, tmdb_id)
+WHERE tmdb_id IS NOT NULL;
+
+CREATE UNIQUE INDEX IF NOT EXISTS title_ratings_title_unique
+ON title_ratings (content_type, normalized_title)
+WHERE tmdb_id IS NULL;
+
+CREATE UNIQUE INDEX IF NOT EXISTS manual_archive_tmdb_unique
+ON manual_archive_entries (content_type, tmdb_id)
+WHERE tmdb_id IS NOT NULL;
+
+CREATE UNIQUE INDEX IF NOT EXISTS manual_archive_title_unique
+ON manual_archive_entries (content_type, normalized_title)
+WHERE tmdb_id IS NULL;
+"""
+
+
+def _connect(db_path: str) -> sqlite3.Connection:
+    conn = sqlite3.connect(db_path)
+    conn.execute("PRAGMA journal_mode = WAL")
+    conn.execute("PRAGMA foreign_keys = ON")
+    return conn
+
+
+def _normalize(title: str) -> str:
+    """Lowercase, strip parenthetical suffixes. Same rule as watch_index._normalize."""
+    title = title.lower()
+    title = re.sub(r'\s*\([^)]*\)', '', title)
+    return title.strip()
+
+
+def _now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat(timespec="seconds")
+
+
+def _reconcile_identity(conn: sqlite3.Connection, table: str, title: str,
+                        content_type: str, tmdb_id: int | None) -> None:
+    """Promote a NULL-tmdb row to a concrete tmdb_id before upsert."""
+    if tmdb_id is None:
+        return
+    norm = _normalize(title)
+    row = conn.execute(
+        f"SELECT id, tmdb_id FROM {table} "
+        "WHERE normalized_title = ? AND content_type = ? "
+        "ORDER BY tmdb_id IS NOT NULL DESC, id ASC LIMIT 1",
+        (norm, content_type),
+    ).fetchone()
+    if row and row[1] is None:
+        conn.execute(
+            f"UPDATE {table} SET title = ?, normalized_title = ?, tmdb_id = ? WHERE id = ?",
+            (title, norm, tmdb_id, row[0]),
+        )
+
+
+def resolve_rating_content_type(db_path: str, title: str,
+                                tmdb_id: int | None = None) -> str:
+    """Infer legacy rating/addition content_type or raise a clear error."""
+    from recommender.event_store import load_events
+
+    norm = _normalize(title)
+    conn = _connect(db_path)
+    try:
+        if tmdb_id is not None:
+            for table in ("saved_titles", "title_ratings", "manual_archive_entries"):
+                row = conn.execute(
+                    f"SELECT content_type FROM {table} WHERE tmdb_id = ? LIMIT 1",
+                    (tmdb_id,),
+                ).fetchone()
+                if row:
+                    return row[0]
+
+        for table in ("saved_titles", "title_ratings", "manual_archive_entries"):
+            rows = conn.execute(
+                f"SELECT DISTINCT content_type FROM {table} WHERE normalized_title = ?",
+                (norm,),
+            ).fetchall()
+            if len(rows) == 1:
+                return rows[0][0]
+
+        event_matches = {
+            event.content_type
+            for event in load_events(db_path)
+            if _normalize(event.series_name if event.content_type == "tv" else event.title) == norm
+        }
+        if len(event_matches) == 1:
+            return event_matches.pop()
+    finally:
+        conn.close()
+
+    raise ValueError(
+        f"Could not infer content type for {title!r}. "
+        "Use an explicit tv/movie type or migrate matching watch history first."
+    )
+
+
+def init_db(db_path: str) -> None:
+    """Create tables and indexes if not present."""
+    Path(db_path).parent.mkdir(parents=True, exist_ok=True)
+    conn = _connect(db_path)
+    try:
+        conn.executescript(_SCHEMA)
+        conn.executescript(_INDEXES)
+    finally:
+        conn.close()
+
+
+def save_title(db_path: str, title: str, content_type: str,
+               tmdb_id: int | None = None, status: str = "watchlist") -> None:
+    """Upsert a title into saved_titles. If dismissed, re-saving sets status to watchlist."""
+    now = _now_iso()
+    norm = _normalize(title)
+    conn = _connect(db_path)
+    try:
+        with conn:
+            _reconcile_identity(conn, "saved_titles", title, content_type, tmdb_id)
+            if tmdb_id is not None:
+                conn.execute(
+                    "INSERT INTO saved_titles "
+                    "(title, normalized_title, content_type, tmdb_id, status, saved_at, updated_at) "
+                    "VALUES (?, ?, ?, ?, ?, ?, ?) "
+                    "ON CONFLICT (content_type, tmdb_id) WHERE tmdb_id IS NOT NULL "
+                    "DO UPDATE SET title=excluded.title, normalized_title=excluded.normalized_title, "
+                    "status=excluded.status, updated_at=excluded.updated_at",
+                    (title, norm, content_type, tmdb_id, status, now, now),
+                )
+            else:
+                conn.execute(
+                    "INSERT INTO saved_titles "
+                    "(title, normalized_title, content_type, tmdb_id, status, saved_at, updated_at) "
+                    "VALUES (?, ?, ?, NULL, ?, ?, ?) "
+                    "ON CONFLICT (content_type, normalized_title) WHERE tmdb_id IS NULL "
+                    "DO UPDATE SET title=excluded.title, status=excluded.status, "
+                    "updated_at=excluded.updated_at",
+                    (title, norm, content_type, status, now, now),
+                )
+    finally:
+        conn.close()
+
+
+def dismiss_title(db_path: str, title: str, content_type: str,
+                  tmdb_id: int | None = None) -> None:
+    """Upsert a title as dismissed."""
+    save_title(db_path, title, content_type, tmdb_id=tmdb_id, status="dismissed")
+
+
+def remove_saved_title(db_path: str, title: str, content_type: str) -> None:
+    """Delete a saved_titles row (watchlist only)."""
+    norm = _normalize(title)
+    conn = _connect(db_path)
+    try:
+        with conn:
+            conn.execute(
+                "DELETE FROM saved_titles WHERE normalized_title = ? AND content_type = ? "
+                "AND status = 'watchlist'",
+                (norm, content_type),
+            )
+    finally:
+        conn.close()
+
+
+def list_saved_titles(db_path: str, status: str | None = None) -> list[dict]:
+    """Return saved titles, optionally filtered by status."""
+    conn = _connect(db_path)
+    try:
+        if status:
+            rows = conn.execute(
+                "SELECT title, normalized_title, content_type, tmdb_id, status, saved_at, updated_at "
+                "FROM saved_titles WHERE status = ? ORDER BY saved_at DESC",
+                (status,),
+            ).fetchall()
+        else:
+            rows = conn.execute(
+                "SELECT title, normalized_title, content_type, tmdb_id, status, saved_at, updated_at "
+                "FROM saved_titles ORDER BY saved_at DESC",
+            ).fetchall()
+        return [
+            {
+                "title": r[0], "normalized_title": r[1], "content_type": r[2],
+                "tmdb_id": r[3], "status": r[4], "saved_at": r[5], "updated_at": r[6],
+            }
+            for r in rows
+        ]
+    finally:
+        conn.close()
+
+
+LIKED_MULTIPLIER = 1.3
+DISLIKED_MULTIPLIER = 0.5
+
+
+def rate_title(db_path: str, title: str, content_type: str | None,
+               rating: str, tmdb_id: int | None = None) -> None:
+    """Upsert a rating. rating='clear' removes it."""
+    content_type = content_type or resolve_rating_content_type(db_path, title, tmdb_id=tmdb_id)
+    norm = _normalize(title)
+    conn = _connect(db_path)
+    try:
+        with conn:
+            _reconcile_identity(conn, "title_ratings", title, content_type, tmdb_id)
+            if rating == "clear":
+                if tmdb_id is not None:
+                    conn.execute(
+                        "DELETE FROM title_ratings "
+                        "WHERE content_type = ? AND tmdb_id = ?",
+                        (content_type, tmdb_id),
+                    )
+                else:
+                    conn.execute(
+                        "DELETE FROM title_ratings "
+                        "WHERE content_type = ? AND normalized_title = ? AND tmdb_id IS NULL",
+                        (content_type, norm),
+                    )
+                return
+
+            now = _now_iso()
+            if tmdb_id is not None:
+                conn.execute(
+                    "INSERT INTO title_ratings "
+                    "(title, normalized_title, content_type, tmdb_id, rating, rated_at, updated_at) "
+                    "VALUES (?, ?, ?, ?, ?, ?, ?) "
+                    "ON CONFLICT (content_type, tmdb_id) WHERE tmdb_id IS NOT NULL "
+                    "DO UPDATE SET title=excluded.title, normalized_title=excluded.normalized_title, "
+                    "rating=excluded.rating, updated_at=excluded.updated_at",
+                    (title, norm, content_type, tmdb_id, rating, now, now),
+                )
+            else:
+                conn.execute(
+                    "INSERT INTO title_ratings "
+                    "(title, normalized_title, content_type, tmdb_id, rating, rated_at, updated_at) "
+                    "VALUES (?, ?, ?, NULL, ?, ?, ?) "
+                    "ON CONFLICT (content_type, normalized_title) WHERE tmdb_id IS NULL "
+                    "DO UPDATE SET title=excluded.title, rating=excluded.rating, "
+                    "updated_at=excluded.updated_at",
+                    (title, norm, content_type, rating, now, now),
+                )
+    finally:
+        conn.close()
+
+
+def remove_rating(db_path: str, title: str, content_type: str) -> None:
+    """Remove a rating entirely."""
+    rate_title(db_path, title, content_type, "clear")
+
+
+def load_ratings(db_path: str) -> list[dict]:
+    """Return all ratings."""
+    if not Path(db_path).exists():
+        return []
+    conn = _connect(db_path)
+    try:
+        rows = conn.execute(
+            "SELECT title, normalized_title, content_type, tmdb_id, rating, rated_at "
+            "FROM title_ratings ORDER BY rated_at DESC",
+        ).fetchall()
+        return [
+            {
+                "title": r[0], "normalized_title": r[1], "content_type": r[2],
+                "tmdb_id": r[3], "rating": r[4], "rated_at": r[5],
+            }
+            for r in rows
+        ]
+    finally:
+        conn.close()
+
+
+def get_disliked_titles(db_path: str) -> list[str]:
+    """Return titles rated as disliked."""
+    if not Path(db_path).exists():
+        return []
+    conn = _connect(db_path)
+    try:
+        rows = conn.execute(
+            "SELECT title FROM title_ratings WHERE rating = 'disliked'",
+        ).fetchall()
+        return [r[0] for r in rows]
+    finally:
+        conn.close()
+
+
+def apply_rating_multipliers(scores: dict[str, float],
+                             ratings: list[dict]) -> dict[str, float]:
+    """Apply liked/disliked multipliers to engagement scores.
+
+    Liked titles get a 1.3x boost (capped at 1.0); disliked get 0.5x penalty.
+    """
+    modified = dict(scores)
+    for entry in ratings:
+        title = entry["title"]
+        rating = entry["rating"]
+        if title in modified:
+            if rating == "liked":
+                modified[title] = min(1.0, modified[title] * LIKED_MULTIPLIER)
+            elif rating == "disliked":
+                modified[title] = modified[title] * DISLIKED_MULTIPLIER
+    return modified
+
+
+def add_to_archive(db_path: str, title: str, content_type: str,
+                   tmdb_id: int | None = None, source: str = "web") -> None:
+    """Upsert a manual archive entry."""
+    now = _now_iso()
+    norm = _normalize(title)
+    conn = _connect(db_path)
+    try:
+        with conn:
+            _reconcile_identity(conn, "manual_archive_entries", title, content_type, tmdb_id)
+            if tmdb_id is not None:
+                conn.execute(
+                    "INSERT INTO manual_archive_entries "
+                    "(title, normalized_title, content_type, tmdb_id, watched_at, source) "
+                    "VALUES (?, ?, ?, ?, ?, ?) "
+                    "ON CONFLICT (content_type, tmdb_id) WHERE tmdb_id IS NOT NULL "
+                    "DO UPDATE SET title=excluded.title, normalized_title=excluded.normalized_title, "
+                    "watched_at=excluded.watched_at, source=excluded.source",
+                    (title, norm, content_type, tmdb_id, now, source),
+                )
+            else:
+                conn.execute(
+                    "INSERT INTO manual_archive_entries "
+                    "(title, normalized_title, content_type, tmdb_id, watched_at, source) "
+                    "VALUES (?, ?, ?, NULL, ?, ?) "
+                    "ON CONFLICT (content_type, normalized_title) WHERE tmdb_id IS NULL "
+                    "DO UPDATE SET title=excluded.title, watched_at=excluded.watched_at, "
+                    "source=excluded.source",
+                    (title, norm, content_type, now, source),
+                )
+    finally:
+        conn.close()
+
+
+def list_manual_archive(db_path: str) -> list[dict]:
+    """Return all manual archive entries."""
+    if not Path(db_path).exists():
+        return []
+    conn = _connect(db_path)
+    try:
+        rows = conn.execute(
+            "SELECT title, normalized_title, content_type, tmdb_id, watched_at, source "
+            "FROM manual_archive_entries ORDER BY watched_at DESC",
+        ).fetchall()
+        return [
+            {
+                "title": r[0], "normalized_title": r[1], "content_type": r[2],
+                "tmdb_id": r[3], "watched_at": r[4], "source": r[5],
+            }
+            for r in rows
+        ]
+    finally:
+        conn.close()

--- a/recommender/user_store.py
+++ b/recommender/user_store.py
@@ -76,7 +76,8 @@ WHERE tmdb_id IS NULL;
 
 
 def _connect(db_path: str) -> sqlite3.Connection:
-    conn = sqlite3.connect(db_path)
+    conn = sqlite3.connect(db_path, timeout=30.0)
+    conn.row_factory = sqlite3.Row
     conn.execute("PRAGMA journal_mode = WAL")
     conn.execute("PRAGMA foreign_keys = ON")
     return conn
@@ -207,17 +208,26 @@ def dismiss_title(db_path: str, title: str, content_type: str,
     save_title(db_path, title, content_type, tmdb_id=tmdb_id, status="dismissed")
 
 
-def remove_saved_title(db_path: str, title: str, content_type: str) -> None:
-    """Delete a saved_titles row (watchlist only)."""
+def remove_saved_title(db_path: str, title: str, content_type: str,
+                       tmdb_id: int | None = None) -> None:
+    """Delete a saved_titles row (watchlist only) using TMDB-first matching."""
     norm = _normalize(title)
     conn = _connect(db_path)
     try:
         with conn:
-            conn.execute(
-                "DELETE FROM saved_titles WHERE normalized_title = ? AND content_type = ? "
-                "AND status = 'watchlist'",
-                (norm, content_type),
-            )
+            if tmdb_id is not None:
+                conn.execute(
+                    "DELETE FROM saved_titles "
+                    "WHERE content_type = ? AND tmdb_id = ? AND status = 'watchlist'",
+                    (content_type, tmdb_id),
+                )
+            else:
+                conn.execute(
+                    "DELETE FROM saved_titles "
+                    "WHERE content_type = ? AND normalized_title = ? "
+                    "AND tmdb_id IS NULL AND status = 'watchlist'",
+                    (content_type, norm),
+                )
     finally:
         conn.close()
 
@@ -241,8 +251,9 @@ def list_saved_titles(db_path: str, status: str | None = None) -> list[dict]:
             ).fetchall()
         return [
             {
-                "title": r[0], "normalized_title": r[1], "content_type": r[2],
-                "tmdb_id": r[3], "status": r[4], "saved_at": r[5], "updated_at": r[6],
+                "title": r["title"], "normalized_title": r["normalized_title"],
+                "content_type": r["content_type"], "tmdb_id": r["tmdb_id"],
+                "status": r["status"], "saved_at": r["saved_at"], "updated_at": r["updated_at"],
             }
             for r in rows
         ]
@@ -320,8 +331,9 @@ def load_ratings(db_path: str) -> list[dict]:
         ).fetchall()
         return [
             {
-                "title": r[0], "normalized_title": r[1], "content_type": r[2],
-                "tmdb_id": r[3], "rating": r[4], "rated_at": r[5],
+                "title": r["title"], "normalized_title": r["normalized_title"],
+                "content_type": r["content_type"], "tmdb_id": r["tmdb_id"],
+                "rating": r["rating"], "rated_at": r["rated_at"],
             }
             for r in rows
         ]
@@ -338,7 +350,7 @@ def get_disliked_titles(db_path: str) -> list[str]:
         rows = conn.execute(
             "SELECT title FROM title_ratings WHERE rating = 'disliked'",
         ).fetchall()
-        return [r[0] for r in rows]
+        return [r["title"] for r in rows]
     finally:
         conn.close()
 
@@ -481,8 +493,9 @@ def list_manual_archive(db_path: str) -> list[dict]:
         ).fetchall()
         return [
             {
-                "title": r[0], "normalized_title": r[1], "content_type": r[2],
-                "tmdb_id": r[3], "watched_at": r[4], "source": r[5],
+                "title": r["title"], "normalized_title": r["normalized_title"],
+                "content_type": r["content_type"], "tmdb_id": r["tmdb_id"],
+                "watched_at": r["watched_at"], "source": r["source"],
             }
             for r in rows
         ]

--- a/recommender/web.py
+++ b/recommender/web.py
@@ -377,6 +377,7 @@ def history() -> str:
 @app.route("/searches")
 def searches() -> str:
     entries = query_history.load()
+    us = _load_user_state()
     for e in entries:
         ts = e.get("timestamp", "")
         try:
@@ -398,6 +399,8 @@ def searches() -> str:
                 e["timestamp_display"] = dt.strftime("%b %d, %Y")
         except (ValueError, TypeError):
             e["timestamp_display"] = ts[:19]
+        for r in e.get("results", []):
+            r["user_state"] = _title_state(r["title"], r["content_type"], us, r.get("tmdb_id"))
     return render_template("searches.html", entries=entries)
 
 
@@ -516,6 +519,46 @@ def _title_state(title: str, content_type: str, us: "UserStateIndex",
     }
 
 
+def _watchlist_saved_fragment(title: str, ct: str, tmdb_id: int | None, target_id: str) -> str:
+    """HTML fragment: 'Saved ×' toggle, used when saving from searches history."""
+    csrf = _get_csrf_token()
+    t = escape(title)
+    tid = escape(target_id)
+    tmdb_val = tmdb_id if tmdb_id is not None else ""
+    return Markup(
+        f'<span id="{tid}" style="display:inline-flex; align-items:center; gap:0.3rem;">'
+        f'<span class="mono" style="font-size:0.58rem; color:var(--teal);">Saved</span>'
+        f'<form hx-post="/watchlist/unsave" hx-target="#{tid}" hx-swap="outerHTML" style="margin:0; display:inline;">'
+        f'<input type="hidden" name="_csrf_token" value="{csrf}">'
+        f'<input type="hidden" name="title" value="{t}">'
+        f'<input type="hidden" name="content_type" value="{escape(ct)}">'
+        f'<input type="hidden" name="tmdb_id" value="{tmdb_val}">'
+        f'<input type="hidden" name="target_id" value="{tid}">'
+        f'<button type="submit" class="mono" style="font-size:0.55rem; background:none; border:none; cursor:pointer; color:var(--muted); padding:0 2px;" title="Remove from watchlist">&times;</button>'
+        f'</form></span>'
+    )
+
+
+def _watchlist_save_fragment(title: str, ct: str, tmdb_id: int | None, target_id: str) -> str:
+    """HTML fragment: '+ Save' toggle, returned after unsaving from searches history."""
+    csrf = _get_csrf_token()
+    t = escape(title)
+    tid = escape(target_id)
+    tmdb_val = tmdb_id if tmdb_id is not None else ""
+    return Markup(
+        f'<span id="{tid}" style="display:inline-flex; align-items:center;">'
+        f'<form hx-post="/watchlist/save" hx-target="#{tid}" hx-swap="outerHTML" style="margin:0; display:inline;">'
+        f'<input type="hidden" name="_csrf_token" value="{csrf}">'
+        f'<input type="hidden" name="title" value="{t}">'
+        f'<input type="hidden" name="content_type" value="{escape(ct)}">'
+        f'<input type="hidden" name="tmdb_id" value="{tmdb_val}">'
+        f'<input type="hidden" name="mode" value="toggle">'
+        f'<input type="hidden" name="target_id" value="{tid}">'
+        f'<button type="submit" class="mono result-link" style="background:none; border:none; cursor:pointer; padding:0;">+ Save</button>'
+        f'</form></span>'
+    )
+
+
 # ── Watchlist routes ──────────────────────────────────────────────────────────
 
 @app.route("/watchlist")
@@ -530,11 +573,28 @@ def watchlist_save() -> str:
     title = (request.form.get("title") or "").strip()
     ct = request.form.get("content_type", "tv")
     tmdb_id = request.form.get("tmdb_id", type=int)
+    mode = request.form.get("mode", "")
+    target_id = (request.form.get("target_id") or "").strip()
     if not title:
         return "Missing title", 400
     user_store.ensure_user_store(config.EVENT_DB_PATH, config.FEEDBACK_PATH)
     user_store.save_title(config.EVENT_DB_PATH, title, ct, tmdb_id=tmdb_id)
+    if mode == "toggle" and target_id:
+        return _watchlist_saved_fragment(title, ct, tmdb_id, target_id)
     return '<span class="mono" style="font-size:0.58rem; color:var(--teal);">Saved</span>'
+
+
+@app.route("/watchlist/unsave", methods=["POST"])
+def watchlist_unsave() -> str:
+    title = (request.form.get("title") or "").strip()
+    ct = request.form.get("content_type", "tv")
+    tmdb_id = request.form.get("tmdb_id", type=int)
+    target_id = (request.form.get("target_id") or "").strip()
+    if not title:
+        return "Missing title", 400
+    user_store.ensure_user_store(config.EVENT_DB_PATH, config.FEEDBACK_PATH)
+    user_store.remove_saved_title(config.EVENT_DB_PATH, title, ct)
+    return _watchlist_save_fragment(title, ct, tmdb_id, target_id)
 
 
 @app.route("/watchlist/dismiss", methods=["POST"])

--- a/recommender/web.py
+++ b/recommender/web.py
@@ -118,6 +118,8 @@ def _build_result_items(results: list, ctx: RecommendContext) -> list[dict]:
             if not imdb_url:
                 from urllib.parse import quote
                 imdb_url = f"https://www.imdb.com/find/?q={quote(r.title)}"
+        tmdb_id_val = meta.tmdb_id if meta else None
+        state = _title_state(r.title, r.content_type, tmdb_id_val)
         items.append({
             "title": r.title,
             "content_type": r.content_type,
@@ -129,6 +131,8 @@ def _build_result_items(results: list, ctx: RecommendContext) -> list[dict]:
             "poster": poster,
             "tmdb_url": tmdb_url,
             "imdb_url": imdb_url,
+            "tmdb_id": tmdb_id_val,
+            "user_state": state,
         })
     return items
 
@@ -321,17 +325,24 @@ def history() -> str:
         entries = [e for e in entries if e.get("content_type") == ct_filter]
 
     entries.sort(key=lambda e: e["title"].lower())
-    items = [
-        {
+    us = _load_user_state()
+    items = []
+    for e in entries:
+        class _M:
+            pass
+        m = _M()
+        m.title = e["title"]
+        m.content_type = e.get("content_type", "tv")
+        m.tmdb_id = e.get("tmdb_id")
+        items.append({
             "title": e["title"],
             "content_type": e.get("content_type", ""),
             "tmdb_id": e.get("tmdb_id"),
             "description": enrichments.get(e["title"], ""),
             "poster": _get_poster_url(e.get("tmdb_id", 0), e.get("content_type", "movie"), "w185")
                       if e.get("tmdb_id") else None,
-        }
-        for e in entries
-    ]
+            "rating": us.get_rating(m),
+        })
     return render_template("history.html", items=items, q=q, ct_filter=ct_filter, total=len(entries))
 
 
@@ -445,9 +456,10 @@ def title_detail(tmdb_id: int) -> str:
         if cache_path.exists():
             raw = json.loads(cache_path.read_text())
             overview = raw.get("overview", "")
+    state = _title_state(meta.title if meta else "", ct, tmdb_id if meta else None)
     return render_template(
         "title.html", meta=meta, description=description, overview=overview,
-        tmdb_id=tmdb_id, ct=ct, poster=poster,
+        tmdb_id=tmdb_id, ct=ct, poster=poster, user_state=state,
     )
 
 
@@ -456,6 +468,23 @@ def _load_user_state():
     user_store.ensure_user_store(config.EVENT_DB_PATH, config.FEEDBACK_PATH)
     from recommender.user_state import UserStateIndex
     return UserStateIndex.load(config.EVENT_DB_PATH)
+
+
+def _title_state(title: str, content_type: str, tmdb_id: int | None = None) -> dict:
+    """Return user state for a title, used across templates."""
+    us = _load_user_state()
+    class _Meta:
+        pass
+    meta = _Meta()
+    meta.title = title
+    meta.content_type = content_type
+    meta.tmdb_id = tmdb_id
+    return {
+        "in_archive": us.is_manually_watched(meta),
+        "in_watchlist": us.is_in_watchlist(meta),
+        "is_dismissed": us.is_dismissed(meta),
+        "rating": us.get_rating(meta),
+    }
 
 
 # ── Watchlist routes ──────────────────────────────────────────────────────────

--- a/recommender/web.py
+++ b/recommender/web.py
@@ -93,13 +93,12 @@ def _get_job_context() -> RecommendContext:
 def _run_recommend_job(query: str) -> dict:
     ctx = _get_job_context()
     results = ask(query, ctx)
-
+    items = _build_result_items(results, ctx)
     try:
-        query_history.record(query, results, ctx.llm.provider, ctx.llm.usage.summary())
+        query_history.record(query, items, ctx.llm.provider, ctx.llm.usage.summary())
     except OSError as exc:
         log.warning("Failed to persist query history for %r: %s", query, exc)
-
-    return {"items": _build_result_items(results, ctx), "query": query}
+    return {"items": items, "query": query}
 
 
 def _build_result_items(results: list, ctx: RecommendContext) -> list[dict]:
@@ -444,11 +443,11 @@ def recommend_post() -> str:
     try:
         ctx = _get_job_context()
         results = ask(query, ctx)
+        items = _build_result_items(results, ctx)
         try:
-            query_history.record(query, results, ctx.llm.provider, ctx.llm.usage.summary())
+            query_history.record(query, items, ctx.llm.provider, ctx.llm.usage.summary())
         except OSError as exc:
             log.warning("Failed to persist query history for %r: %s", query, exc)
-        items = _build_result_items(results, ctx)
         return render_template("recommend.html", query=query, results=items)
     except Exception as exc:
         log.exception("Error during recommendation")

--- a/recommender/web.py
+++ b/recommender/web.py
@@ -220,6 +220,16 @@ def _inject_footer() -> dict:
     }
 
 
+@app.context_processor
+def _inject_watchlist_count() -> dict:
+    try:
+        user_store.ensure_user_store(config.EVENT_DB_PATH, config.FEEDBACK_PATH)
+        items = user_store.list_saved_titles(config.EVENT_DB_PATH, status="watchlist")
+        return {"watchlist_count": len(items)}
+    except Exception:
+        return {"watchlist_count": 0}
+
+
 # ── Auth ──────────────────────────────────────────────────────────────────────
 
 @app.before_request

--- a/recommender/web.py
+++ b/recommender/web.py
@@ -18,6 +18,7 @@ from markupsafe import Markup, escape
 
 import config
 from recommender import history as query_history
+from recommender import user_store
 from recommender import watch_index as wi
 from recommender import event_store
 from recommender.event_store import load_events
@@ -438,6 +439,105 @@ def title_detail(tmdb_id: int) -> str:
         "title.html", meta=meta, description=description, overview=overview,
         tmdb_id=tmdb_id, ct=ct, poster=poster,
     )
+
+
+def _load_user_state():
+    """Load fresh user state snapshot for the current request."""
+    user_store.ensure_user_store(config.EVENT_DB_PATH, config.FEEDBACK_PATH)
+    from recommender.user_state import UserStateIndex
+    return UserStateIndex.load(config.EVENT_DB_PATH)
+
+
+# ── Watchlist routes ──────────────────────────────────────────────────────────
+
+@app.route("/watchlist")
+def watchlist_page() -> str:
+    user_store.ensure_user_store(config.EVENT_DB_PATH, config.FEEDBACK_PATH)
+    items = user_store.list_saved_titles(config.EVENT_DB_PATH, status="watchlist")
+    return render_template("watchlist.html", items=items)
+
+
+@app.route("/watchlist/save", methods=["POST"])
+def watchlist_save() -> str:
+    title = (request.form.get("title") or "").strip()
+    ct = request.form.get("content_type", "tv")
+    tmdb_id = request.form.get("tmdb_id", type=int)
+    if not title:
+        return "Missing title", 400
+    user_store.ensure_user_store(config.EVENT_DB_PATH, config.FEEDBACK_PATH)
+    user_store.save_title(config.EVENT_DB_PATH, title, ct, tmdb_id=tmdb_id)
+    return '<span class="mono" style="font-size:0.58rem; color:var(--teal);">Saved</span>'
+
+
+@app.route("/watchlist/dismiss", methods=["POST"])
+def watchlist_dismiss() -> str:
+    title = (request.form.get("title") or "").strip()
+    ct = request.form.get("content_type", "tv")
+    tmdb_id = request.form.get("tmdb_id", type=int)
+    if not title:
+        return "Missing title", 400
+    user_store.ensure_user_store(config.EVENT_DB_PATH, config.FEEDBACK_PATH)
+    user_store.dismiss_title(config.EVENT_DB_PATH, title, ct, tmdb_id=tmdb_id)
+    return ""
+
+
+@app.route("/watchlist/remove", methods=["POST"])
+def watchlist_remove() -> str:
+    title = (request.form.get("title") or "").strip()
+    ct = request.form.get("content_type", "tv")
+    if not title:
+        return "Missing title", 400
+    user_store.ensure_user_store(config.EVENT_DB_PATH, config.FEEDBACK_PATH)
+    user_store.remove_saved_title(config.EVENT_DB_PATH, title, ct)
+    return ""
+
+
+@app.route("/watchlist/watched", methods=["POST"])
+def watchlist_watched() -> str:
+    title = (request.form.get("title") or "").strip()
+    ct = request.form.get("content_type", "tv")
+    tmdb_id = request.form.get("tmdb_id", type=int)
+    if not title:
+        return "Missing title", 400
+    user_store.ensure_user_store(config.EVENT_DB_PATH, config.FEEDBACK_PATH)
+    user_store.mark_watched_from_watchlist(config.EVENT_DB_PATH, title, ct, tmdb_id=tmdb_id)
+    uid = f"wl-{hash(title) & 0xFFFFFF:06x}"
+    return render_template("_rating_prompt.html", title=title, content_type=ct,
+                           tmdb_id=tmdb_id, uid=uid)
+
+
+# ── Archive routes ────────────────────────────────────────────────────────────
+
+@app.route("/archive/add", methods=["POST"])
+def archive_add() -> str:
+    title = (request.form.get("title") or "").strip()
+    ct = request.form.get("content_type", "tv")
+    tmdb_id = request.form.get("tmdb_id", type=int)
+    if not title:
+        return "Missing title", 400
+    user_store.ensure_user_store(config.EVENT_DB_PATH, config.FEEDBACK_PATH)
+    user_store.add_to_archive(config.EVENT_DB_PATH, title, ct, tmdb_id=tmdb_id, source="web")
+    uid = f"aa-{hash(title) & 0xFFFFFF:06x}"
+    return render_template("_rating_prompt.html", title=title, content_type=ct,
+                           tmdb_id=tmdb_id, uid=uid)
+
+
+@app.route("/archive/rate", methods=["POST"])
+def archive_rate() -> str:
+    title = (request.form.get("title") or "").strip()
+    ct = request.form.get("content_type", "tv")
+    rating = request.form.get("rating", "")
+    tmdb_id = request.form.get("tmdb_id", type=int)
+    if not title:
+        return "Missing title", 400
+    if rating == "skip":
+        return '<span class="mono" style="font-size:0.58rem; color:var(--teal);">added</span>'
+    user_store.ensure_user_store(config.EVENT_DB_PATH, config.FEEDBACK_PATH)
+    user_store.rate_title(config.EVENT_DB_PATH, title, ct, rating, tmdb_id=tmdb_id)
+    current = None if rating == "clear" else rating
+    uid = f"rt-{hash(title) & 0xFFFFFF:06x}"
+    return render_template("_rating_state.html", title=title, content_type=ct,
+                           tmdb_id=tmdb_id, current_rating=current, uid=uid)
 
 
 @app.route("/help")

--- a/recommender/web.py
+++ b/recommender/web.py
@@ -1,6 +1,8 @@
 """Flask web UI for Streamline — taste profile dashboard, watch history, and recommendation search."""
 
+import csv
 import importlib
+import io
 import json
 import logging
 import os
@@ -326,6 +328,7 @@ def history() -> str:
     enrichments = _load_enrichments()
     q = request.args.get("q", "").lower()
     ct_filter = request.args.get("type", "")
+    sort = request.args.get("sort", "az")
 
     entries = list(ctx.watch_index.entries)
 
@@ -352,7 +355,10 @@ def history() -> str:
     if ct_filter in ("tv", "movie"):
         entries = [e for e in entries if e.get("content_type") == ct_filter]
 
-    entries.sort(key=lambda e: e["title"].lower())
+    if sort == "za":
+        entries.sort(key=lambda e: e["title"].lower(), reverse=True)
+    else:
+        entries.sort(key=lambda e: e["title"].lower())
     us = _load_user_state()
     items = []
     for e in entries:
@@ -371,7 +377,7 @@ def history() -> str:
                       if e.get("tmdb_id") else None,
             "rating": us.get_rating(m),
         })
-    return render_template("history.html", items=items, q=q, ct_filter=ct_filter, total=len(entries))
+    return render_template("history.html", items=items, q=q, ct_filter=ct_filter, sort=sort, total=len(entries))
 
 
 @app.route("/searches")
@@ -566,6 +572,23 @@ def watchlist_page() -> str:
     user_store.ensure_user_store(config.EVENT_DB_PATH, config.FEEDBACK_PATH)
     items = user_store.list_saved_titles(config.EVENT_DB_PATH, status="watchlist")
     return render_template("watchlist.html", items=items)
+
+
+@app.route("/watchlist/export")
+def watchlist_export():
+    user_store.ensure_user_store(config.EVENT_DB_PATH, config.FEEDBACK_PATH)
+    items = user_store.list_saved_titles(config.EVENT_DB_PATH, status="watchlist")
+    output = io.StringIO()
+    writer = csv.writer(output)
+    writer.writerow(["title", "content_type", "tmdb_id", "saved_at"])
+    for item in items:
+        writer.writerow([item["title"], item["content_type"],
+                         item.get("tmdb_id") or "", item.get("saved_at") or ""])
+    return Response(
+        output.getvalue(),
+        mimetype="text/csv",
+        headers={"Content-Disposition": "attachment; filename=watchlist.csv"},
+    )
 
 
 @app.route("/watchlist/save", methods=["POST"])

--- a/recommender/web.py
+++ b/recommender/web.py
@@ -494,6 +494,11 @@ def title_detail(tmdb_id: int) -> str:
             overview = raw.get("overview", "")
     us = _load_user_state()
     state = _title_state(meta.title if meta else "", ct, us, tmdb_id if meta else None)
+    # Also count watch-index entries (imported from Netflix/Prime/etc.) as archived
+    if not state["in_archive"] and meta:
+        wi_ctx = _get_context()
+        if tmdb_id in wi_ctx.watch_index.tmdb_ids:
+            state["in_archive"] = True
     return render_template(
         "title.html", meta=meta, description=description, overview=overview,
         tmdb_id=tmdb_id, ct=ct, poster=poster, user_state=state,
@@ -570,6 +575,21 @@ def _watchlist_save_fragment(title: str, ct: str, tmdb_id: int | None, target_id
 def watchlist_page() -> str:
     user_store.ensure_user_store(config.EVENT_DB_PATH, config.FEEDBACK_PATH)
     items = user_store.list_saved_titles(config.EVENT_DB_PATH, status="watchlist")
+    try:
+        ctx = _get_context()
+        for item in items:
+            vote_average = 0.0
+            if item.get("tmdb_id"):
+                try:
+                    cached = ctx.tmdb_client._load_cache(item["content_type"], item["tmdb_id"])
+                    if cached:
+                        vote_average = cached.get("vote_average") or 0.0
+                except Exception:
+                    pass
+            item["vote_average"] = vote_average
+    except Exception:
+        for item in items:
+            item.setdefault("vote_average", 0.0)
     return render_template("watchlist.html", items=items)
 
 
@@ -653,7 +673,7 @@ def watchlist_watched() -> str:
     user_store.mark_watched_from_watchlist(config.EVENT_DB_PATH, title, ct, tmdb_id=tmdb_id)
     uid = f"wl-{hash(title) & 0xFFFFFF:06x}"
     return render_template("_rating_prompt.html", title=title, content_type=ct,
-                           tmdb_id=tmdb_id, uid=uid)
+                           tmdb_id=tmdb_id, uid=uid, context="watchlist")
 
 
 # ── Archive routes ────────────────────────────────────────────────────────────
@@ -678,12 +698,15 @@ def archive_rate() -> str:
     ct = request.form.get("content_type", "tv")
     rating = request.form.get("rating", "")
     tmdb_id = request.form.get("tmdb_id", type=int)
+    context = request.form.get("context", "")
     if not title:
         return "Missing title", 400
     if rating == "skip":
-        return '<span class="mono" style="font-size:0.58rem; color:var(--teal);">added</span>'
+        return "" if context == "watchlist" else '<span class="mono" style="font-size:0.58rem; color:var(--teal);">added</span>'
     user_store.ensure_user_store(config.EVENT_DB_PATH, config.FEEDBACK_PATH)
     user_store.rate_title(config.EVENT_DB_PATH, title, ct, rating, tmdb_id=tmdb_id)
+    if context == "watchlist":
+        return ""
     current = None if rating == "clear" else rating
     uid = f"rt-{hash(title) & 0xFFFFFF:06x}"
     return render_template("_rating_state.html", title=title, content_type=ct,

--- a/recommender/web.py
+++ b/recommender/web.py
@@ -102,6 +102,7 @@ def _run_recommend_job(query: str) -> dict:
 
 def _build_result_items(results: list, ctx: RecommendContext) -> list[dict]:
     items = []
+    us = _load_user_state()
     for r in results:
         meta = ctx.tmdb_client.get_metadata(r.title, r.content_type)
         poster = _get_poster_url(meta.tmdb_id, r.content_type) if meta else None
@@ -120,7 +121,7 @@ def _build_result_items(results: list, ctx: RecommendContext) -> list[dict]:
                 from urllib.parse import quote
                 imdb_url = f"https://www.imdb.com/find/?q={quote(r.title)}"
         tmdb_id_val = meta.tmdb_id if meta else None
-        state = _title_state(r.title, r.content_type, tmdb_id_val)
+        state = _title_state(r.title, r.content_type, us, tmdb_id_val)
         items.append({
             "title": r.title,
             "content_type": r.content_type,
@@ -139,6 +140,13 @@ def _build_result_items(results: list, ctx: RecommendContext) -> list[dict]:
 
 
 # ── Helpers ───────────────────────────────────────────────────────────────────
+
+def _norm_title(title: str) -> str:
+    """Normalize a title for dedup (same rule as user_store._normalize)."""
+    title = title.lower()
+    title = re.sub(r'\s*\([^)]*\)', '', title)
+    return title.strip()
+
 
 def _load_enrichments() -> dict[str, str]:
     index_path = Path(config.ENRICHMENT_CACHE_DIR) / "index.json"
@@ -325,18 +333,12 @@ def history() -> str:
     user_store.ensure_user_store(config.EVENT_DB_PATH, config.FEEDBACK_PATH)
     manual = user_store.list_manual_archive(config.EVENT_DB_PATH)
 
-    import re as _re
-    def _norm(t: str) -> str:
-        t = t.lower()
-        t = _re.sub(r'\s*\([^)]*\)', '', t)
-        return t.strip()
-
     existing_norm = {
-        (_norm(e.get("title", "")), e.get("content_type", "tv"))
+        (_norm_title(e.get("title", "")), e.get("content_type", "tv"))
         for e in entries
     }
     for m in manual:
-        key = (_norm(m["title"]), m["content_type"])
+        key = (_norm_title(m["title"]), m["content_type"])
         if key not in existing_norm:
             entries.append({
                 "title": m["title"],
@@ -482,7 +484,8 @@ def title_detail(tmdb_id: int) -> str:
         if cache_path.exists():
             raw = json.loads(cache_path.read_text())
             overview = raw.get("overview", "")
-    state = _title_state(meta.title if meta else "", ct, tmdb_id if meta else None)
+    us = _load_user_state()
+    state = _title_state(meta.title if meta else "", ct, us, tmdb_id if meta else None)
     return render_template(
         "title.html", meta=meta, description=description, overview=overview,
         tmdb_id=tmdb_id, ct=ct, poster=poster, user_state=state,
@@ -496,9 +499,9 @@ def _load_user_state():
     return UserStateIndex.load(config.EVENT_DB_PATH)
 
 
-def _title_state(title: str, content_type: str, tmdb_id: int | None = None) -> dict:
+def _title_state(title: str, content_type: str, us: "UserStateIndex",
+                 tmdb_id: int | None = None) -> dict:
     """Return user state for a title, used across templates."""
-    us = _load_user_state()
     class _Meta:
         pass
     meta = _Meta()

--- a/recommender/web.py
+++ b/recommender/web.py
@@ -82,6 +82,7 @@ def _get_job_context() -> RecommendContext:
     """
     ctx = copy(_get_context())
     ctx.llm = create_client()
+    ctx.user_state = _load_user_state()
     return ctx
 
 
@@ -319,6 +320,31 @@ def history() -> str:
     ct_filter = request.args.get("type", "")
 
     entries = list(ctx.watch_index.entries)
+
+    # Union manual archive entries that aren't already in the watch index
+    user_store.ensure_user_store(config.EVENT_DB_PATH, config.FEEDBACK_PATH)
+    manual = user_store.list_manual_archive(config.EVENT_DB_PATH)
+
+    import re as _re
+    def _norm(t: str) -> str:
+        t = t.lower()
+        t = _re.sub(r'\s*\([^)]*\)', '', t)
+        return t.strip()
+
+    existing_norm = {
+        (_norm(e.get("title", "")), e.get("content_type", "tv"))
+        for e in entries
+    }
+    for m in manual:
+        key = (_norm(m["title"]), m["content_type"])
+        if key not in existing_norm:
+            entries.append({
+                "title": m["title"],
+                "content_type": m["content_type"],
+                "tmdb_id": m.get("tmdb_id"),
+                "source": m["source"],
+            })
+
     if q:
         entries = [e for e in entries if q in e["title"].lower()]
     if ct_filter in ("tv", "movie"):

--- a/recommender/web.py
+++ b/recommender/web.py
@@ -48,6 +48,23 @@ _ctx: RecommendContext | None = None
 _ctx_lock = threading.Lock()
 _config_reload_pending = False
 
+# ── User store initialization ─────────────────────────────────────────────────
+# Run once per process. ensure_user_store does IF-NOT-EXISTS DDL + migration
+# checks — cheap but not free. A flag prevents the overhead on every request.
+_user_store_ready = False
+_user_store_lock = threading.Lock()
+
+
+def _ensure_user_store_once() -> None:
+    global _user_store_ready
+    if _user_store_ready:
+        return
+    with _user_store_lock:
+        if _user_store_ready:
+            return
+        user_store.ensure_user_store(config.EVENT_DB_PATH, config.FEEDBACK_PATH)
+        _user_store_ready = True
+
 
 def _get_context() -> RecommendContext:
     global _ctx
@@ -237,7 +254,7 @@ def _inject_footer() -> dict:
 @app.context_processor
 def _inject_watchlist_count() -> dict:
     try:
-        user_store.ensure_user_store(config.EVENT_DB_PATH, config.FEEDBACK_PATH)
+        _ensure_user_store_once()
         items = user_store.list_saved_titles(config.EVENT_DB_PATH, status="watchlist")
         return {"watchlist_count": len(items)}
     except Exception:
@@ -332,7 +349,7 @@ def history() -> str:
     entries = list(ctx.watch_index.entries)
 
     # Union manual archive entries that aren't already in the watch index
-    user_store.ensure_user_store(config.EVENT_DB_PATH, config.FEEDBACK_PATH)
+    _ensure_user_store_once()
     manual = user_store.list_manual_archive(config.EVENT_DB_PATH)
 
     existing_norm = {
@@ -478,9 +495,7 @@ def title_detail(tmdb_id: int) -> str:
     enrichments = _load_enrichments()
     meta = None
     try:
-        cached = ctx.tmdb_client._load_cache(ct, tmdb_id)
-        if cached:
-            meta = ctx.tmdb_client._parse_metadata(cached, ct)
+        meta = ctx.tmdb_client.get_cached_by_id(tmdb_id, ct)
     except Exception:
         pass
 
@@ -507,7 +522,7 @@ def title_detail(tmdb_id: int) -> str:
 
 def _load_user_state():
     """Load fresh user state snapshot for the current request."""
-    user_store.ensure_user_store(config.EVENT_DB_PATH, config.FEEDBACK_PATH)
+    _ensure_user_store_once()
     from recommender.user_state import UserStateIndex
     return UserStateIndex.load(config.EVENT_DB_PATH)
 
@@ -573,7 +588,7 @@ def _watchlist_save_fragment(title: str, ct: str, tmdb_id: int | None, target_id
 
 @app.route("/watchlist")
 def watchlist_page() -> str:
-    user_store.ensure_user_store(config.EVENT_DB_PATH, config.FEEDBACK_PATH)
+    _ensure_user_store_once()
     items = user_store.list_saved_titles(config.EVENT_DB_PATH, status="watchlist")
     try:
         ctx = _get_context()
@@ -581,9 +596,9 @@ def watchlist_page() -> str:
             vote_average = 0.0
             if item.get("tmdb_id"):
                 try:
-                    cached = ctx.tmdb_client._load_cache(item["content_type"], item["tmdb_id"])
-                    if cached:
-                        vote_average = cached.get("vote_average") or 0.0
+                    meta = ctx.tmdb_client.get_cached_by_id(item["tmdb_id"], item["content_type"])
+                    if meta:
+                        vote_average = meta.vote_average or 0.0
                 except Exception:
                     pass
             item["vote_average"] = vote_average
@@ -595,7 +610,7 @@ def watchlist_page() -> str:
 
 @app.route("/watchlist/export")
 def watchlist_export():
-    user_store.ensure_user_store(config.EVENT_DB_PATH, config.FEEDBACK_PATH)
+    _ensure_user_store_once()
     items = user_store.list_saved_titles(config.EVENT_DB_PATH, status="watchlist")
     output = io.StringIO()
     writer = csv.writer(output)
@@ -619,7 +634,7 @@ def watchlist_save() -> str:
     target_id = (request.form.get("target_id") or "").strip()
     if not title:
         return "Missing title", 400
-    user_store.ensure_user_store(config.EVENT_DB_PATH, config.FEEDBACK_PATH)
+    _ensure_user_store_once()
     user_store.save_title(config.EVENT_DB_PATH, title, ct, tmdb_id=tmdb_id)
     if mode == "toggle" and target_id:
         return _watchlist_saved_fragment(title, ct, tmdb_id, target_id)
@@ -634,8 +649,8 @@ def watchlist_unsave() -> str:
     target_id = (request.form.get("target_id") or "").strip()
     if not title:
         return "Missing title", 400
-    user_store.ensure_user_store(config.EVENT_DB_PATH, config.FEEDBACK_PATH)
-    user_store.remove_saved_title(config.EVENT_DB_PATH, title, ct)
+    _ensure_user_store_once()
+    user_store.remove_saved_title(config.EVENT_DB_PATH, title, ct, tmdb_id=tmdb_id)
     return _watchlist_save_fragment(title, ct, tmdb_id, target_id)
 
 
@@ -646,7 +661,7 @@ def watchlist_dismiss() -> str:
     tmdb_id = request.form.get("tmdb_id", type=int)
     if not title:
         return "Missing title", 400
-    user_store.ensure_user_store(config.EVENT_DB_PATH, config.FEEDBACK_PATH)
+    _ensure_user_store_once()
     user_store.dismiss_title(config.EVENT_DB_PATH, title, ct, tmdb_id=tmdb_id)
     return ""
 
@@ -655,10 +670,11 @@ def watchlist_dismiss() -> str:
 def watchlist_remove() -> str:
     title = (request.form.get("title") or "").strip()
     ct = request.form.get("content_type", "tv")
+    tmdb_id = request.form.get("tmdb_id", type=int)
     if not title:
         return "Missing title", 400
-    user_store.ensure_user_store(config.EVENT_DB_PATH, config.FEEDBACK_PATH)
-    user_store.remove_saved_title(config.EVENT_DB_PATH, title, ct)
+    _ensure_user_store_once()
+    user_store.remove_saved_title(config.EVENT_DB_PATH, title, ct, tmdb_id=tmdb_id)
     return ""
 
 
@@ -669,7 +685,7 @@ def watchlist_watched() -> str:
     tmdb_id = request.form.get("tmdb_id", type=int)
     if not title:
         return "Missing title", 400
-    user_store.ensure_user_store(config.EVENT_DB_PATH, config.FEEDBACK_PATH)
+    _ensure_user_store_once()
     user_store.mark_watched_from_watchlist(config.EVENT_DB_PATH, title, ct, tmdb_id=tmdb_id)
     uid = f"wl-{hash(title) & 0xFFFFFF:06x}"
     return render_template("_rating_prompt.html", title=title, content_type=ct,
@@ -685,7 +701,7 @@ def archive_add() -> str:
     tmdb_id = request.form.get("tmdb_id", type=int)
     if not title:
         return "Missing title", 400
-    user_store.ensure_user_store(config.EVENT_DB_PATH, config.FEEDBACK_PATH)
+    _ensure_user_store_once()
     user_store.add_to_archive(config.EVENT_DB_PATH, title, ct, tmdb_id=tmdb_id, source="web")
     uid = f"aa-{hash(title) & 0xFFFFFF:06x}"
     return render_template("_rating_prompt.html", title=title, content_type=ct,
@@ -703,7 +719,7 @@ def archive_rate() -> str:
         return "Missing title", 400
     if rating == "skip":
         return "" if context == "watchlist" else '<span class="mono" style="font-size:0.58rem; color:var(--teal);">added</span>'
-    user_store.ensure_user_store(config.EVENT_DB_PATH, config.FEEDBACK_PATH)
+    _ensure_user_store_once()
     user_store.rate_title(config.EVENT_DB_PATH, title, ct, rating, tmdb_id=tmdb_id)
     if context == "watchlist":
         return ""

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -935,3 +935,41 @@ def test_load_context_debug_log_does_not_force_events_load(monkeypatch, tmp_path
     ctx = main_module.load_context()
     # After load_context, _events_resolved should still be None (not loaded)
     assert ctx._events_resolved is None
+
+
+def test_liked_writes_to_sqlite(tmp_path, monkeypatch):
+    from recommender.user_store import init_db, load_ratings
+    import recommender.user_store as us
+
+    db = str(tmp_path / "test.db")
+    init_db(db)
+    monkeypatch.setattr("config.EVENT_DB_PATH", db)
+    monkeypatch.setattr("config.FEEDBACK_PATH", str(tmp_path / "feedback.json"))
+    monkeypatch.setattr(us, "resolve_rating_content_type", lambda *_args, **_kwargs: "tv")
+    monkeypatch.setattr("sys.argv", ["recommend", "--liked", "Breaking Bad"])
+    monkeypatch.setattr("config.WATCH_INDEX_PATH", str(tmp_path / "wi.json"))
+    monkeypatch.setattr("config.TASTE_PROFILE_PATH", str(tmp_path / "tp.txt"))
+
+    from recommender.main import main
+    main()
+
+    ratings = load_ratings(db)
+    assert any(r["title"] == "Breaking Bad" and r["rating"] == "liked" for r in ratings)
+
+
+def test_add_writes_to_sqlite(tmp_path, monkeypatch):
+    from recommender.user_store import init_db, list_manual_archive
+
+    db = str(tmp_path / "test.db")
+    init_db(db)
+    monkeypatch.setattr("config.EVENT_DB_PATH", db)
+    monkeypatch.setattr("config.FEEDBACK_PATH", str(tmp_path / "feedback.json"))
+    monkeypatch.setattr("sys.argv", ["recommend", "--add", "The Bear", "--type", "tv"])
+    monkeypatch.setattr("config.WATCH_INDEX_PATH", str(tmp_path / "wi.json"))
+    monkeypatch.setattr("config.TASTE_PROFILE_PATH", str(tmp_path / "tp.txt"))
+
+    from recommender.main import main
+    main()
+
+    archive = list_manual_archive(db)
+    assert any(a["title"] == "The Bear" for a in archive)

--- a/tests/test_query_engine.py
+++ b/tests/test_query_engine.py
@@ -218,3 +218,61 @@ def test_recommend_context_events_no_loader_returns_empty():
         cache_dir="/tmp",
     )
     assert ctx.events == []
+
+
+def test_user_state_excludes_dismissed_and_manual_archive():
+    """ask() drops dismissed and manually-watched titles from the candidate pool."""
+    meta_dismissed = make_meta("Dismissed Show", tmdb_id=111)
+    meta_manual = make_meta("Already Watched", tmdb_id=222)
+    meta_new = make_meta("Fresh Pick", tmdb_id=333)
+
+    mock_tmdb = MagicMock()
+    mock_tmdb.search_by_filters.return_value = [meta_dismissed, meta_manual, meta_new]
+    mock_tmdb.get_metadata.return_value = None
+
+    intent_json = json.dumps({
+        "genres": ["crime"], "origin_countries": ["GB"], "languages": [],
+        "mood_descriptors": [], "similar_to": [], "max_runtime_minutes": None,
+        "year_from": None, "year_to": None,
+        "unwatched_only": True, "special_intent": None, "content_type": "tv",
+        "top_n": 1, "platforms": [],
+    })
+    suggestions_json = json.dumps([])
+    ranked_json = json.dumps([
+        {"title": "Fresh Pick", "explanation": "Still eligible.", "score": 0.91}
+    ])
+    mock_llm = make_mock_llm_sequence([intent_json, suggestions_json, ranked_json])
+
+    class FakeUserState:
+        def is_manually_watched(self, meta):
+            return meta.tmdb_id == 222
+
+        def is_dismissed(self, meta):
+            return meta.tmdb_id == 111
+
+        def has_rating(self, meta):
+            return False
+
+        def get_rating(self, meta):
+            return None
+
+        def is_in_watchlist(self, meta):
+            return False
+
+    ctx = RecommendContext(
+        taste_profile="taste profile text",
+        watch_index=WatchIndex(tmdb_ids=set(), normalized_titles=set(), entries=[]),
+        events=[],
+        tmdb_client=mock_tmdb,
+        llm=mock_llm,
+        cache_dir="/tmp/test_cache",
+        user_state=FakeUserState(),
+    )
+
+    with patch("recommender.query_engine.enrich_batch", return_value={"Fresh Pick": "Eligible"}):
+        results = ask("British crime drama", ctx)
+
+    titles = [r.title for r in results]
+    assert "Dismissed Show" not in titles
+    assert "Already Watched" not in titles
+    assert titles == ["Fresh Pick"]

--- a/tests/test_user_state.py
+++ b/tests/test_user_state.py
@@ -1,0 +1,106 @@
+from pathlib import Path
+
+from recommender.user_store import (
+    init_db, save_title, dismiss_title, add_to_archive, rate_title,
+)
+
+
+class FakeMeta:
+    """Minimal stand-in for TmdbMetadata with the fields UserStateIndex needs."""
+    def __init__(self, title, content_type, tmdb_id=None):
+        self.title = title
+        self.content_type = content_type
+        self.tmdb_id = tmdb_id
+
+
+def test_is_manually_watched_by_tmdb_id(tmp_path):
+    db = str(tmp_path / "test.db")
+    init_db(db)
+    add_to_archive(db, "Breaking Bad", "tv", tmdb_id=1396)
+
+    from recommender.user_state import UserStateIndex
+    idx = UserStateIndex.load(db)
+
+    assert idx.is_manually_watched(FakeMeta("Breaking Bad", "tv", tmdb_id=1396))
+    assert not idx.is_manually_watched(FakeMeta("Breaking Bad", "tv", tmdb_id=9999))
+
+
+def test_is_manually_watched_fallback_to_normalized_title(tmp_path):
+    db = str(tmp_path / "test.db")
+    init_db(db)
+    add_to_archive(db, "Some Show (2020)", "tv")
+
+    from recommender.user_state import UserStateIndex
+    idx = UserStateIndex.load(db)
+
+    # Normalized: "some show"
+    assert idx.is_manually_watched(FakeMeta("Some Show", "tv"))
+    assert not idx.is_manually_watched(FakeMeta("Some Show", "movie"))
+
+
+def test_is_dismissed_by_tmdb_id(tmp_path):
+    db = str(tmp_path / "test.db")
+    init_db(db)
+    dismiss_title(db, "Bad Show", "tv", tmdb_id=555)
+
+    from recommender.user_state import UserStateIndex
+    idx = UserStateIndex.load(db)
+
+    assert idx.is_dismissed(FakeMeta("Bad Show", "tv", tmdb_id=555))
+    assert not idx.is_dismissed(FakeMeta("Bad Show", "tv", tmdb_id=111))
+
+
+def test_is_dismissed_fallback_to_normalized_title(tmp_path):
+    db = str(tmp_path / "test.db")
+    init_db(db)
+    dismiss_title(db, "Bad Show", "tv")
+
+    from recommender.user_state import UserStateIndex
+    idx = UserStateIndex.load(db)
+
+    assert idx.is_dismissed(FakeMeta("Bad Show", "tv"))
+    assert not idx.is_dismissed(FakeMeta("Bad Show", "movie"))
+
+
+def test_has_rating_and_get_rating(tmp_path):
+    db = str(tmp_path / "test.db")
+    init_db(db)
+    rate_title(db, "Breaking Bad", "tv", "liked", tmdb_id=1396)
+
+    from recommender.user_state import UserStateIndex
+    idx = UserStateIndex.load(db)
+
+    meta = FakeMeta("Breaking Bad", "tv", tmdb_id=1396)
+    assert idx.has_rating(meta)
+    assert idx.get_rating(meta) == "liked"
+
+    assert not idx.has_rating(FakeMeta("Unknown", "tv"))
+    assert idx.get_rating(FakeMeta("Unknown", "tv")) is None
+
+
+def test_snapshot_does_not_see_later_mutations(tmp_path):
+    db = str(tmp_path / "test.db")
+    init_db(db)
+
+    from recommender.user_state import UserStateIndex
+    idx = UserStateIndex.load(db)
+
+    # Mutate after snapshot
+    add_to_archive(db, "New Show", "tv")
+    assert not idx.is_manually_watched(FakeMeta("New Show", "tv"))
+
+    # New snapshot sees it
+    idx2 = UserStateIndex.load(db)
+    assert idx2.is_manually_watched(FakeMeta("New Show", "tv"))
+
+
+def test_is_in_watchlist(tmp_path):
+    db = str(tmp_path / "test.db")
+    init_db(db)
+    save_title(db, "Upcoming Show", "tv", tmdb_id=777)
+
+    from recommender.user_state import UserStateIndex
+    idx = UserStateIndex.load(db)
+
+    assert idx.is_in_watchlist(FakeMeta("Upcoming Show", "tv", tmdb_id=777))
+    assert not idx.is_in_watchlist(FakeMeta("Other", "tv"))

--- a/tests/test_user_state.py
+++ b/tests/test_user_state.py
@@ -94,6 +94,19 @@ def test_snapshot_does_not_see_later_mutations(tmp_path):
     assert idx2.is_manually_watched(FakeMeta("New Show", "tv"))
 
 
+def test_get_rating_does_not_fallthrough_on_wrong_tmdb_id(tmp_path):
+    db = str(tmp_path / "test.db")
+    init_db(db)
+    rate_title(db, "Breaking Bad", "tv", "liked")  # no tmdb_id, stored by title
+
+    from recommender.user_state import UserStateIndex
+    idx = UserStateIndex.load(db)
+
+    # meta has a tmdb_id that is NOT in the ratings dict
+    # should NOT fall through to title-based match
+    assert idx.get_rating(FakeMeta("Breaking Bad", "tv", tmdb_id=9999)) is None
+
+
 def test_is_in_watchlist(tmp_path):
     db = str(tmp_path / "test.db")
     init_db(db)

--- a/tests/test_user_store.py
+++ b/tests/test_user_store.py
@@ -249,3 +249,103 @@ def test_add_to_archive_without_tmdb_id(tmp_path):
     items = list_manual_archive(db)
     assert len(items) == 1
     assert items[0]["tmdb_id"] is None
+
+
+def test_mark_watched_from_watchlist(tmp_path):
+    db = str(tmp_path / "test.db")
+    from recommender.user_store import (
+        init_db, save_title, mark_watched_from_watchlist,
+        list_saved_titles, list_manual_archive, load_ratings,
+    )
+
+    init_db(db)
+    save_title(db, "Breaking Bad", "tv", tmdb_id=1396)
+    mark_watched_from_watchlist(db, "Breaking Bad", "tv", rating="liked", tmdb_id=1396)
+
+    assert list_saved_titles(db) == []
+    archive = list_manual_archive(db)
+    assert len(archive) == 1
+    assert archive[0]["title"] == "Breaking Bad"
+    ratings = load_ratings(db)
+    assert len(ratings) == 1
+    assert ratings[0]["rating"] == "liked"
+
+
+def test_mark_watched_without_rating(tmp_path):
+    db = str(tmp_path / "test.db")
+    from recommender.user_store import (
+        init_db, save_title, mark_watched_from_watchlist,
+        list_saved_titles, list_manual_archive, load_ratings,
+    )
+
+    init_db(db)
+    save_title(db, "The Wire", "tv")
+    mark_watched_from_watchlist(db, "The Wire", "tv")
+
+    assert list_saved_titles(db) == []
+    assert len(list_manual_archive(db)) == 1
+    assert load_ratings(db) == []
+
+
+def test_mark_watched_rollback_on_failure(tmp_path):
+    """If the rating write fails, the entire transaction rolls back."""
+    db = str(tmp_path / "test.db")
+    from recommender.user_store import init_db, save_title, list_saved_titles, list_manual_archive
+    import recommender.user_store as us
+
+    init_db(db)
+    save_title(db, "Test Show", "tv", tmdb_id=999)
+
+    # Corrupt the title_ratings table to force a write failure
+    import sqlite3
+    conn = sqlite3.connect(db)
+    conn.execute("DROP TABLE title_ratings")
+    conn.commit()
+    conn.close()
+
+    with pytest.raises(Exception):
+        us.mark_watched_from_watchlist(db, "Test Show", "tv", rating="liked", tmdb_id=999)
+
+    # Watchlist row must still be present
+    assert len(list_saved_titles(db)) == 1
+    # No archive entry should exist
+    assert list_manual_archive(db) == []
+
+
+def test_tmdb_id_takes_precedence_over_title(tmp_path):
+    """Two entries with same normalized title but different tmdb_ids are separate."""
+    db = str(tmp_path / "test.db")
+    from recommender.user_store import init_db, save_title, list_saved_titles
+
+    init_db(db)
+    save_title(db, "The Office", "tv", tmdb_id=2316)
+    save_title(db, "The Office", "tv", tmdb_id=69735)  # US vs UK
+
+    items = list_saved_titles(db)
+    assert len(items) == 2
+
+
+def test_no_tmdb_id_dedupes_by_normalized_title(tmp_path):
+    db = str(tmp_path / "test.db")
+    from recommender.user_store import init_db, save_title, list_saved_titles
+
+    init_db(db)
+    save_title(db, "The Office (US)", "tv")  # normalized: "the office"
+    save_title(db, "The Office", "tv")       # same normalized title
+
+    items = list_saved_titles(db)
+    assert len(items) == 1
+
+
+def test_tmdb_id_upgrade_reuses_existing_null_identity(tmp_path):
+    """A later TMDB-backed save upgrades the NULL-tmdb row instead of duplicating it."""
+    db = str(tmp_path / "test.db")
+    from recommender.user_store import init_db, save_title, list_saved_titles
+
+    init_db(db)
+    save_title(db, "Severance", "tv")
+    save_title(db, "Severance", "tv", tmdb_id=95396)
+
+    items = list_saved_titles(db)
+    assert len(items) == 1
+    assert items[0]["tmdb_id"] == 95396

--- a/tests/test_user_store.py
+++ b/tests/test_user_store.py
@@ -349,3 +349,134 @@ def test_tmdb_id_upgrade_reuses_existing_null_identity(tmp_path):
     items = list_saved_titles(db)
     assert len(items) == 1
     assert items[0]["tmdb_id"] == 95396
+
+
+import json
+
+
+def test_ensure_user_store_creates_tables(tmp_path):
+    db = str(tmp_path / "test.db")
+    feedback_path = str(tmp_path / "feedback.json")
+    from recommender.user_store import ensure_user_store
+
+    ensure_user_store(db, feedback_path)
+
+    import sqlite3
+    conn = sqlite3.connect(db)
+    tables = {
+        row[0] for row in
+        conn.execute("SELECT name FROM sqlite_master WHERE type='table'").fetchall()
+    }
+    conn.close()
+    assert "saved_titles" in tables
+
+
+def test_ensure_user_store_migrates_feedback_json(tmp_path):
+    db = str(tmp_path / "test.db")
+    feedback_path = str(tmp_path / "feedback.json")
+    Path(feedback_path).write_text(json.dumps({
+        "ratings": [
+            {"title": "Show A", "rating": "liked", "content_type": "tv",
+             "timestamp": "2026-01-15T10:30:00+00:00"},
+            {"title": "Show B", "rating": "disliked", "timestamp": "2026-02-01T08:00:00+00:00",
+             "content_type": "movie"},
+        ],
+        "additions": [
+            {"title": "Movie X", "content_type": "movie", "timestamp": "2026-03-01T12:00:00+00:00"},
+        ],
+    }))
+
+    from recommender.user_store import ensure_user_store, load_ratings, list_manual_archive
+
+    ensure_user_store(db, feedback_path)
+
+    ratings = load_ratings(db)
+    assert len(ratings) == 2
+    assert any(r["title"] == "Show A" and r["rating"] == "liked" for r in ratings)
+
+    archive = list_manual_archive(db)
+    assert len(archive) == 1
+    assert archive[0]["source"] == "feedback_migration"
+    assert archive[0]["watched_at"] == "2026-03-01T12:00:00+00:00"
+
+    # feedback.json should be renamed
+    assert not Path(feedback_path).exists()
+    assert Path(feedback_path + ".migrated").exists()
+
+
+def test_ensure_user_store_rejects_untyped_feedback_when_type_cannot_be_inferred(tmp_path):
+    db = str(tmp_path / "test.db")
+    feedback_path = str(tmp_path / "feedback.json")
+    Path(feedback_path).write_text(json.dumps({
+        "ratings": [
+            {"title": "Unknown Title", "rating": "liked", "timestamp": "2026-01-15T10:30:00+00:00"},
+        ],
+        "additions": [],
+    }))
+
+    from recommender.user_store import ensure_user_store
+
+    with pytest.raises(ValueError, match="content type"):
+        ensure_user_store(db, feedback_path)
+
+
+def test_ensure_user_store_skips_if_already_migrated(tmp_path):
+    db = str(tmp_path / "test.db")
+    feedback_path = str(tmp_path / "feedback.json")
+
+    from recommender.user_store import ensure_user_store
+
+    # First migration
+    Path(feedback_path).write_text(json.dumps({"ratings": [], "additions": []}))
+    ensure_user_store(db, feedback_path)
+
+    # Calling again with no feedback.json should be fine
+    ensure_user_store(db, feedback_path)
+
+
+def test_ensure_user_store_errors_if_json_exists_but_tables_have_rows(tmp_path):
+    db = str(tmp_path / "test.db")
+    feedback_path = str(tmp_path / "feedback.json")
+
+    from recommender.user_store import init_db, rate_title, ensure_user_store
+
+    # Create tables and add a row manually (simulating prior user-store writes)
+    init_db(db)
+    rate_title(db, "Existing", "tv", "liked")
+
+    # Now place a feedback.json (simulating incomplete migration)
+    Path(feedback_path).write_text(json.dumps({
+        "ratings": [{"title": "New", "rating": "liked", "content_type": "tv",
+                     "timestamp": "2026-01-01T00:00:00+00:00"}],
+        "additions": [],
+    }))
+
+    with pytest.raises(RuntimeError, match="already contain"):
+        ensure_user_store(db, feedback_path)
+
+
+def test_ensure_user_store_retries_rename_if_marker_set(tmp_path):
+    """If migration marker exists but feedback.json was not renamed, retry only the rename."""
+    db = str(tmp_path / "test.db")
+    feedback_path = str(tmp_path / "feedback.json")
+
+    from recommender.user_store import init_db, ensure_user_store
+
+    init_db(db)
+
+    # Set migration marker manually
+    import sqlite3
+    conn = sqlite3.connect(db)
+    conn.execute(
+        "INSERT INTO user_store_meta (key, value) VALUES ('feedback_migrated', '1')"
+    )
+    conn.commit()
+    conn.close()
+
+    # feedback.json still exists (rename failed last time)
+    Path(feedback_path).write_text(json.dumps({"ratings": [], "additions": []}))
+    ensure_user_store(db, feedback_path)
+
+    # Should have renamed without re-importing
+    assert not Path(feedback_path).exists()
+    assert Path(feedback_path + ".migrated").exists()

--- a/tests/test_user_store.py
+++ b/tests/test_user_store.py
@@ -1,0 +1,239 @@
+import sqlite3
+from pathlib import Path
+
+import pytest
+
+
+def test_init_creates_tables(tmp_path):
+    db = str(tmp_path / "test.db")
+    from recommender.user_store import init_db
+
+    init_db(db)
+
+    conn = sqlite3.connect(db)
+    tables = {
+        row[0]
+        for row in conn.execute(
+            "SELECT name FROM sqlite_master WHERE type='table'"
+        ).fetchall()
+    }
+    conn.close()
+    assert "saved_titles" in tables
+    assert "title_ratings" in tables
+    assert "manual_archive_entries" in tables
+    assert "user_store_meta" in tables
+
+
+def test_init_is_idempotent(tmp_path):
+    db = str(tmp_path / "test.db")
+    from recommender.user_store import init_db
+
+    init_db(db)
+    init_db(db)  # should not raise
+
+
+def test_save_title_creates_watchlist_entry(tmp_path):
+    db = str(tmp_path / "test.db")
+    from recommender.user_store import init_db, save_title, list_saved_titles
+
+    init_db(db)
+    save_title(db, "Breaking Bad", "tv", tmdb_id=1396)
+
+    items = list_saved_titles(db, status="watchlist")
+    assert len(items) == 1
+    assert items[0]["title"] == "Breaking Bad"
+    assert items[0]["content_type"] == "tv"
+    assert items[0]["tmdb_id"] == 1396
+    assert items[0]["status"] == "watchlist"
+
+
+def test_save_title_without_tmdb_id(tmp_path):
+    db = str(tmp_path / "test.db")
+    from recommender.user_store import init_db, save_title, list_saved_titles
+
+    init_db(db)
+    save_title(db, "Some Obscure Show", "tv")
+
+    items = list_saved_titles(db)
+    assert len(items) == 1
+    assert items[0]["tmdb_id"] is None
+
+
+def test_save_title_upserts_on_tmdb_id(tmp_path):
+    db = str(tmp_path / "test.db")
+    from recommender.user_store import init_db, save_title, list_saved_titles
+
+    init_db(db)
+    save_title(db, "Breaking Bad", "tv", tmdb_id=1396)
+    save_title(db, "Breaking Bad (2008)", "tv", tmdb_id=1396)  # same tmdb_id
+
+    items = list_saved_titles(db)
+    assert len(items) == 1
+    assert items[0]["title"] == "Breaking Bad (2008)"  # updated
+
+
+def test_save_title_upserts_on_normalized_title_when_no_tmdb(tmp_path):
+    db = str(tmp_path / "test.db")
+    from recommender.user_store import init_db, save_title, list_saved_titles
+
+    init_db(db)
+    save_title(db, "Some Show", "tv")
+    save_title(db, "Some Show", "tv")  # same normalized title
+
+    items = list_saved_titles(db)
+    assert len(items) == 1
+
+
+def test_dismiss_title(tmp_path):
+    db = str(tmp_path / "test.db")
+    from recommender.user_store import init_db, save_title, dismiss_title, list_saved_titles
+
+    init_db(db)
+    save_title(db, "Breaking Bad", "tv", tmdb_id=1396)
+    dismiss_title(db, "Breaking Bad", "tv", tmdb_id=1396)
+
+    items = list_saved_titles(db, status="watchlist")
+    assert len(items) == 0
+    dismissed = list_saved_titles(db, status="dismissed")
+    assert len(dismissed) == 1
+
+
+def test_save_dismissed_title_flips_to_watchlist(tmp_path):
+    db = str(tmp_path / "test.db")
+    from recommender.user_store import init_db, dismiss_title, save_title, list_saved_titles
+
+    init_db(db)
+    dismiss_title(db, "Breaking Bad", "tv", tmdb_id=1396)
+    save_title(db, "Breaking Bad", "tv", tmdb_id=1396)
+
+    items = list_saved_titles(db)
+    assert len(items) == 1
+    assert items[0]["status"] == "watchlist"
+
+
+def test_remove_saved_title(tmp_path):
+    db = str(tmp_path / "test.db")
+    from recommender.user_store import init_db, save_title, remove_saved_title, list_saved_titles
+
+    init_db(db)
+    save_title(db, "Breaking Bad", "tv", tmdb_id=1396)
+    remove_saved_title(db, "Breaking Bad", "tv")
+
+    assert list_saved_titles(db) == []
+
+
+def test_list_saved_titles_filters_by_status(tmp_path):
+    db = str(tmp_path / "test.db")
+    from recommender.user_store import init_db, save_title, dismiss_title, list_saved_titles
+
+    init_db(db)
+    save_title(db, "Show A", "tv")
+    dismiss_title(db, "Show B", "tv")
+
+    assert len(list_saved_titles(db, status="watchlist")) == 1
+    assert len(list_saved_titles(db, status="dismissed")) == 1
+    assert len(list_saved_titles(db)) == 2
+
+
+def test_rate_title(tmp_path):
+    db = str(tmp_path / "test.db")
+    from recommender.user_store import init_db, rate_title, load_ratings
+
+    init_db(db)
+    rate_title(db, "Breaking Bad", "tv", "liked", tmdb_id=1396)
+
+    ratings = load_ratings(db)
+    assert len(ratings) == 1
+    assert ratings[0]["title"] == "Breaking Bad"
+    assert ratings[0]["rating"] == "liked"
+
+
+def test_rate_title_replaces_previous(tmp_path):
+    db = str(tmp_path / "test.db")
+    from recommender.user_store import init_db, rate_title, load_ratings
+
+    init_db(db)
+    rate_title(db, "Breaking Bad", "tv", "liked", tmdb_id=1396)
+    rate_title(db, "Breaking Bad", "tv", "disliked", tmdb_id=1396)
+
+    ratings = load_ratings(db)
+    assert len(ratings) == 1
+    assert ratings[0]["rating"] == "disliked"
+
+
+def test_rate_title_clear_removes_rating(tmp_path):
+    db = str(tmp_path / "test.db")
+    from recommender.user_store import init_db, rate_title, load_ratings
+
+    init_db(db)
+    rate_title(db, "Breaking Bad", "tv", "liked", tmdb_id=1396)
+    rate_title(db, "Breaking Bad", "tv", "clear", tmdb_id=1396)
+
+    assert load_ratings(db) == []
+
+
+def test_get_disliked_titles(tmp_path):
+    db = str(tmp_path / "test.db")
+    from recommender.user_store import init_db, rate_title, get_disliked_titles
+
+    init_db(db)
+    rate_title(db, "Show A", "tv", "liked")
+    rate_title(db, "Show B", "tv", "disliked")
+    rate_title(db, "Movie C", "movie", "disliked")
+
+    disliked = get_disliked_titles(db)
+    assert sorted(disliked) == ["Movie C", "Show B"]
+
+
+def test_apply_rating_multipliers(tmp_path):
+    db = str(tmp_path / "test.db")
+    from recommender.user_store import init_db, rate_title, load_ratings, apply_rating_multipliers
+
+    init_db(db)
+    rate_title(db, "Show A", "tv", "liked")
+    rate_title(db, "Show B", "tv", "disliked")
+
+    scores = {"Show A": 0.8, "Show B": 0.8, "Show C": 0.5}
+    ratings = load_ratings(db)
+    result = apply_rating_multipliers(scores, ratings)
+    assert result["Show A"] == min(1.0, 0.8 * 1.3)
+    assert result["Show B"] == 0.8 * 0.5
+    assert result["Show C"] == 0.5  # unrated, unchanged
+
+
+def test_add_to_archive(tmp_path):
+    db = str(tmp_path / "test.db")
+    from recommender.user_store import init_db, add_to_archive, list_manual_archive
+
+    init_db(db)
+    add_to_archive(db, "The Bear", "tv", tmdb_id=194583, source="web")
+
+    items = list_manual_archive(db)
+    assert len(items) == 1
+    assert items[0]["title"] == "The Bear"
+    assert items[0]["source"] == "web"
+
+
+def test_add_to_archive_upserts_on_tmdb_id(tmp_path):
+    db = str(tmp_path / "test.db")
+    from recommender.user_store import init_db, add_to_archive, list_manual_archive
+
+    init_db(db)
+    add_to_archive(db, "The Bear", "tv", tmdb_id=194583)
+    add_to_archive(db, "The Bear (2022)", "tv", tmdb_id=194583)
+
+    items = list_manual_archive(db)
+    assert len(items) == 1
+    assert items[0]["title"] == "The Bear (2022)"
+
+
+def test_add_to_archive_without_tmdb_id(tmp_path):
+    db = str(tmp_path / "test.db")
+    from recommender.user_store import init_db, add_to_archive, list_manual_archive
+
+    init_db(db)
+    add_to_archive(db, "Obscure Film", "movie")
+
+    items = list_manual_archive(db)
+    assert len(items) == 1
+    assert items[0]["tmdb_id"] is None

--- a/tests/test_user_store.py
+++ b/tests/test_user_store.py
@@ -116,9 +116,14 @@ def test_remove_saved_title(tmp_path):
     from recommender.user_store import init_db, save_title, remove_saved_title, list_saved_titles
 
     init_db(db)
+    # With tmdb_id: removal uses TMDB-first matching
     save_title(db, "Breaking Bad", "tv", tmdb_id=1396)
-    remove_saved_title(db, "Breaking Bad", "tv")
+    remove_saved_title(db, "Breaking Bad", "tv", tmdb_id=1396)
+    assert list_saved_titles(db) == []
 
+    # Without tmdb_id: removal matches only rows where tmdb_id IS NULL
+    save_title(db, "Some Show", "tv")
+    remove_saved_title(db, "Some Show", "tv")
     assert list_saved_titles(db) == []
 
 

--- a/tests/test_user_store.py
+++ b/tests/test_user_store.py
@@ -227,6 +227,18 @@ def test_add_to_archive_upserts_on_tmdb_id(tmp_path):
     assert items[0]["title"] == "The Bear (2022)"
 
 
+def test_remove_saved_title_does_not_affect_dismissed(tmp_path):
+    db = str(tmp_path / "test.db")
+    from recommender.user_store import init_db, dismiss_title, remove_saved_title, list_saved_titles
+
+    init_db(db)
+    dismiss_title(db, "Breaking Bad", "tv", tmdb_id=1396)
+    remove_saved_title(db, "Breaking Bad", "tv")  # should be no-op
+
+    dismissed = list_saved_titles(db, status="dismissed")
+    assert len(dismissed) == 1  # dismissed entry still present
+
+
 def test_add_to_archive_without_tmdb_id(tmp_path):
     db = str(tmp_path / "test.db")
     from recommender.user_store import init_db, add_to_archive, list_manual_archive

--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -647,3 +647,23 @@ class TestArchiveRoutes:
         })
         assert resp.status_code == 200
         assert load_ratings(db) == []
+
+
+def test_history_includes_manual_archive_entries(client, tmp_path, monkeypatch):
+    from recommender.user_store import init_db, add_to_archive
+    from unittest.mock import MagicMock, patch
+
+    db = str(tmp_path / "test.db")
+    init_db(db)
+    add_to_archive(db, "Manual Show", "tv", source="web")
+    monkeypatch.setattr("config.EVENT_DB_PATH", db)
+    monkeypatch.setattr("config.FEEDBACK_PATH", str(tmp_path / "feedback.json"))
+
+    mock_ctx = MagicMock()
+    mock_ctx.watch_index.entries = []
+
+    with patch("recommender.web._get_context", return_value=mock_ctx):
+        resp = client.get("/history")
+
+    assert resp.status_code == 200
+    assert b"Manual Show" in resp.data

--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -518,3 +518,132 @@ class TestEventStoreStatus:
         assert payload["status"] == "ok"
         assert payload["event_store_ready"] is False
         assert payload["event_store_import_count"] == 0
+
+
+class TestWatchlistRoutes:
+
+    def test_save_to_watchlist(self, client, tmp_path, monkeypatch):
+        from recommender.user_store import init_db, list_saved_titles
+
+        db = str(tmp_path / "test.db")
+        init_db(db)
+        monkeypatch.setattr("config.EVENT_DB_PATH", db)
+        monkeypatch.setattr("config.FEEDBACK_PATH", str(tmp_path / "feedback.json"))
+
+        resp = client.post("/watchlist/save", data={
+            **_csrf_form(),
+            "title": "Breaking Bad",
+            "content_type": "tv",
+        })
+        assert resp.status_code == 200
+        items = list_saved_titles(db, status="watchlist")
+        assert len(items) == 1
+
+    def test_dismiss_title(self, client, tmp_path, monkeypatch):
+        from recommender.user_store import init_db, save_title, list_saved_titles
+
+        db = str(tmp_path / "test.db")
+        init_db(db)
+        save_title(db, "Bad Show", "tv")
+        monkeypatch.setattr("config.EVENT_DB_PATH", db)
+        monkeypatch.setattr("config.FEEDBACK_PATH", str(tmp_path / "feedback.json"))
+
+        resp = client.post("/watchlist/dismiss", data={
+            **_csrf_form(),
+            "title": "Bad Show",
+            "content_type": "tv",
+        })
+        assert resp.status_code == 200
+        assert len(list_saved_titles(db, status="dismissed")) == 1
+
+    def test_remove_from_watchlist(self, client, tmp_path, monkeypatch):
+        from recommender.user_store import init_db, save_title, list_saved_titles
+
+        db = str(tmp_path / "test.db")
+        init_db(db)
+        save_title(db, "Some Show", "tv")
+        monkeypatch.setattr("config.EVENT_DB_PATH", db)
+        monkeypatch.setattr("config.FEEDBACK_PATH", str(tmp_path / "feedback.json"))
+
+        resp = client.post("/watchlist/remove", data={
+            **_csrf_form(),
+            "title": "Some Show",
+            "content_type": "tv",
+        })
+        assert resp.status_code == 200
+        assert list_saved_titles(db) == []
+
+    def test_mark_watched_returns_rating_prompt(self, client, tmp_path, monkeypatch):
+        from recommender.user_store import init_db, save_title, list_manual_archive
+
+        db = str(tmp_path / "test.db")
+        init_db(db)
+        save_title(db, "The Wire", "tv")
+        monkeypatch.setattr("config.EVENT_DB_PATH", db)
+        monkeypatch.setattr("config.FEEDBACK_PATH", str(tmp_path / "feedback.json"))
+
+        resp = client.post("/watchlist/watched", data={
+            **_csrf_form(),
+            "title": "The Wire",
+            "content_type": "tv",
+        })
+        assert resp.status_code == 200
+        assert len(list_manual_archive(db)) == 1
+        # Response should contain rating prompt
+        assert b"liked" in resp.data or b"thumbs" in resp.data.lower()
+
+
+class TestArchiveRoutes:
+
+    def test_add_to_archive(self, client, tmp_path, monkeypatch):
+        from recommender.user_store import init_db, list_manual_archive
+
+        db = str(tmp_path / "test.db")
+        init_db(db)
+        monkeypatch.setattr("config.EVENT_DB_PATH", db)
+        monkeypatch.setattr("config.FEEDBACK_PATH", str(tmp_path / "feedback.json"))
+
+        resp = client.post("/archive/add", data={
+            **_csrf_form(),
+            "title": "The Bear",
+            "content_type": "tv",
+        })
+        assert resp.status_code == 200
+        assert len(list_manual_archive(db)) == 1
+
+    def test_rate_archive_title(self, client, tmp_path, monkeypatch):
+        from recommender.user_store import init_db, load_ratings
+
+        db = str(tmp_path / "test.db")
+        init_db(db)
+        monkeypatch.setattr("config.EVENT_DB_PATH", db)
+        monkeypatch.setattr("config.FEEDBACK_PATH", str(tmp_path / "feedback.json"))
+
+        resp = client.post("/archive/rate", data={
+            **_csrf_form(),
+            "title": "Breaking Bad",
+            "content_type": "tv",
+            "rating": "liked",
+        })
+        assert resp.status_code == 200
+        ratings = load_ratings(db)
+        assert len(ratings) == 1
+        assert ratings[0]["rating"] == "liked"
+
+    def test_clear_rating(self, client, tmp_path, monkeypatch):
+        from recommender.user_store import init_db, rate_title, load_ratings
+
+        db = str(tmp_path / "test.db")
+        init_db(db)
+        rate_title(db, "Breaking Bad", "tv", "liked")
+        monkeypatch.setattr("config.EVENT_DB_PATH", db)
+        monkeypatch.setattr("config.FEEDBACK_PATH", str(tmp_path / "feedback.json"))
+
+        resp = client.post("/archive/rate", data={
+            **_csrf_form(),
+            "title": "Breaking Bad",
+            "content_type": "tv",
+            "rating": "clear",
+        })
+        assert resp.status_code == 200
+        assert load_ratings(db) == []

--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -649,6 +649,83 @@ class TestArchiveRoutes:
         assert load_ratings(db) == []
 
 
+class TestRenderedState:
+
+    def test_watchlist_badge_count(self, client, tmp_path, monkeypatch):
+        from recommender.user_store import init_db, save_title
+
+        db = str(tmp_path / "test.db")
+        init_db(db)
+        save_title(db, "Show A", "tv")
+        save_title(db, "Show B", "tv")
+        monkeypatch.setattr("config.EVENT_DB_PATH", db)
+        monkeypatch.setattr("config.FEEDBACK_PATH", str(tmp_path / "feedback.json"))
+
+        resp = client.get("/watchlist")
+        assert resp.status_code == 200
+        # Badge count and items|length both render "2" on the page
+        assert b"2" in resp.data
+
+    def test_watchlist_page_renders_items(self, client, tmp_path, monkeypatch):
+        from recommender.user_store import init_db, save_title
+
+        db = str(tmp_path / "test.db")
+        init_db(db)
+        save_title(db, "Breaking Bad", "tv")
+        monkeypatch.setattr("config.EVENT_DB_PATH", db)
+        monkeypatch.setattr("config.FEEDBACK_PATH", str(tmp_path / "feedback.json"))
+
+        resp = client.get("/watchlist")
+        assert b"Breaking Bad" in resp.data
+        assert b"Watched" in resp.data  # action button present
+        assert b"Won&#39;t watch" in resp.data or b"Won't watch" in resp.data
+
+    def test_archive_rate_shows_thumbs_state(self, client, tmp_path, monkeypatch):
+        from recommender.user_store import init_db, rate_title
+
+        db = str(tmp_path / "test.db")
+        init_db(db)
+        rate_title(db, "Breaking Bad", "tv", "liked")
+        monkeypatch.setattr("config.EVENT_DB_PATH", db)
+        monkeypatch.setattr("config.FEEDBACK_PATH", str(tmp_path / "feedback.json"))
+
+        # Rate endpoint should return the _rating_state partial
+        resp = client.post("/archive/rate", data={
+            **_csrf_form(),
+            "title": "Breaking Bad",
+            "content_type": "tv",
+            "rating": "liked",
+        })
+        assert resp.status_code == 200
+        # Should show the liked state (clear button for liked thumb)
+        assert b"clear" in resp.data
+
+    def test_history_dedup_does_not_double_show_manual_entry(self, client, tmp_path, monkeypatch):
+        """A manual archive entry already in the watch index should not appear twice."""
+        from recommender.user_store import init_db, add_to_archive
+        from unittest.mock import MagicMock, patch
+
+        db = str(tmp_path / "test.db")
+        init_db(db)
+        add_to_archive(db, "Duplicate Show", "tv", source="web")
+        monkeypatch.setattr("config.EVENT_DB_PATH", db)
+        monkeypatch.setattr("config.FEEDBACK_PATH", str(tmp_path / "feedback.json"))
+
+        # Simulate watch index already having the same title
+        mock_ctx = MagicMock()
+        mock_ctx.watch_index.entries = [
+            {"title": "Duplicate Show", "content_type": "tv", "tmdb_id": None}
+        ]
+
+        with patch("recommender.web._get_context", return_value=mock_ctx):
+            resp = client.get("/history")
+
+        assert resp.status_code == 200
+        # hist-1 is the uid for the first item; hist-2 would only appear if there are two items
+        assert b"Duplicate Show" in resp.data
+        assert b"hist-2" not in resp.data  # only one item in the deduped list
+
+
 def test_history_includes_manual_archive_entries(client, tmp_path, monkeypatch):
     from recommender.user_store import init_db, add_to_archive
     from unittest.mock import MagicMock, patch

--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -677,7 +677,7 @@ class TestRenderedState:
 
         resp = client.get("/watchlist")
         assert b"Breaking Bad" in resp.data
-        assert b"Watched" in resp.data  # action button present
+        assert b"Mark as watched" in resp.data  # action button present
         assert b"Won&#39;t watch" in resp.data or b"Won't watch" in resp.data
 
     def test_archive_rate_shows_thumbs_state(self, client, tmp_path, monkeypatch):


### PR DESCRIPTION
## Summary

- Adds watchlist: save titles from search results, mark watched (with optional rating), dismiss (suppress from recommendations), or remove
- Adds archive ratings: thumbs up/down toggle on watched titles, wired into the existing taste profile multipliers
- Adds ad-hoc archive additions: add titles to watch history from the web UI without a fresh provider export
- Migrates liked/disliked ratings and manual additions from `feedback.json` to SQLite (`user_store.py`), with one-time automatic migration on startup
- Wires `UserStateIndex` into the query engine so dismissed and manually-archived titles are excluded from recommendations

## Architecture

New modules:
- `recommender/user_store.py` — SQLite storage with 4 tables, 6 partial unique indexes, atomic compound actions, and feedback migration
- `recommender/user_state.py` — `UserStateIndex` immutable snapshot with TMDB-ID-first matching

New web routes: `GET /watchlist`, `POST /watchlist/save|dismiss|remove|watched`, `POST /archive/add|rate`

New templates: `watchlist.html`, `_rating_prompt.html`, `_rating_state.html`; updated `base.html`, `_results.html`, `history.html`, `title.html`

## Test Plan

- [ ] 262 tests passing (`source venv/bin/activate && python3 -m pytest tests/ -v`)
- [ ] Save a title from search results → appears in `/watchlist`
- [ ] Mark watched from watchlist → rating prompt appears; title moves to archive
- [ ] Dismiss a title → no longer appears in recommendations
- [ ] Rate an archive title → thumbs state updates inline; clicking active thumb clears rating
- [ ] Add a title ad-hoc via `/history` → appears in archive union
- [ ] Watchlist nav badge shows correct count
- [ ] First startup with existing `feedback.json` → auto-migrates, renames to `feedback.json.migrated`
- [ ] `./recommend --liked "Title"` and `./recommend --add "Title" --type tv` write to SQLite