### PR TITLE
fix: enrichment identity keys, brand polish, and review fixes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,64 +1,64 @@
 # Repository Guidelines
 
-## Product Philosophy
-
-Streamline is a personal media system for one owner. Optimize for trust, clarity, and low operational burden over scale, abstraction, or SaaS-style architecture.
-
-The product is the local library, profile, and recommendation quality. Every interface should strengthen that core model rather than compete with it or hide it behind unnecessary automation.
-
-The CLI and web UI are both valid interfaces to the same system. Put each task in the interface that makes it clearer and safer, not the one that looks more "production". Browser-based settings are acceptable when they remain understandable and recoverable.
-
-State-changing or expensive operations must be explicit, observable, and recoverable. Saving a setting, rebuilding derived data, and ingesting watch history are different actions and should not be blurred together.
-
-Convenience features are welcome, but they must not remove the simple fallback path. A user should always be able to understand what happened, inspect the local state, and recover with a direct command.
-
-Use progressive enhancement, not dependency layering. HTMX, JavaScript, background jobs, and deployment packaging may improve the experience, but core workflows must continue to work when optional layers fail.
-
-Do not add infrastructure or complexity unless it materially improves the single-user experience. Prefer the simplest design that keeps behavior predictable and the system easy to operate.
-
 ## Project Structure & Module Organization
 
-Core application code lives in `recommender/`. Key areas:
-- `recommender/ingestion/` parses provider exports and manual lists.
-- `recommender/query_engine.py`, `tmdb_client.py`, and `taste_profile_builder.py` drive recommendation logic.
-- `recommender/templates/` and `recommender/static/` back the Flask web UI.
-- `recommender/cache/` stores generated artifacts such as `watch_index.json` and `taste_profile.txt`.
+Streamline is a personal Flask and CLI media recommendation app. Core Python code lives in `recommender/`. Query logic is in `recommender/query_engine.py`, TMDB access in `recommender/tmdb_client.py`, enrichment/profile generation in `recommender/enricher.py` and `recommender/taste_profile_builder.py`, and web routes in `recommender/web.py`.
 
-Tests live in `tests/`, with ingestion-specific coverage under `tests/ingestion/`. Entry points are `./recommend` for CLI/setup and `./recommend-web` for the web app. Shared defaults live in `config.yaml`; machine-local overrides belong in `config.local.yaml`.
+Templates live in `recommender/templates/`; generated caches and local artifacts live under `recommender/cache/`, `data/`, and `logs/`. Tests live in `tests/`, with shared test helpers such as `tests/mock_llm.py`.
 
 ## Build, Test, and Development Commands
 
 Use the local virtualenv first:
 
 ```bash
-python3 -m venv venv
 source venv/bin/activate
 pip install -r requirements.txt
 ```
 
 Key commands:
-- `./recommend setup` rebuilds watch history, TMDB enrichment, and taste profile artifacts.
-- `./recommend setup --ingest-only` validates configured provider exports without rebuilding caches.
-- `./recommend "good British crime drama"` runs a CLI recommendation query.
-- `./recommend-web start` launches the Flask UI on `http://localhost:5050`.
-- `pytest -q` runs the full test suite.
+
+```bash
+./recommend setup
+```
+
+Rebuilds watch history, TMDB cache, enrichments, and taste profile.
+
+```bash
+./recommend "good British crime drama"
+```
+
+Runs a CLI recommendation query.
+
+```bash
+./recommend-web start
+```
+
+Starts the Flask web UI on `http://localhost:5050`.
+
+```bash
+python3 -m pytest -q
+```
+
+Runs the full test suite.
 
 ## Coding Style & Naming Conventions
 
-Target Python 3.10+. Use 4-space indentation, type hints where the module already uses them, and `snake_case` for functions, variables, and test names. Keep changes direct and consistent with existing patterns. Prefer editing existing files over adding new ones. Comments should explain intent or constraints, not restate obvious code.
+Target Python 3.10+. Use 4-space indentation, `snake_case` for functions and variables, and direct, descriptive names. Match existing module patterns before introducing new abstractions. Prefer simple functions over framework-heavy designs. Comments should explain intent or constraints, not restate obvious code.
+
+Do not use emoji in code, documentation, templates, or test fixtures.
 
 ## Testing Guidelines
 
-Pytest is the test framework. Name tests `test_<behavior>()` and keep provider-parser coverage in `tests/ingestion/`. When changing ingestion or setup logic, run the affected subset first, then `pytest -q`. For user-facing query or web changes, add or update tests in `tests/test_main.py` and related modules.
+Pytest is the test framework. Name tests `test_<behavior>()` and keep them close to the module behavior they verify. Use real SQLite temp files for persistence tests when possible. For web changes, update `tests/test_web.py`; for recommendation behavior, update `tests/test_query_engine.py` or `tests/test_main.py`.
+
+Run focused tests first, then `python3 -m pytest -q` before merging.
 
 ## Commit & Pull Request Guidelines
 
-Recent history uses conventional prefixes such as `feat:`, `fix:`, and `refactor:` with imperative summaries. Keep commits scoped to one logical change. PRs should include:
-- a concise summary of behavior changes
-- validation commands and results
-- config or migration notes if setup behavior changes
-- screenshots only for visible web UI changes
+Recent history uses concise imperative commits with prefixes such as `feat:`, `fix:`, and `refactor:`. Keep each commit scoped to one logical change.
+
+Pull requests should include a short summary, validation commands with results, migration or cache notes when relevant, and screenshots for visible web UI changes.
 
 ## Security & Configuration Tips
 
-Never commit secrets or personal watch-history paths. Keep API keys in the environment or `.env`, and keep machine-specific provider zips in `config.local.yaml`, not `config.yaml`.
+Do not commit secrets, personal provider exports, or machine-local paths. Keep local overrides in `config.local.yaml` or environment variables. Use `config.local.example.yaml` as the public reference for configuration shape.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## What This Is
 
-Streamline is a personal streaming recommendation engine. It ingests real watch history (Netflix, Prime Video, manual lists), enriches titles via TMDB and LLM, builds a full taste profile from all watched content, then answers natural language queries using hybrid candidate generation (TMDB Discover + LLM semantic suggestions). Supports Anthropic (Claude) and Google (Gemini) as LLM providers.
+Streamline is a personal streaming recommendation engine. It ingests real watch history (Netflix, Prime Video, Apple TV, manual lists), enriches titles via TMDB and LLM, builds a full taste profile from all watched content, then answers natural language queries using hybrid candidate generation (TMDB Discover + LLM semantic suggestions). Supports Anthropic (Claude), Google (Gemini), and OpenAI as LLM providers.
 
 ## Product Philosophy
 
@@ -65,7 +65,7 @@ Two-phase LLM pipeline. LLM calls use roles ("fast" for enrichment, "reason" for
 - `recommender/ingestion/` — Platform parsers. Manual titles use `datetime.now()` for competitive scoring.
 - `recommender/tmdb_client.py` — Metadata lookup with guessit title classification, title cleanup fallback (strips suffixes, tries alternate content type), discover endpoint (page-limited), watch providers.
 - `recommender/watch_index.py` — Content-type-aware dual-key dedup (TMDB ID + `(normalized_title, content_type)`). Post-build rapidfuzz dedup. Stale cache cleanup.
-- `recommender/enricher.py` — LLM enrichment (role=fast), 30s timeout, rate limit retry. Only caches successful responses.
+- `recommender/enricher.py` — LLM enrichment (role=fast), 30s timeout, rate limit retry. Only caches successful responses. Identity-keyed index (`content_type/tmdb_id` or `unknown/slug`).
 - `recommender/taste_profile_builder.py` — Batched profile builder (200 titles/batch, rate limit retry, merge pass). No top-N limit.
 - `recommender/signals.py` — Scoring: completion (50%) + rewatch (30%) + true half-life recency decay (20%).
 - `recommender/query_engine.py` — Full online pipeline. "Why not X?" trace mode, conversational context, platform filtering.
@@ -73,7 +73,7 @@ Two-phase LLM pipeline. LLM calls use roles ("fast" for enrichment, "reason" for
 - `recommender/feedback.py` — (Deprecated) Original JSON-based feedback storage. Migrated to `user_store.py` SQLite tables.
 - `recommender/user_store.py` — SQLite storage for watchlist (`saved_titles`), ratings (`title_ratings`), and manual archive additions (`manual_archive_entries`). Migration from `feedback.json`.
 - `recommender/user_state.py` — `UserStateIndex` snapshot for TMDB-ID-first matching in query filtering and UI rendering.
-- `recommender/web.py` — Flask web UI with HTMX search, poster grid, taste profile clusters.
+- `recommender/web.py` — Flask web UI with HTMX search, poster grid, taste profile clusters, watchlist management (save/unsave/export CSV), search history with user state.
 - `recommender/main.py` — Rich CLI with spinners, panels, stderr/stdout separation, REPL with inline feedback, usage stats.
 
 ### Data Models
@@ -83,7 +83,7 @@ Two-phase LLM pipeline. LLM calls use roles ("fast" for enrichment, "reason" for
 - `UsageStats` — accumulated token counts and cost per query
 
 ### Cache Layout
-All under `recommender/cache/`: `tmdb/`, `enrichments/` (+ index.json), `providers/`, `watch_index.json`, `taste_profile.txt` (+ timestamped backups), `feedback.json`. User-managed state (watchlist, ratings, manual archive) lives in the same SQLite database as imported watch events (`events.db`).
+All under `recommender/cache/`: `tmdb/`, `enrichments/` (+ identity-keyed index.json), `providers/`, `watch_index.json`, `taste_profile.txt` (+ timestamped backups), `feedback.json`. User-managed state (watchlist, ratings, manual archive) lives in the same SQLite database as imported watch events (`events.db`).
 
 ## Configuration
 

--- a/README.md
+++ b/README.md
@@ -18,14 +18,14 @@
 
 <p align="center">
   <img src="https://img.shields.io/badge/python-3.10+-blue?logo=python&logoColor=white" alt="Python 3.10+">
-  <img src="https://img.shields.io/badge/LLM-Claude%20%7C%20Gemini-blueviolet" alt="LLM Support">
+  <img src="https://img.shields.io/badge/LLM-Claude%20%7C%20Gemini%20%7C%20OpenAI-blueviolet" alt="LLM Support">
   <img src="https://img.shields.io/badge/tests-86%20passing-brightgreen" alt="Tests">
   <img src="https://img.shields.io/badge/license-MIT-green" alt="License">
 </p>
 
 ---
 
-Streamline ingests your real watch history from Netflix, Prime Video, and manual lists, enriches every title via TMDB and LLM, builds a detailed taste profile from *all* your watched content, then answers natural-language queries using hybrid candidate generation. No generic "top 10" lists — recommendations are calibrated to *your* patterns.
+Streamline ingests your real watch history from Netflix, Prime Video, Apple TV, and manual lists, enriches every title via TMDB and LLM, builds a detailed taste profile from *all* your watched content, then answers natural-language queries using hybrid candidate generation. No generic "top 10" lists — recommendations are calibrated to *your* patterns.
 
 <p align="center">
   <img src="docs/screenshot-hero.png" width="720" alt="Streamline in action">
@@ -36,8 +36,8 @@ Streamline ingests your real watch history from Netflix, Prime Video, and manual
 - **Natural language search** — "paranoid spy thriller like The Night Manager", "feel-good Bollywood comedy", "why not Slow Horses?"
 - **Taste profile** — built from your entire watch history (2000+ titles), organized into 15+ genre clusters with deep analysis
 - **Hybrid candidate generation** — TMDB Discover (structured filters) + LLM semantic suggestions (creative matches)
-- **Multi-provider LLM** — Anthropic (Claude) and Google (Gemini) with role-based model dispatch (fast/reason)
-- **Web UI** — Flask + HTMX with editorial design: search, taste profile dashboard, poster archive, search history, settings
+- **Multi-provider LLM** — Anthropic (Claude), Google (Gemini), and OpenAI with role-based model dispatch (fast/reason)
+- **Web UI** — Flask + HTMX with editorial design: search, taste profile dashboard, poster archive, watchlist management, search history, settings
 - **Rich CLI** — interactive REPL, conversational context ("more like that"), feedback system, usage/cost tracking
 - **Streaming availability** — annotated results with platform filtering (Netflix, Prime, etc.)
 - **Quality filters** — configurable minimum rating, release year, and vote count
@@ -138,8 +138,9 @@ Each query prints token usage and estimated cost at the end.
 
 The web UI includes:
 - **Home** — natural language search with HTMX, suggestion pills, recent searches
-- **Searches** — expandable history of past queries with cached results
-- **Archive** — full watch history with poster grid, list, and compact views
+- **Searches** — expandable history of past queries with cached results and watchlist actions
+- **Archive** — full watch history with poster grid, list, and compact views; sortable A-Z/Z-A
+- **Watchlist** — save/unsave titles from any page, CSV export
 - **Settings** — edit all configuration from the browser with live reload
 - **Help** — built-in usage guide
 
@@ -158,7 +159,7 @@ Settings live in a few places:
 
 ```yaml
 # config.yaml
-provider: anthropic                    # or "gemini"
+provider: anthropic                    # or "gemini" or "openai"
 
 models:
   anthropic:
@@ -167,6 +168,9 @@ models:
   gemini:
     fast: gemini-2.5-flash
     reason: gemini-2.5-pro
+  openai:
+    fast: gpt-4.1-mini
+    reason: gpt-4.1
 ```
 
 Switch providers by changing `provider:` in config or per-query with `--provider gemini`.
@@ -208,7 +212,7 @@ All shared settings in `config.yaml`:
 **LLM:**
 | Setting | Default | Description |
 |---------|---------|-------------|
-| `provider` | anthropic | LLM provider ("anthropic" or "gemini") |
+| `provider` | anthropic | LLM provider ("anthropic", "gemini", or "openai") |
 | `models.*` | (see above) | Model assignments per provider (fast/reason roles) |
 | `llm.timeout_*` | 30-300s | Per-call-type timeouts |
 | `llm.tokens_*` | 200-16000 | Per-call-type max output tokens |

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -100,6 +100,8 @@ This prevents cross-media false matches (watching the TV show "Fargo" won't bloc
 
 Calls Claude Haiku to generate 2-3 sentence semantic descriptions per title. Only successful LLM responses are cached — fallback descriptions (keyword strings) are not persisted, allowing retry on subsequent runs.
 
+The enrichment index (`index.json`) uses identity keys: `content_type/tmdb_id` for resolved titles (e.g. `tv/12345`) and `unknown/slug` for unresolved ones. A `_title_keyed_enrichments()` bridge in `setup.py` converts identity keys back to display titles for the taste profile builder.
+
 ### Taste Profile Builder (`recommender/taste_profile_builder.py`)
 
 Processes ALL enriched titles (no limit) in batches of 200. Each batch produces a mini taste profile, then a merge pass consolidates them into one document covering every taste cluster. Includes rate limit retry with backoff.
@@ -108,13 +110,19 @@ Previous profiles are auto-backed up with timestamps before rebuild.
 
 Negative preferences from the feedback system are included in the prompt, generating a "What you don't enjoy" section.
 
-### Feedback (`recommender/feedback.py`)
+### User Store (`recommender/user_store.py`)
 
-Persists user feedback at `recommender/cache/feedback.json`:
+SQLite storage (`events.db`) for user-managed state:
 
-- **Liked/disliked ratings** — applied as score multipliers (1.3x liked, 0.5x disliked) during profile rebuild
-- **Title additions** — added to watch history with current timestamp
+- **Watchlist** (`saved_titles` with status `watchlist`) — save/unsave from any UI page, CSV export
+- **Dismissed** (`saved_titles` with status `dismissed`) — excluded from recommendations
+- **Ratings** (`title_ratings`) — liked/disliked, applied as score multipliers during profile rebuild
+- **Manual archive** (`manual_archive_entries`) — titles added via CLI or web UI
 - Disliked titles inform negative preference prompting in the taste profile
+
+All lookups use TMDB-ID-first matching with normalized-title fallback. `UserStateIndex` (in `user_state.py`) provides a read-only snapshot for fast matching in query filtering and UI rendering.
+
+Note: `recommender/feedback.py` is deprecated. The original JSON-based feedback was migrated to the SQLite tables above.
 
 ### Query Engine (`recommender/query_engine.py`)
 
@@ -142,9 +150,12 @@ The online pipeline:
 
 Flask app serving:
 - `/` — Home: search bar (HTMX-powered), taste profile clusters (expandable, markdown-rendered), archive poster wall
-- `/history` — Watch archive with switchable views (list, poster grid, compact). Search + type filter.
+- `/history` — Watch archive with switchable views (list, poster grid, compact). Search + type filter + A-Z/Z-A sort.
 - `/title/:id` — Title detail with poster, TMDB overview, AI analysis, credits, keywords, TMDB link
 - `/recommend` — Standalone discover page
+- `/watchlist` — Saved titles with TMDB ratings, CSV export via `/watchlist/export`
+- `/watchlist/save`, `/watchlist/unsave` — HTMX toggle endpoints for inline save/unsave from any page
+- `/searches` — Query history with user state badges (watchlist, archived, dismissed) per result
 
 ### LLM Abstraction (`recommender/llm.py`)
 
@@ -184,7 +195,7 @@ recommender/cache/
     tv/{tmdb_id}.txt
     movie/{tmdb_id}.txt
     unknown/{slug}.txt
-    index.json                   title -> description index
+    index.json                   identity-keyed description index (content_type/tmdb_id -> text)
   providers/
     {content_type}/{region}/{tmdb_id}.json
   profile_batches/               Intermediate batch profiles (auto-cleaned after merge)

--- a/recommender/enricher.py
+++ b/recommender/enricher.py
@@ -9,12 +9,43 @@ from .tmdb_client import TmdbMetadata
 
 log = logging.getLogger("recommender.enricher")
 
+_IDENTITY_KEY_RE = re.compile(r"^(tv|movie)/[0-9]+$")
+_UNKNOWN_KEY_RE = re.compile(r"^unknown/[a-z0-9-]+$")
+
+
+def _slug(title: str) -> str:
+    return re.sub(r"[^a-z0-9]+", "-", title.lower()).strip("-")
+
+
+def enrichment_key(metadata: TmdbMetadata) -> str:
+    return enrichment_key_from_parts(
+        metadata.content_type,
+        metadata.tmdb_id,
+        metadata.title,
+    )
+
+
+def enrichment_key_from_parts(
+    content_type: str | None,
+    tmdb_id: int | None,
+    title: str,
+) -> str:
+    if tmdb_id is not None and content_type in ("tv", "movie"):
+        return f"{content_type}/{tmdb_id}"
+    return f"unknown/{_slug(title)}"
+
+
+def is_identity_enrichment_key(key: str) -> bool:
+    return bool(_IDENTITY_KEY_RE.match(key) or _UNKNOWN_KEY_RE.match(key))
+
+
+def is_identity_enrichment_index(enrichments: dict[str, str]) -> bool:
+    return all(is_identity_enrichment_key(k) for k in enrichments)
+
 
 def _cache_path(metadata: TmdbMetadata, cache_dir: str) -> Path:
-    if metadata.tmdb_id:
-        return Path(cache_dir) / metadata.content_type / f"{metadata.tmdb_id}.txt"
-    slug = re.sub(r'[^a-z0-9]+', '-', metadata.title.lower()).strip('-')
-    return Path(cache_dir) / 'unknown' / f"{slug}.txt"
+    key = enrichment_key(metadata)
+    return Path(cache_dir) / f"{key}.txt"
 
 
 def _fallback_description(metadata: TmdbMetadata) -> str:
@@ -88,7 +119,7 @@ def enrich_batch(
     for i, (title, metadata) in enumerate(titles_metadata.items()):
         cache_path = _cache_path(metadata, cache_dir)
         needs_api = not cache_path.exists()
-        result[title] = enrich(metadata, cache_dir, client)
+        result[enrichment_key(metadata)] = enrich(metadata, cache_dir, client)
         if needs_api and throttle:
             api_calls += 1
             time.sleep(throttle)

--- a/recommender/enricher.py
+++ b/recommender/enricher.py
@@ -30,7 +30,7 @@ def enrichment_key_from_parts(
     tmdb_id: int | None,
     title: str,
 ) -> str:
-    if tmdb_id is not None and content_type in ("tv", "movie"):
+    if tmdb_id and content_type in ("tv", "movie"):
         return f"{content_type}/{tmdb_id}"
     return f"unknown/{_slug(title)}"
 

--- a/recommender/ingestion/base.py
+++ b/recommender/ingestion/base.py
@@ -17,6 +17,7 @@ class WatchEvent:
     total_duration: timedelta | None   # filled by TMDB lookup
     timestamp: datetime
     profile: str
+    release_year_hint: int | None = None  # source year for TMDB matching
 
 
 def classify_title(title: str) -> tuple[str, str]:

--- a/recommender/ingestion/manual.py
+++ b/recommender/ingestion/manual.py
@@ -51,6 +51,8 @@ def parse(tv_path: str, movies_path: str) -> list[WatchEvent]:
             raw = line.strip()
             if not raw:
                 continue
+            year_match = _YEAR_RE.search(raw)
+            year_hint = int(year_match.group().strip()) if year_match else None
             title = _strip_year(raw)
             if not title or title in seen_movies:
                 continue
@@ -64,6 +66,7 @@ def parse(tv_path: str, movies_path: str) -> list[WatchEvent]:
                 total_duration=movie_duration,
                 timestamp=timestamp,
                 profile='',
+                release_year_hint=year_hint,
             ))
 
     return events

--- a/recommender/query_engine.py
+++ b/recommender/query_engine.py
@@ -7,7 +7,7 @@ from typing import Callable
 
 import config
 
-from .enricher import enrich, enrich_batch
+from .enricher import enrich, enrich_batch, enrichment_key
 from .ingestion.base import WatchEvent
 from .llm import LLMClient
 from .models import Recommendation
@@ -227,7 +227,7 @@ def rank_candidates(
     meta_by_title = {c.title: c for c in candidates}
 
     cands_str = '\n'.join(
-        f"{i+1}. {c.title} (rating: {c.vote_average:.1f}): {enrichments.get(c.title, ' '.join(c.genres))}"
+        f"{i+1}. {c.title} (rating: {c.vote_average:.1f}): {enrichments.get(enrichment_key(c), ' '.join(c.genres))}"
         for i, c in enumerate(candidates)
     )
     log.debug("Candidate list sent to ranker:\n%s", cands_str)

--- a/recommender/setup.py
+++ b/recommender/setup.py
@@ -15,8 +15,13 @@ from recommender.ingestion.prime import parse as parse_prime
 from recommender.ingestion.apple_tv import parse as parse_apple_tv
 from recommender.ingestion.manual import parse as parse_manual
 from recommender.signals import compute_scores
-from recommender.tmdb_client import TmdbClient
-from recommender.enricher import enrich_batch
+from recommender.tmdb_client import TmdbClient, TmdbMetadata
+from recommender.enricher import (
+    enrich_batch,
+    enrichment_key,
+    enrichment_key_from_parts,
+    is_identity_enrichment_index,
+)
 from recommender.taste_profile_builder import build as build_taste_profile
 from recommender.llm import create_client
 from recommender import watch_index as wi
@@ -41,6 +46,39 @@ def _compute_file_sha256(path: str) -> str:
         while chunk := f.read(8192):
             h.update(chunk)
     return h.hexdigest()
+
+
+def _title_keyed_enrichments(
+    raw_enrichments: dict[str, str],
+    watch_entries: list[dict],
+    metadata: dict[str, TmdbMetadata],
+) -> dict[str, str]:
+    """Return the title-keyed view expected by taste_profile_builder.build()."""
+    if not is_identity_enrichment_index(raw_enrichments):
+        return raw_enrichments
+
+    title_keyed: dict[str, str] = {}
+
+    # Works in refresh-profile-only mode, where metadata may be empty but watch_index exists.
+    for entry in watch_entries:
+        title = entry.get("title", "")
+        if not title:
+            continue
+        key = enrichment_key_from_parts(
+            entry.get("content_type"),
+            entry.get("tmdb_id"),
+            title,
+        )
+        if key in raw_enrichments:
+            title_keyed[title] = raw_enrichments[key]
+
+    # Works in refresh-data mode, where metadata has just been rebuilt.
+    for title, meta in metadata.items():
+        key = enrichment_key(meta)
+        if key in raw_enrichments:
+            title_keyed[title] = raw_enrichments[key]
+
+    return title_keyed
 
 
 def _load_platform_events_by_provider(
@@ -217,7 +255,9 @@ def run_setup(refresh_profile: bool = False, refresh_data: bool = False, provide
 
     if not refresh_data and index_path.exists():
         console.print("\nWatch index exists, skipping data fetch (use --refresh-data to rebuild).")
-        enrichments = json.loads(enrichments_index_path.read_text()) if enrichments_index_path.exists() else {}
+        raw_enrichments = json.loads(enrichments_index_path.read_text()) if enrichments_index_path.exists() else {}
+        index = wi.load(config.WATCH_INDEX_PATH)
+        enrichments = _title_keyed_enrichments(raw_enrichments, index.entries, metadata)
     else:
         console.print("\nFetching TMDB metadata...")
         tmdb = TmdbClient(api_key=config.TMDB_API_KEY, cache_dir=config.CACHE_DIR)
@@ -316,9 +356,11 @@ def run_setup(refresh_profile: bool = False, refresh_data: bool = False, provide
                           f"{removed['providers']} provider files)")
 
         with console.status(f"[bold magenta]Enriching {len(metadata)} titles with Claude Haiku...[/bold magenta]", spinner="dots"):
-            enrichments = enrich_batch(metadata, config.ENRICHMENT_CACHE_DIR, llm)
-        enrichments_index_path.write_text(json.dumps(enrichments))
-        console.print(f"  {len(enrichments)} descriptions cached → {config.ENRICHMENT_CACHE_DIR}")
+            raw_enrichments = enrich_batch(metadata, config.ENRICHMENT_CACHE_DIR, llm)
+        enrichments_index_path.write_text(json.dumps(raw_enrichments))
+        console.print(f"  {len(raw_enrichments)} descriptions cached → {config.ENRICHMENT_CACHE_DIR}")
+
+        enrichments = _title_keyed_enrichments(raw_enrichments, index.entries, metadata)
 
     profile_path = Path(config.TASTE_PROFILE_PATH)
     if refresh_profile or not profile_path.exists():

--- a/recommender/setup.py
+++ b/recommender/setup.py
@@ -51,9 +51,12 @@ def _compute_file_sha256(path: str) -> str:
 def _title_keyed_enrichments(
     raw_enrichments: dict[str, str],
     watch_entries: list[dict],
-    metadata: dict[str, TmdbMetadata],
+    metadata: dict,
 ) -> dict[str, str]:
-    """Return the title-keyed view expected by taste_profile_builder.build()."""
+    """Return the title-keyed view expected by taste_profile_builder.build().
+
+    metadata may be keyed by title string or (title, content_type) tuple.
+    """
     if not is_identity_enrichment_index(raw_enrichments):
         return raw_enrichments
 
@@ -73,10 +76,11 @@ def _title_keyed_enrichments(
             title_keyed[title] = raw_enrichments[key]
 
     # Works in refresh-data mode, where metadata has just been rebuilt.
-    for title, meta in metadata.items():
+    for meta_key, meta in metadata.items():
+        display_title = meta_key[0] if isinstance(meta_key, tuple) else meta_key
         key = enrichment_key(meta)
         if key in raw_enrichments:
-            title_keyed[title] = raw_enrichments[key]
+            title_keyed[display_title] = raw_enrichments[key]
 
     return title_keyed
 
@@ -267,10 +271,10 @@ def run_setup(refresh_profile: bool = False, refresh_data: bool = False, provide
         if title_overrides:
             console.print(f"  Loaded {len(title_overrides)} title overrides")
 
-        title_type: dict[str, str] = {}
+        title_type: dict[tuple[str, str], str] = {}
         for e in events:
             key = e.series_name if e.content_type == 'tv' else e.title
-            title_type[key] = e.content_type
+            title_type[(key, e.content_type)] = e.content_type
 
         # Apply overrides: collect skips and content_type corrections
         skip_titles: set[str] = set()
@@ -297,12 +301,12 @@ def run_setup(refresh_profile: bool = False, refresh_data: bool = False, provide
             title_type = {}
             for e in events:
                 key = e.series_name if e.content_type == 'tv' else e.title
-                title_type[key] = e.content_type
+                title_type[(key, e.content_type)] = e.content_type
 
         metadata = {}
         skipped = len(skip_titles)
         with console.status("[bold magenta]Fetching TMDB metadata...[/bold magenta]", spinner="dots"):
-            for i, (title, ct) in enumerate(title_type.items()):
+            for i, ((title, _), ct) in enumerate(title_type.items()):
                 if title in skip_titles:
                     continue
                 # Check overrides
@@ -314,23 +318,23 @@ def run_setup(refresh_profile: bool = False, refresh_data: bool = False, provide
                     if override.get("tmdb_id"):
                         cached = tmdb._load_cache(ct, override["tmdb_id"])
                         if cached:
-                            metadata[title] = tmdb._parse_metadata(cached, ct)
+                            metadata[(title, ct)] = tmdb._parse_metadata(cached, ct)
                         else:
                             try:
                                 data = tmdb._fetch_details(override["tmdb_id"], ct)
                                 tmdb._save_cache(ct, override["tmdb_id"], data)
-                                metadata[title] = tmdb._parse_metadata(data, ct)
+                                metadata[(title, ct)] = tmdb._parse_metadata(data, ct)
                             except Exception as exc:
                                 log.warning("Override TMDB fetch failed for %s (ID %d): %s",
                                             title, override["tmdb_id"], exc)
                     else:
                         meta = tmdb.get_metadata(search_title, ct)
                         if meta:
-                            metadata[title] = meta
+                            metadata[(title, ct)] = meta
                 else:
                     meta = tmdb.get_metadata(title, ct)
                     if meta:
-                        metadata[title] = meta
+                        metadata[(title, ct)] = meta
                 if (i + 1) % 50 == 0:
                     console.print(f"  {i+1}/{len(title_type)} titles processed...")
         console.print(f"  {len(metadata)} titles with TMDB metadata")

--- a/recommender/setup.py
+++ b/recommender/setup.py
@@ -2,6 +2,7 @@ import argparse
 import hashlib
 import json
 import logging
+import re
 import sys
 from pathlib import Path
 
@@ -15,7 +16,7 @@ from recommender.ingestion.prime import parse as parse_prime
 from recommender.ingestion.apple_tv import parse as parse_apple_tv
 from recommender.ingestion.manual import parse as parse_manual
 from recommender.signals import compute_scores
-from recommender.tmdb_client import TmdbClient, TmdbMetadata
+from recommender.tmdb_client import TmdbClient, TmdbMetadata, MatchHints
 from recommender.enricher import (
     enrich_batch,
     enrichment_key,
@@ -85,10 +86,84 @@ def _title_keyed_enrichments(
     return title_keyed
 
 
-def _audit_cache_mismatches(index, cache_dir: str) -> None:
-    """Report watch-index entries whose TMDB cache is under the wrong content type."""
+def _normalize_audit_title(title: str) -> str:
+    title = title.lower()
+    title = re.sub(r'\s*\([^)]*\)', '', title)
+    return title.strip()
+
+
+def _cache_title(cache_path: Path) -> str:
+    try:
+        raw = json.loads(cache_path.read_text())
+    except (OSError, json.JSONDecodeError) as exc:
+        log.debug("Unable to inspect TMDB cache %s: %s", cache_path, exc)
+        return ""
+    return raw.get("name") or raw.get("title") or ""
+
+
+def _titles_are_compatible(index_title: str, cache_title: str) -> bool:
+    index_norm = _normalize_audit_title(index_title)
+    cache_norm = _normalize_audit_title(cache_title)
+    if not index_norm or not cache_norm:
+        return False
+    if index_norm == cache_norm:
+        return True
+    if len(cache_norm) < 4:
+        return False
+    return cache_norm in index_norm
+
+
+def _build_hints_map(events: list) -> dict[tuple[str, str], MatchHints]:
+    """Build per-title MatchHints from source event data."""
+    hints_map: dict[tuple[str, str], MatchHints] = {}
+    for e in events:
+        key_title = e.series_name if e.content_type == 'tv' else e.title
+        map_key = (key_title, e.content_type)
+        if map_key in hints_map:
+            continue
+
+        release_year = getattr(e, 'release_year_hint', None)
+
+        runtime_minutes = None
+        runtime_is_exact = False
+
+        if e.platform == 'apple_tv' and e.total_duration:
+            runtime_minutes = int(e.total_duration.total_seconds() / 60)
+            runtime_is_exact = True
+        elif e.platform in ('netflix', 'prime') and e.content_type == 'movie':
+            if e.watched_duration and e.watched_duration.total_seconds() >= 3600:
+                runtime_minutes = int(e.watched_duration.total_seconds() / 60)
+                runtime_is_exact = False
+        # Do not use manual default durations as runtime hints (they are synthetic)
+
+        if release_year or runtime_minutes:
+            hints_map[map_key] = MatchHints(
+                release_year=release_year,
+                runtime_minutes=runtime_minutes,
+                runtime_is_exact=runtime_is_exact,
+            )
+
+    return hints_map
+
+
+def _audit_cache_mismatches(
+    index, cache_dir: str, hints_map: dict | None = None,
+) -> None:
+    """Report watch-index entries whose TMDB cache is suspicious.
+
+    Checks: content-type mismatch, title mismatch, year mismatch,
+    runtime mismatch, and weak matches (no poster, zero votes).
+    """
+    if hints_map is None:
+        hints_map = {}
+
     mismatched = []
+    title_mismatches = []
+    year_mismatches = []
+    runtime_mismatches = []
+    weak_matches = []
     missing = []
+
     for e in index.entries:
         tmdb_id = e.get("tmdb_id")
         ct = e.get("content_type", "movie")
@@ -96,7 +171,51 @@ def _audit_cache_mismatches(index, cache_dir: str) -> None:
             continue
         cache_path = Path(cache_dir) / ct / f"{tmdb_id}.json"
         if cache_path.exists():
+            try:
+                raw = json.loads(cache_path.read_text())
+            except (OSError, json.JSONDecodeError):
+                continue
+
+            cache_title = raw.get("name") or raw.get("title") or ""
+            if cache_title and not _titles_are_compatible(e["title"], cache_title):
+                title_mismatches.append((e["title"], ct, tmdb_id, cache_title))
+
+            # Year mismatch check
+            hints = hints_map.get((e["title"], ct))
+            if hints and hints.release_year:
+                date_str = raw.get("first_air_date") if ct == "tv" else raw.get("release_date")
+                if date_str and len(date_str) >= 4:
+                    cache_year = int(date_str[:4])
+                    if abs(cache_year - hints.release_year) > 2:
+                        year_mismatches.append((
+                            e["title"], ct, tmdb_id, cache_title,
+                            hints.release_year, cache_year,
+                        ))
+
+            # Runtime mismatch check
+            if hints and hints.runtime_minutes:
+                if ct == "tv":
+                    runtimes = raw.get("episode_run_time", [])
+                    cache_runtime = runtimes[0] if runtimes else None
+                else:
+                    cache_runtime = raw.get("runtime")
+                if cache_runtime and cache_runtime > 0 and hints.runtime_minutes > 0:
+                    ratio = min(cache_runtime, hints.runtime_minutes) / max(cache_runtime, hints.runtime_minutes)
+                    if ratio < 0.7:
+                        runtime_mismatches.append((
+                            e["title"], ct, tmdb_id, cache_title,
+                            hints.runtime_minutes, cache_runtime,
+                        ))
+
+            # Weak match check
+            poster = raw.get("poster_path")
+            vote_count = raw.get("vote_count", 0)
+            popularity = raw.get("popularity", 0)
+            if not poster and vote_count == 0 and popularity < 2:
+                weak_matches.append((e["title"], ct, tmdb_id, cache_title))
+
             continue
+
         alt_ct = "movie" if ct == "tv" else "tv"
         alt_path = Path(cache_dir) / alt_ct / f"{tmdb_id}.json"
         if alt_path.exists():
@@ -104,13 +223,31 @@ def _audit_cache_mismatches(index, cache_dir: str) -> None:
         else:
             missing.append((e["title"], ct, tmdb_id))
 
-    if mismatched:
-        console.print(f"\n  [yellow]{len(mismatched)} entries with content-type cache mismatch "
-                      f"(consider adding overrides):[/yellow]")
-        for title, idx_ct, cache_ct, tid in mismatched[:10]:
-            console.print(f"    {title} — index says {idx_ct}, cache at {cache_ct}/{tid}")
-        if len(mismatched) > 10:
-            console.print(f"    ... and {len(mismatched) - 10} more")
+    def _report(label, items, formatter, limit=10):
+        if not items:
+            return
+        console.print(f"\n  [yellow]{len(items)} {label} (consider adding overrides):[/yellow]")
+        for item in items[:limit]:
+            console.print(f"    {formatter(item)}")
+        if len(items) > limit:
+            console.print(f"    ... and {len(items) - limit} more")
+
+    _report("content-type cache mismatches",
+            mismatched,
+            lambda x: f"{x[0]} — index says {x[1]}, cache at {x[2]}/{x[3]}")
+    _report("title mismatches",
+            title_mismatches,
+            lambda x: f"{x[0]} -> {x[1]}/{x[2]} cached as {x[3]}")
+    _report("year mismatches",
+            year_mismatches,
+            lambda x: f"{x[0]} -> {x[1]}/{x[2]} ({x[3]}): source year {x[4]}, cached year {x[5]}")
+    _report("runtime mismatches (>30% off)",
+            runtime_mismatches,
+            lambda x: f"{x[0]} -> {x[1]}/{x[2]} ({x[3]}): source {x[4]}min, cached {x[5]}min")
+    _report("weak TMDB matches (no poster, zero votes)",
+            weak_matches,
+            lambda x: f"{x[0]} -> {x[1]}/{x[2]} ({x[3]})")
+
     if missing:
         log.debug("%d entries with no TMDB cache at all", len(missing))
 
@@ -333,6 +470,9 @@ def run_setup(refresh_profile: bool = False, refresh_data: bool = False, provide
                 key = e.series_name if e.content_type == 'tv' else e.title
                 title_type[(key, e.content_type)] = e.content_type
 
+        # Build source hints for TMDB candidate ranking
+        hints_map = _build_hints_map(events)
+
         metadata = {}
         skipped = len(skip_titles)
         with console.status("[bold magenta]Fetching TMDB metadata...[/bold magenta]", spinner="dots"):
@@ -358,11 +498,13 @@ def run_setup(refresh_profile: bool = False, refresh_data: bool = False, provide
                                 log.warning("Override TMDB fetch failed for %s (ID %d): %s",
                                             title, override["tmdb_id"], exc)
                     else:
-                        meta = tmdb.get_metadata(search_title, ct)
+                        hints = hints_map.get((title, ct))
+                        meta = tmdb.get_metadata(search_title, ct, hints=hints)
                         if meta:
                             metadata[(title, ct)] = meta
                 else:
-                    meta = tmdb.get_metadata(title, ct)
+                    hints = hints_map.get((title, ct))
+                    meta = tmdb.get_metadata(title, ct, hints=hints)
                     if meta:
                         metadata[(title, ct)] = meta
                 if (i + 1) % 50 == 0:
@@ -381,7 +523,7 @@ def run_setup(refresh_profile: bool = False, refresh_data: bool = False, provide
         ov.report_unmatched(unmatched, config.OVERRIDES_PATH)
 
         # Audit: report cache mismatches (wrong TMDB match candidates)
-        _audit_cache_mismatches(index, config.CACHE_DIR)
+        _audit_cache_mismatches(index, config.CACHE_DIR, hints_map)
 
         # Clean up stale cache files for removed/deduped entries
         removed = wi.cleanup_stale_cache(index, config.ENRICHMENT_CACHE_DIR, config.PROVIDERS_CACHE_DIR)

--- a/recommender/setup.py
+++ b/recommender/setup.py
@@ -85,6 +85,36 @@ def _title_keyed_enrichments(
     return title_keyed
 
 
+def _audit_cache_mismatches(index, cache_dir: str) -> None:
+    """Report watch-index entries whose TMDB cache is under the wrong content type."""
+    mismatched = []
+    missing = []
+    for e in index.entries:
+        tmdb_id = e.get("tmdb_id")
+        ct = e.get("content_type", "movie")
+        if not tmdb_id:
+            continue
+        cache_path = Path(cache_dir) / ct / f"{tmdb_id}.json"
+        if cache_path.exists():
+            continue
+        alt_ct = "movie" if ct == "tv" else "tv"
+        alt_path = Path(cache_dir) / alt_ct / f"{tmdb_id}.json"
+        if alt_path.exists():
+            mismatched.append((e["title"], ct, alt_ct, tmdb_id))
+        else:
+            missing.append((e["title"], ct, tmdb_id))
+
+    if mismatched:
+        console.print(f"\n  [yellow]{len(mismatched)} entries with content-type cache mismatch "
+                      f"(consider adding overrides):[/yellow]")
+        for title, idx_ct, cache_ct, tid in mismatched[:10]:
+            console.print(f"    {title} — index says {idx_ct}, cache at {cache_ct}/{tid}")
+        if len(mismatched) > 10:
+            console.print(f"    ... and {len(mismatched) - 10} more")
+    if missing:
+        log.debug("%d entries with no TMDB cache at all", len(missing))
+
+
 def _load_platform_events_by_provider(
     fail_on_error: bool = True,
     emit_console: bool = True,
@@ -349,6 +379,9 @@ def run_setup(refresh_profile: bool = False, refresh_data: bool = False, provide
         # Report unmatched titles
         unmatched = [e for e in index.entries if not e.get("tmdb_id")]
         ov.report_unmatched(unmatched, config.OVERRIDES_PATH)
+
+        # Audit: report cache mismatches (wrong TMDB match candidates)
+        _audit_cache_mismatches(index, config.CACHE_DIR)
 
         # Clean up stale cache files for removed/deduped entries
         removed = wi.cleanup_stale_cache(index, config.ENRICHMENT_CACHE_DIR, config.PROVIDERS_CACHE_DIR)

--- a/recommender/signals.py
+++ b/recommender/signals.py
@@ -9,7 +9,7 @@ from .tmdb_client import TmdbMetadata
 
 def compute_scores(
     events: list[WatchEvent],
-    metadata: dict[str, TmdbMetadata],
+    metadata: dict[str | tuple[str, str], TmdbMetadata],
     recency_half_life_days: int = 90,
 ) -> dict[str, float]:
     """
@@ -27,7 +27,7 @@ def compute_scores(
     scores: dict[str, float] = {}
     for key, evts in grouped.items():
         content_type = evts[0].content_type
-        meta = metadata.get(key)
+        meta = metadata.get((key, content_type)) or metadata.get(key)
 
         # Runtime
         if meta and meta.runtime_minutes:

--- a/recommender/templates/base.html
+++ b/recommender/templates/base.html
@@ -78,11 +78,26 @@
       border-bottom: 1px solid var(--border);
     }
     .nav-brand {
-      font-family: 'DM Serif Display', serif;
-      font-size: 1.15rem;
-      color: var(--text);
-      letter-spacing: 0.04em;
+      display: inline-flex;
+      align-items: center;
+      gap: 0.45rem;
       text-decoration: none;
+      font-family: 'DM Serif Display', serif;
+      font-size: 1.18rem;
+      letter-spacing: 0.01em;
+    }
+    .nav-brand img {
+      height: 21px;
+      width: 21px;
+      border-radius: 4px;
+      opacity: 0.92;
+      flex-shrink: 0;
+    }
+    .nav-brand:hover { text-decoration: none; }
+    .nav-brand-word { color: var(--text); }
+    .nav-brand-word em {
+      font-style: italic;
+      color: var(--teal);
     }
     .nav-link {
       font-family: 'JetBrains Mono', monospace;
@@ -280,7 +295,10 @@
 <body>
 
   <nav>
-    <a href="/" class="nav-brand"><img src="/static/logo.png" alt="Streamline" style="height:22px; width:22px; vertical-align:middle; margin-right:0.4rem; border-radius:3px;">Streamline</a>
+    <a href="/" class="nav-brand">
+      <img src="/static/logo.png" alt="">
+      <span class="nav-brand-word">Stream<em>line</em></span>
+    </a>
     <div class="nav-group" style="margin-left:0.5rem;">
       <a href="/" class="nav-link {% if request.path == '/' %}active{% endif %}">Home</a>
       <a href="/searches" class="nav-link {% if request.path == '/searches' %}active{% endif %}">Searches</a>

--- a/recommender/tmdb_client.py
+++ b/recommender/tmdb_client.py
@@ -4,6 +4,7 @@ import re
 import shutil
 import time
 from dataclasses import dataclass, field
+from difflib import SequenceMatcher
 from pathlib import Path
 
 import requests
@@ -46,6 +47,35 @@ class TmdbMetadata:
     release_year: int | None = None
 
 
+@dataclass
+class MatchHints:
+    """Source hints for ranking TMDB search candidates."""
+    release_year: int | None = None
+    runtime_minutes: int | None = None
+    runtime_is_exact: bool = False
+
+
+def _normalize_for_match(s: str) -> str:
+    """Lowercase, strip articles and punctuation for title comparison."""
+    s = s.lower().strip()
+    s = re.sub(r'^(the|a|an)\s+', '', s)
+    s = re.sub(r'[^\w\s]', '', s)
+    return s.strip()
+
+
+def _title_similarity(query: str, candidate: str) -> float:
+    """Score 0.0-1.0 for how well the candidate title matches the query."""
+    nq = _normalize_for_match(query)
+    nc = _normalize_for_match(candidate)
+    if nq == nc:
+        return 1.0
+    ratio = SequenceMatcher(None, nq, nc).ratio()
+    # Bonus for containment
+    if nq in nc or nc in nq:
+        ratio = max(ratio, 0.85)
+    return ratio
+
+
 class TmdbClient:
     def __init__(self, api_key: str, cache_dir: str = "recommender/cache/tmdb"):
         self.api_key = api_key
@@ -83,6 +113,144 @@ class TmdbClient:
             return None
         results = data.get("results", [])
         return results[0]["id"] if results else None
+
+    def _search_candidates(
+        self, title: str, content_type: str, hints: MatchHints | None = None,
+    ) -> list[dict]:
+        """Return up to 5 TMDB search results. Uses year hint when available."""
+        endpoint = "search/tv" if content_type == "tv" else "search/movie"
+        params: dict = {"query": title}
+
+        # Try year-hinted search first
+        if hints and hints.release_year:
+            year_param = "first_air_date_year" if content_type == "tv" else "primary_release_year"
+            hinted_params = {**params, year_param: hints.release_year}
+            try:
+                data = self._get(endpoint, hinted_params)
+                results = data.get("results", [])[:5]
+                if results:
+                    return results
+            except Exception as exc:
+                log.debug("TMDB hinted search error for %r: %s", title, exc)
+
+        # Fall back to unhinted search
+        try:
+            data = self._get(endpoint, params)
+            return data.get("results", [])[:5]
+        except Exception as exc:
+            log.debug("TMDB search error for %r (%s): %s", title, content_type, exc)
+            return []
+
+    def _score_candidate(
+        self, candidate: dict, title: str, content_type: str,
+        hints: MatchHints | None = None, details: dict | None = None,
+    ) -> float:
+        """Score a TMDB search result. Higher is better."""
+        score = 0.0
+
+        # Title similarity (0-40 points)
+        cand_title = candidate.get("name") or candidate.get("title") or ""
+        sim = _title_similarity(title, cand_title)
+        score += sim * 40.0
+
+        # Year match (0-25 points)
+        if hints and hints.release_year:
+            date_str = (candidate.get("first_air_date") or
+                        candidate.get("release_date") or "")
+            if date_str and len(date_str) >= 4:
+                cand_year = int(date_str[:4])
+                year_diff = abs(cand_year - hints.release_year)
+                if year_diff == 0:
+                    score += 25.0
+                elif year_diff == 1:
+                    score += 15.0
+                elif year_diff <= 3:
+                    score += 5.0
+                # >3 years off: no bonus
+
+        # Runtime match (0-15 points) - needs details
+        if hints and hints.runtime_minutes and details:
+            if content_type == "tv":
+                runtimes = details.get("episode_run_time", [])
+                cand_runtime = runtimes[0] if runtimes else None
+            else:
+                cand_runtime = details.get("runtime")
+            if cand_runtime and cand_runtime > 0:
+                runtime_ratio = min(cand_runtime, hints.runtime_minutes) / max(cand_runtime, hints.runtime_minutes)
+                if hints.runtime_is_exact:
+                    score += runtime_ratio * 15.0
+                else:
+                    score += runtime_ratio * 8.0
+
+        # Poster present (0-3 points, weak signal)
+        if candidate.get("poster_path"):
+            score += 3.0
+
+        # Popularity/votes as tiebreakers (0-7 points)
+        vote_count = candidate.get("vote_count", 0)
+        if vote_count >= 100:
+            score += 4.0
+        elif vote_count >= 10:
+            score += 2.0
+        popularity = candidate.get("popularity", 0)
+        if popularity >= 20:
+            score += 3.0
+        elif popularity >= 5:
+            score += 1.0
+
+        return score
+
+    def _ranked_search(
+        self, title: str, content_type: str, hints: MatchHints | None = None,
+    ) -> int | None:
+        """Search TMDB and return the best-matching ID using candidate ranking."""
+        candidates = self._search_candidates(title, content_type, hints)
+        if not candidates:
+            return None
+
+        if len(candidates) == 1 and not hints:
+            return candidates[0]["id"]
+
+        # Score candidates, fetching details for top 3 to get runtime
+        scored: list[tuple[float, int, str]] = []
+        for i, cand in enumerate(candidates[:3]):
+            details = None
+            if hints and (hints.runtime_minutes or hints.release_year):
+                cand_id = cand["id"]
+                cached = self._load_cache(content_type, cand_id)
+                if cached:
+                    details = cached
+                else:
+                    try:
+                        details = self._fetch_details(cand_id, content_type)
+                        self._save_cache(content_type, cand_id, details)
+                    except Exception:
+                        pass
+            s = self._score_candidate(cand, title, content_type, hints, details)
+            cand_title = cand.get("name") or cand.get("title") or ""
+            scored.append((s, cand["id"], cand_title))
+
+        # Score remaining candidates without details
+        for cand in candidates[3:]:
+            s = self._score_candidate(cand, title, content_type, hints)
+            cand_title = cand.get("name") or cand.get("title") or ""
+            scored.append((s, cand["id"], cand_title))
+
+        scored.sort(key=lambda x: x[0], reverse=True)
+        best_score, best_id, best_title = scored[0]
+
+        # Log low-confidence selections
+        if best_score < 30.0:
+            log.warning("Low-confidence TMDB match: %r -> %r (id=%d, score=%.1f)",
+                        title, best_title, best_id, best_score)
+        elif len(scored) > 1:
+            second_score = scored[1][0]
+            if best_score - second_score < 5.0:
+                log.debug("Close TMDB match: %r -> %r (%.1f) vs %r (%.1f)",
+                          title, best_title, best_score,
+                          scored[1][2], second_score)
+
+        return best_id
 
     def _fetch_details(self, tmdb_id: int, content_type: str) -> dict:
         endpoint = f"tv/{tmdb_id}" if content_type == "tv" else f"movie/{tmdb_id}"
@@ -216,11 +384,15 @@ class TmdbClient:
             return self._parse_metadata(cached, content_type)
         return None
 
-    def get_metadata(self, title: str, content_type: str) -> TmdbMetadata | None:
+    def get_metadata(
+        self, title: str, content_type: str, hints: MatchHints | None = None,
+    ) -> TmdbMetadata | None:
         """Fetch and cache metadata for a single title. Returns None if not found.
 
         Uses guessit to detect misclassified episodes and tries cleaned
-        title variants if the original search fails.
+        title variants if the original search fails. When hints are provided,
+        ranks candidates by title similarity, year, and runtime instead of
+        blindly taking the first result.
         """
         # Let guessit override content_type if it detects an episode
         detected_type, detected_title = self.classify_title(title)
@@ -231,8 +403,8 @@ class TmdbClient:
 
         alt_type = "tv" if content_type == "movie" else "movie"
         for variant in self._clean_title_variants(title):
-            # Try the requested content type first
-            tmdb_id = self._search(variant, content_type)
+            # Try the requested content type first, with ranked search
+            tmdb_id = self._ranked_search(variant, content_type, hints)
             if tmdb_id is not None:
                 if variant != title:
                     log.debug("TMDB search hit via variant: %r -> %r -> ID %d", title, variant, tmdb_id)
@@ -240,7 +412,7 @@ class TmdbClient:
                     log.debug("TMDB search hit: %r -> ID %d", title, tmdb_id)
                 break
             # Try the alternate content type (misclassified episodes, etc.)
-            tmdb_id = self._search(variant, alt_type)
+            tmdb_id = self._ranked_search(variant, alt_type, hints)
             if tmdb_id is not None:
                 content_type = alt_type
                 log.debug("TMDB search hit via alt type: %r -> %r (%s) -> ID %d", title, variant, alt_type, tmdb_id)

--- a/recommender/watch_index.py
+++ b/recommender/watch_index.py
@@ -21,12 +21,13 @@ def _normalize(title: str) -> str:
 @dataclass
 class WatchIndex:
     tmdb_ids: set[int]
+    tmdb_keys: set[tuple[str, int]]
     normalized_titles: set[tuple[str, str]]
     entries: list[dict]
 
     def is_watched(self, candidate: TmdbMetadata) -> bool:
-        """Check by TMDB ID first; fall back to content-type-aware normalized title match."""
-        if candidate.tmdb_id and candidate.tmdb_id in self.tmdb_ids:
+        """Check by typed TMDB identity first; fall back to content-type-aware normalized title match."""
+        if candidate.tmdb_id and (candidate.content_type, candidate.tmdb_id) in self.tmdb_keys:
             return True
         return (_normalize(candidate.title), candidate.content_type) in self.normalized_titles
 
@@ -34,6 +35,7 @@ class WatchIndex:
 def build(events: list[WatchEvent], metadata: dict[str, TmdbMetadata]) -> WatchIndex:
     """Build exclusion index from watch events. metadata provides TMDB IDs."""
     tmdb_ids: set[int] = set()
+    tmdb_keys: set[tuple[str, int]] = set()
     normalized_titles: set[tuple[str, str]] = set()
     entries: list[dict] = []
     seen_keys: set[str] = set()
@@ -47,37 +49,42 @@ def build(events: list[WatchEvent], metadata: dict[str, TmdbMetadata]) -> WatchI
             seen_keys.add(key)
             meta = metadata.get(key)
             tmdb_id = meta.tmdb_id if meta else 0
+            ct = meta.content_type if meta else e.content_type
             if tmdb_id:
                 tmdb_ids.add(tmdb_id)
+                tmdb_keys.add((ct, tmdb_id))
             entries.append({
                 "tmdb_id": tmdb_id,
                 "title": key,
-                "content_type": e.content_type,
+                "content_type": ct,
             })
 
-    index = WatchIndex(tmdb_ids=tmdb_ids, normalized_titles=normalized_titles, entries=entries)
+    index = WatchIndex(tmdb_ids=tmdb_ids, tmdb_keys=tmdb_keys,
+                       normalized_titles=normalized_titles, entries=entries)
     return deduplicate(index)
 
 
 def deduplicate(index: WatchIndex) -> WatchIndex:
-    """Merge near-duplicate entries using TMDB ID and fuzzy title matching.
+    """Merge near-duplicate entries using typed TMDB identity and fuzzy title matching.
 
-    1. Entries with the same TMDB ID are merged (keep first occurrence).
+    1. Entries with the same (content_type, tmdb_id) are merged (keep first occurrence).
     2. Entries with no TMDB ID are fuzzy-matched against each other (threshold 90).
     """
     from rapidfuzz import fuzz
 
-    # Phase 1: merge by TMDB ID
-    seen_ids: dict[int, int] = {}  # tmdb_id -> index in deduped
+    # Phase 1: merge by typed TMDB identity (content_type, tmdb_id)
+    seen_keys: dict[tuple[str, int], int] = {}
     deduped: list[dict] = []
     for e in index.entries:
         tmdb_id = e.get("tmdb_id", 0)
-        if tmdb_id and tmdb_id in seen_ids:
-            log.debug("Dedup by TMDB ID: %r merged with %r (ID %d)",
-                       e["title"], deduped[seen_ids[tmdb_id]]["title"], tmdb_id)
-            continue
+        ct = e.get("content_type", "movie")
         if tmdb_id:
-            seen_ids[tmdb_id] = len(deduped)
+            typed_key = (ct, tmdb_id)
+            if typed_key in seen_keys:
+                log.debug("Dedup by typed TMDB ID: %r merged with %r (%s/%d)",
+                           e["title"], deduped[seen_keys[typed_key]]["title"], ct, tmdb_id)
+                continue
+            seen_keys[typed_key] = len(deduped)
         deduped.append(e)
 
     # Phase 2: fuzzy dedup for entries without TMDB ID
@@ -105,11 +112,16 @@ def deduplicate(index: WatchIndex) -> WatchIndex:
 
     # Rebuild sets from deduped entries
     tmdb_ids = {e["tmdb_id"] for e in final if e.get("tmdb_id")}
+    tmdb_keys = {
+        (e.get("content_type", "movie"), e["tmdb_id"])
+        for e in final if e.get("tmdb_id")
+    }
     normalized_titles = set()
     for e in final:
         normalized_titles.add((_normalize(e["title"]), e.get("content_type", "movie")))
 
-    return WatchIndex(tmdb_ids=tmdb_ids, normalized_titles=normalized_titles, entries=final)
+    return WatchIndex(tmdb_ids=tmdb_ids, tmdb_keys=tmdb_keys,
+                      normalized_titles=normalized_titles, entries=final)
 
 
 def cleanup_stale_cache(
@@ -209,5 +221,10 @@ def save(index: WatchIndex, path: str) -> None:
 def load(path: str) -> WatchIndex:
     entries = json.loads(Path(path).read_text())
     tmdb_ids = {e["tmdb_id"] for e in entries if e.get("tmdb_id")}
+    tmdb_keys = {
+        (e.get("content_type", "movie"), e["tmdb_id"])
+        for e in entries if e.get("tmdb_id")
+    }
     normalized_titles = {(_normalize(e["title"]), e.get("content_type", "movie")) for e in entries}
-    return WatchIndex(tmdb_ids=tmdb_ids, normalized_titles=normalized_titles, entries=entries)
+    return WatchIndex(tmdb_ids=tmdb_ids, tmdb_keys=tmdb_keys,
+                      normalized_titles=normalized_titles, entries=entries)

--- a/recommender/watch_index.py
+++ b/recommender/watch_index.py
@@ -32,22 +32,28 @@ class WatchIndex:
         return (_normalize(candidate.title), candidate.content_type) in self.normalized_titles
 
 
-def build(events: list[WatchEvent], metadata: dict[str, TmdbMetadata]) -> WatchIndex:
-    """Build exclusion index from watch events. metadata provides TMDB IDs."""
+def build(events: list[WatchEvent], metadata: dict) -> WatchIndex:
+    """Build exclusion index from watch events. metadata provides TMDB IDs.
+
+    metadata may be keyed by title string or by (title, content_type) tuple.
+    Typed keys are checked first to support dual-existence titles (e.g. "Breathe"
+    existing as both TV and movie).
+    """
     tmdb_ids: set[int] = set()
     tmdb_keys: set[tuple[str, int]] = set()
     normalized_titles: set[tuple[str, str]] = set()
     entries: list[dict] = []
-    seen_keys: set[str] = set()
+    seen_keys: set[tuple[str, str]] = set()
 
     for e in events:
         key = e.series_name if e.content_type == 'tv' else e.title
         normalized_titles.add((_normalize(e.title), e.content_type))
         if e.content_type == 'tv':
             normalized_titles.add((_normalize(e.series_name), e.content_type))
-        if key not in seen_keys:
-            seen_keys.add(key)
-            meta = metadata.get(key)
+        dedup_key = (key, e.content_type)
+        if dedup_key not in seen_keys:
+            seen_keys.add(dedup_key)
+            meta = metadata.get((key, e.content_type)) or metadata.get(key)
             tmdb_id = meta.tmdb_id if meta else 0
             ct = meta.content_type if meta else e.content_type
             if tmdb_id:

--- a/recommender/watch_index.py
+++ b/recommender/watch_index.py
@@ -5,6 +5,7 @@ from dataclasses import dataclass
 from pathlib import Path
 
 from .ingestion.base import WatchEvent
+from .enricher import enrichment_key_from_parts, is_identity_enrichment_index
 from .tmdb_client import TmdbMetadata
 
 log = logging.getLogger("recommender.index")
@@ -151,7 +152,22 @@ def cleanup_stale_cache(
     if index_json.exists():
         enrichments = json.loads(index_json.read_text())
         before = len(enrichments)
-        enrichments = {k: v for k, v in enrichments.items() if k in valid_titles}
+        if is_identity_enrichment_index(enrichments):
+            valid_keys = {
+                enrichment_key_from_parts(
+                    e.get("content_type", "movie"),
+                    e.get("tmdb_id"),
+                    e.get("title", ""),
+                )
+                for e in index.entries
+                if e.get("title")
+            }
+            enrichments = {
+                k: v for k, v in enrichments.items()
+                if k in valid_keys or k.startswith("unknown/")
+            }
+        else:
+            enrichments = {k: v for k, v in enrichments.items() if k in valid_titles}
         after = len(enrichments)
         if after < before:
             index_json.write_text(json.dumps(enrichments))

--- a/recommender/web.py
+++ b/recommender/web.py
@@ -389,9 +389,11 @@ def history() -> str:
             "title": e["title"],
             "content_type": e.get("content_type", ""),
             "tmdb_id": e.get("tmdb_id"),
-            "description": enrichments.get(
-                enrichment_key_from_parts(e.get("content_type", "movie"), e.get("tmdb_id"), e["title"]),
-                "",
+            "description": (
+                enrichments.get(
+                    enrichment_key_from_parts(e.get("content_type", "movie"), e.get("tmdb_id"), e["title"]),
+                )
+                or enrichments.get(e["title"], "")
             ),
             "poster": _get_poster_url(e.get("tmdb_id", 0), e.get("content_type", "movie"), "w185")
                       if e.get("tmdb_id") else None,
@@ -509,7 +511,7 @@ def title_detail(tmdb_id: int) -> str:
         description = enrichment_path.read_text()
     elif meta:
         key = enrichment_key_from_parts(ct, tmdb_id, meta.title)
-        description = enrichments.get(key, "")
+        description = enrichments.get(key) or enrichments.get(meta.title, "")
     poster = _get_poster_url(tmdb_id, ct, "w500") if meta else None
     overview = ""
     if meta:

--- a/recommender/web.py
+++ b/recommender/web.py
@@ -167,6 +167,29 @@ def _norm_title(title: str) -> str:
     return title.strip()
 
 
+def _title_matches_legacy_entry(entry_title: str, meta_title: str) -> bool:
+    """Return True when alternate-type metadata is title-compatible with an old index entry."""
+    entry_norm = _norm_title(entry_title)
+    meta_norm = _norm_title(meta_title)
+    if not entry_norm or not meta_norm:
+        return False
+    if entry_norm == meta_norm:
+        return True
+    if len(meta_norm) < 4:
+        return False
+    return meta_norm in entry_norm
+
+
+def _can_use_alternate_title_cache(watch_index, tmdb_id: int, alt_ct: str, alt_title: str) -> bool:
+    """Allow alternate-type title details only for typed or title-compatible legacy entries."""
+    if (alt_ct, tmdb_id) in getattr(watch_index, "tmdb_keys", set()):
+        return True
+    return any(
+        e.get("tmdb_id") == tmdb_id and _title_matches_legacy_entry(e.get("title", ""), alt_title)
+        for e in getattr(watch_index, "entries", [])
+    )
+
+
 def _load_enrichments() -> dict[str, str]:
     index_path = Path(config.ENRICHMENT_CACHE_DIR) / "index.json"
     if index_path.exists():
@@ -514,9 +537,7 @@ def title_detail(tmdb_id: int) -> str:
         except Exception:
             alt_meta = None
         if alt_meta:
-            # Accept if the watch index has this tmdb_id under either type
-            # (old indexes may store the wrong content_type for the ID)
-            if tmdb_id in ctx.watch_index.tmdb_ids:
+            if _can_use_alternate_title_cache(ctx.watch_index, tmdb_id, alt_ct, alt_meta.title):
                 meta = alt_meta
                 ct = alt_ct
 

--- a/recommender/web.py
+++ b/recommender/web.py
@@ -505,6 +505,20 @@ def title_detail(tmdb_id: int) -> str:
     except Exception:
         pass
 
+    # Fallback: if the requested type has no cache, check if the watch index
+    # has this tmdb_id under the alternate type (content-type mismatch fix).
+    if meta is None:
+        alt_ct = "movie" if ct == "tv" else "tv"
+        try:
+            alt_meta = ctx.tmdb_client.get_cached_by_id(tmdb_id, alt_ct)
+        except Exception:
+            alt_meta = None
+        if alt_meta:
+            # Only accept if the watch index actually has an entry for this ID
+            if (alt_ct, tmdb_id) in ctx.watch_index.tmdb_keys:
+                meta = alt_meta
+                ct = alt_ct
+
     description = ""
     enrichment_path = Path(config.ENRICHMENT_CACHE_DIR) / ct / f"{tmdb_id}.txt"
     if enrichment_path.exists():
@@ -523,8 +537,7 @@ def title_detail(tmdb_id: int) -> str:
     state = _title_state(meta.title if meta else "", ct, us, tmdb_id if meta else None)
     # Also count watch-index entries (imported from Netflix/Prime/etc.) as archived
     if not state["in_archive"] and meta:
-        wi_ctx = _get_context()
-        if tmdb_id in wi_ctx.watch_index.tmdb_ids:
+        if (ct, tmdb_id) in ctx.watch_index.tmdb_keys:
             state["in_archive"] = True
     return render_template(
         "title.html", meta=meta, description=description, overview=overview,

--- a/recommender/web.py
+++ b/recommender/web.py
@@ -514,8 +514,9 @@ def title_detail(tmdb_id: int) -> str:
         except Exception:
             alt_meta = None
         if alt_meta:
-            # Only accept if the watch index actually has an entry for this ID
-            if (alt_ct, tmdb_id) in ctx.watch_index.tmdb_keys:
+            # Accept if the watch index has this tmdb_id under either type
+            # (old indexes may store the wrong content_type for the ID)
+            if tmdb_id in ctx.watch_index.tmdb_ids:
                 meta = alt_meta
                 ct = alt_ct
 

--- a/recommender/web.py
+++ b/recommender/web.py
@@ -499,7 +499,12 @@ def title_detail(tmdb_id: int) -> str:
     except Exception:
         pass
 
-    description = enrichments.get(meta.title, "") if meta else ""
+    description = ""
+    enrichment_path = Path(config.ENRICHMENT_CACHE_DIR) / ct / f"{tmdb_id}.txt"
+    if enrichment_path.exists():
+        description = enrichment_path.read_text()
+    elif meta:
+        description = enrichments.get(meta.title, "")
     poster = _get_poster_url(tmdb_id, ct, "w500") if meta else None
     overview = ""
     if meta:

--- a/recommender/web.py
+++ b/recommender/web.py
@@ -27,6 +27,7 @@ from recommender.event_store import load_events
 from recommender.jobs import registry as job_registry
 from recommender.llm import create_client
 from recommender.log import setup_logging
+from recommender.enricher import enrichment_key_from_parts
 from recommender.query_engine import RecommendContext, ask
 from recommender.tmdb_client import TmdbClient
 
@@ -388,7 +389,10 @@ def history() -> str:
             "title": e["title"],
             "content_type": e.get("content_type", ""),
             "tmdb_id": e.get("tmdb_id"),
-            "description": enrichments.get(e["title"], ""),
+            "description": enrichments.get(
+                enrichment_key_from_parts(e.get("content_type", "movie"), e.get("tmdb_id"), e["title"]),
+                "",
+            ),
             "poster": _get_poster_url(e.get("tmdb_id", 0), e.get("content_type", "movie"), "w185")
                       if e.get("tmdb_id") else None,
             "rating": us.get_rating(m),
@@ -504,7 +508,8 @@ def title_detail(tmdb_id: int) -> str:
     if enrichment_path.exists():
         description = enrichment_path.read_text()
     elif meta:
-        description = enrichments.get(meta.title, "")
+        key = enrichment_key_from_parts(ct, tmdb_id, meta.title)
+        description = enrichments.get(key, "")
     poster = _get_poster_url(tmdb_id, ct, "w500") if meta else None
     overview = ""
     if meta:

--- a/tests/ingestion/test_manual.py
+++ b/tests/ingestion/test_manual.py
@@ -96,3 +96,45 @@ def test_skips_blank_lines():
         assert len(events) == 2
     finally:
         os.unlink(tv); os.unlink(movies)
+
+
+def test_release_year_hint_extracted():
+    tv = write_tmp("")
+    movies = write_tmp("Honeyland 2019\n")
+    try:
+        events = parse(tv, movies)
+        assert events[0].title == "Honeyland"
+        assert events[0].release_year_hint == 2019
+    finally:
+        os.unlink(tv); os.unlink(movies)
+
+
+def test_release_year_hint_none_without_year():
+    tv = write_tmp("")
+    movies = write_tmp("Some Movie\n")
+    try:
+        events = parse(tv, movies)
+        assert events[0].release_year_hint is None
+    finally:
+        os.unlink(tv); os.unlink(movies)
+
+
+def test_numeric_title_not_treated_as_year():
+    tv = write_tmp("")
+    movies = write_tmp("1917\n")
+    try:
+        events = parse(tv, movies)
+        assert events[0].title == "1917"
+        assert events[0].release_year_hint is None
+    finally:
+        os.unlink(tv); os.unlink(movies)
+
+
+def test_tv_titles_no_year_hint():
+    tv = write_tmp("Broadchurch\n")
+    movies = write_tmp("")
+    try:
+        events = parse(tv, movies)
+        assert events[0].release_year_hint is None
+    finally:
+        os.unlink(tv); os.unlink(movies)

--- a/tests/test_enricher.py
+++ b/tests/test_enricher.py
@@ -49,7 +49,7 @@ def test_enrich_fallback_on_api_error(tmp_path):
 
 def test_enrich_unknown_title_uses_slug_cache(tmp_path):
     meta = TmdbMetadata(
-        tmdb_id=0, content_type="movie", title="My Unknown Film",
+        tmdb_id=None, content_type="movie", title="My Unknown Film",
         genres=["Drama"], keywords=[], cast=[],
         original_language="en", vote_average=0.0, vote_count=0,
     )
@@ -65,6 +65,36 @@ def test_enrich_batch_skips_failed(tmp_path):
     client = make_mock_llm("")
     client.generate.side_effect = ["Good description.", Exception("fail")]
     result = enrich_batch({"Show A": meta1, "Show B": meta2}, str(tmp_path), client)
-    assert "Show A" in result
-    assert "Show B" in result
-    assert result["Show A"] == "Good description."
+    assert "tv/1" in result
+    assert "tv/2" in result
+    assert result["tv/1"] == "Good description."
+
+
+def test_enrichment_key_for_movie():
+    from recommender.enricher import enrichment_key
+    meta = TmdbMetadata(
+        tmdb_id=601337, content_type="movie", title="83",
+        genres=["Drama"], keywords=[], cast=[],
+        original_language="en", vote_average=0.0, vote_count=0,
+    )
+    assert enrichment_key(meta) == "movie/601337"
+
+
+def test_enrichment_key_from_parts_unknown():
+    from recommender.enricher import enrichment_key_from_parts
+    assert enrichment_key_from_parts("movie", None, "Some Title!") == "unknown/some-title"
+
+
+def test_is_identity_enrichment_index_true():
+    from recommender.enricher import is_identity_enrichment_index
+    assert is_identity_enrichment_index({"movie/601337": "Desc", "tv/1396": "Desc2"})
+
+
+def test_is_identity_enrichment_index_false_for_slash_title():
+    from recommender.enricher import is_identity_enrichment_index
+    assert not is_identity_enrichment_index({"Frost/Nixon": "Desc"})
+
+
+def test_is_identity_enrichment_index_empty():
+    from recommender.enricher import is_identity_enrichment_index
+    assert is_identity_enrichment_index({})

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -973,3 +973,197 @@ def test_add_writes_to_sqlite(tmp_path, monkeypatch):
 
     archive = list_manual_archive(db)
     assert any(a["title"] == "The Bear" for a in archive)
+
+
+def test_cache_audit_reports_existing_cache_with_mismatched_title(tmp_path, capsys):
+    import json
+    import recommender.setup as setup
+    from recommender.watch_index import WatchIndex
+
+    cache_path = tmp_path / "tv" / "55063.json"
+    cache_path.parent.mkdir(parents=True)
+    cache_path.write_text(json.dumps({
+        "id": 55063,
+        "name": "Man on the Moon: The Epic Journey of Apollo 11",
+    }))
+    index = WatchIndex(
+        tmdb_ids={55063},
+        tmdb_keys={("tv", 55063)},
+        normalized_titles={("apollo 11", "tv")},
+        entries=[{"tmdb_id": 55063, "title": "Apollo 11", "content_type": "tv"}],
+    )
+
+    setup._audit_cache_mismatches(index, str(tmp_path))
+
+    err = capsys.readouterr().err
+    assert "Apollo 11" in err
+    assert "Man on the Moon" in err
+
+
+def test_cache_audit_allows_exact_short_title_match(tmp_path, capsys):
+    import json
+    import recommender.setup as setup
+    from recommender.watch_index import WatchIndex
+
+    cache_path = tmp_path / "movie" / "11.json"
+    cache_path.parent.mkdir(parents=True)
+    cache_path.write_text(json.dumps({
+        "id": 11,
+        "title": "Up",
+        "release_date": "2009-05-28",
+    }))
+    index = WatchIndex(
+        tmdb_ids={11},
+        tmdb_keys={("movie", 11)},
+        normalized_titles={("up", "movie")},
+        entries=[{"tmdb_id": 11, "title": "Up", "content_type": "movie"}],
+    )
+
+    setup._audit_cache_mismatches(index, str(tmp_path))
+
+    err = capsys.readouterr().err
+    assert "possible wrong TMDB match" not in err
+    assert "title mismatch" not in err
+
+
+def test_build_hints_map_manual_year():
+    from datetime import datetime, timedelta
+    import recommender.setup as setup
+    from recommender.ingestion.base import WatchEvent
+
+    event = WatchEvent(
+        platform='manual', title='Honeyland', content_type='movie',
+        series_name='Honeyland', watched_duration=timedelta(minutes=120),
+        total_duration=timedelta(minutes=120), timestamp=datetime.now(),
+        profile='', release_year_hint=2019,
+    )
+    hints_map = setup._build_hints_map([event])
+    assert ('Honeyland', 'movie') in hints_map
+    assert hints_map[('Honeyland', 'movie')].release_year == 2019
+
+
+def test_build_hints_map_manual_no_year():
+    from datetime import datetime, timedelta
+    import recommender.setup as setup
+    from recommender.ingestion.base import WatchEvent
+
+    event = WatchEvent(
+        platform='manual', title='Some Movie', content_type='movie',
+        series_name='Some Movie', watched_duration=timedelta(minutes=120),
+        total_duration=timedelta(minutes=120), timestamp=datetime.now(),
+        profile='',
+    )
+    hints_map = setup._build_hints_map([event])
+    assert ('Some Movie', 'movie') not in hints_map
+
+
+def test_build_hints_map_apple_tv_runtime():
+    from datetime import datetime, timedelta
+    import recommender.setup as setup
+    from recommender.ingestion.base import WatchEvent
+
+    event = WatchEvent(
+        platform='apple_tv', title='Test Movie', content_type='movie',
+        series_name='Test Movie', watched_duration=timedelta(minutes=100),
+        total_duration=timedelta(minutes=142), timestamp=datetime.now(),
+        profile='testuser',
+    )
+    hints_map = setup._build_hints_map([event])
+    hints = hints_map[('Test Movie', 'movie')]
+    assert hints.runtime_minutes == 142
+    assert hints.runtime_is_exact is True
+
+
+def test_build_hints_map_manual_duration_not_used():
+    """Manual default durations should not be passed as runtime hints."""
+    from datetime import datetime, timedelta
+    import recommender.setup as setup
+    from recommender.ingestion.base import WatchEvent
+
+    event = WatchEvent(
+        platform='manual', title='Generic Movie', content_type='movie',
+        series_name='Generic Movie', watched_duration=timedelta(minutes=120),
+        total_duration=timedelta(minutes=120), timestamp=datetime.now(),
+        profile='',
+    )
+    hints_map = setup._build_hints_map([event])
+    # No year hint and manual platform -> no hints entry
+    assert ('Generic Movie', 'movie') not in hints_map
+
+
+def test_audit_reports_year_mismatch(tmp_path, capsys):
+    import json
+    import recommender.setup as setup
+    from recommender.watch_index import WatchIndex
+    from recommender.tmdb_client import MatchHints
+
+    cache_path = tmp_path / "movie" / "111.json"
+    cache_path.parent.mkdir(parents=True)
+    cache_path.write_text(json.dumps({
+        "id": 111, "title": "Iceland", "release_date": "1942-01-01",
+        "runtime": 90, "vote_count": 50, "popularity": 5, "poster_path": "/p.jpg",
+    }))
+    index = WatchIndex(
+        tmdb_ids={111},
+        tmdb_keys={("movie", 111)},
+        normalized_titles={("iceland", "movie")},
+        entries=[{"tmdb_id": 111, "title": "Iceland", "content_type": "movie"}],
+    )
+    hints_map = {("Iceland", "movie"): MatchHints(release_year=2016)}
+
+    setup._audit_cache_mismatches(index, str(tmp_path), hints_map)
+
+    err = capsys.readouterr().err
+    assert "year mismatch" in err.lower() or "source year 2016" in err
+
+
+def test_audit_reports_runtime_mismatch(tmp_path, capsys):
+    import json
+    import recommender.setup as setup
+    from recommender.watch_index import WatchIndex
+    from recommender.tmdb_client import MatchHints
+
+    cache_path = tmp_path / "movie" / "555.json"
+    cache_path.parent.mkdir(parents=True)
+    cache_path.write_text(json.dumps({
+        "id": 555, "title": "Hum Tum", "release_date": "2004-05-28",
+        "runtime": 80, "vote_count": 100, "popularity": 10, "poster_path": "/p.jpg",
+    }))
+    index = WatchIndex(
+        tmdb_ids={555},
+        tmdb_keys={("movie", 555)},
+        normalized_titles={("hum tum", "movie")},
+        entries=[{"tmdb_id": 555, "title": "Hum Tum", "content_type": "movie"}],
+    )
+    hints_map = {("Hum Tum", "movie"): MatchHints(runtime_minutes=140, runtime_is_exact=True)}
+
+    setup._audit_cache_mismatches(index, str(tmp_path), hints_map)
+
+    err = capsys.readouterr().err
+    assert "runtime" in err.lower() or "source 140min" in err
+
+
+def test_audit_existing_title_mismatch_still_works(tmp_path, capsys):
+    """Existing title mismatch audit continues to work."""
+    import json
+    import recommender.setup as setup
+    from recommender.watch_index import WatchIndex
+
+    cache_path = tmp_path / "movie" / "700.json"
+    cache_path.parent.mkdir(parents=True)
+    cache_path.write_text(json.dumps({
+        "id": 700, "title": "The King", "release_date": "2019-10-11",
+        "runtime": 140, "vote_count": 2000, "popularity": 50, "poster_path": "/p.jpg",
+    }))
+    index = WatchIndex(
+        tmdb_ids={700},
+        tmdb_keys={("movie", 700)},
+        normalized_titles={("kesari", "movie")},
+        entries=[{"tmdb_id": 700, "title": "Kesari", "content_type": "movie"}],
+    )
+
+    setup._audit_cache_mismatches(index, str(tmp_path))
+
+    err = capsys.readouterr().err
+    assert "Kesari" in err
+    assert "The King" in err

--- a/tests/test_query_engine.py
+++ b/tests/test_query_engine.py
@@ -153,7 +153,7 @@ def test_ask_excludes_watched_titles():
 
     ctx = RecommendContext(
         taste_profile="taste profile text",
-        watch_index=WatchIndex(tmdb_ids={1}, normalized_titles={("broadchurch", "tv")}, entries=[]),
+        watch_index=WatchIndex(tmdb_ids={1}, tmdb_keys={("tv", 1)}, normalized_titles={("broadchurch", "tv")}, entries=[]),
         events=[],
         tmdb_client=mock_tmdb,
         llm=mock_llm,
@@ -173,7 +173,7 @@ def test_recommend_context_events_eager():
     mock_llm = make_mock_llm("")
     ctx = RecommendContext(
         taste_profile="profile",
-        watch_index=WatchIndex(tmdb_ids=set(), normalized_titles=set(), entries=[]),
+        watch_index=WatchIndex(tmdb_ids=set(), tmdb_keys=set(), normalized_titles=set(), entries=[]),
         events=[],
         tmdb_client=MagicMock(),
         llm=mock_llm,
@@ -194,7 +194,7 @@ def test_recommend_context_events_lazy_loads_once():
     mock_llm = make_mock_llm("")
     ctx = RecommendContext(
         taste_profile="profile",
-        watch_index=WatchIndex(tmdb_ids=set(), normalized_titles=set(), entries=[]),
+        watch_index=WatchIndex(tmdb_ids=set(), tmdb_keys=set(), normalized_titles=set(), entries=[]),
         tmdb_client=MagicMock(),
         llm=mock_llm,
         cache_dir="/tmp",
@@ -212,7 +212,7 @@ def test_recommend_context_events_no_loader_returns_empty():
     mock_llm = make_mock_llm("")
     ctx = RecommendContext(
         taste_profile="profile",
-        watch_index=WatchIndex(tmdb_ids=set(), normalized_titles=set(), entries=[]),
+        watch_index=WatchIndex(tmdb_ids=set(), tmdb_keys=set(), normalized_titles=set(), entries=[]),
         tmdb_client=MagicMock(),
         llm=mock_llm,
         cache_dir="/tmp",
@@ -261,7 +261,7 @@ def test_user_state_excludes_dismissed_and_manual_archive():
 
     ctx = RecommendContext(
         taste_profile="taste profile text",
-        watch_index=WatchIndex(tmdb_ids=set(), normalized_titles=set(), entries=[]),
+        watch_index=WatchIndex(tmdb_ids=set(), tmdb_keys=set(), normalized_titles=set(), entries=[]),
         events=[],
         tmdb_client=mock_tmdb,
         llm=mock_llm,

--- a/tests/test_query_engine.py
+++ b/tests/test_query_engine.py
@@ -92,7 +92,7 @@ def make_meta(title, tmdb_id=1, content_type="tv", genres=None, vote_avg=8.0):
 
 def test_rank_candidates_returns_recommendations():
     candidates = [make_meta("Broadchurch", tmdb_id=1), make_meta("Hinterland", tmdb_id=2)]
-    enrichments = {"Broadchurch": "Dark coastal crime.", "Hinterland": "Welsh noir."}
+    enrichments = {"tv/1": "Dark coastal crime.", "tv/2": "Welsh noir."}
     ranked = [
         {"title": "Broadchurch", "explanation": "Fits your taste.", "score": 0.92},
         {"title": "Hinterland", "explanation": "Similar tone.", "score": 0.85},
@@ -107,7 +107,7 @@ def test_rank_candidates_returns_recommendations():
 
 def test_rank_candidates_uses_reason_role():
     candidates = [make_meta("Broadchurch")]
-    enrichments = {"Broadchurch": "Desc."}
+    enrichments = {"tv/1": "Desc."}
     ranked = [{"title": "Broadchurch", "explanation": "Good.", "score": 0.9}]
     client = make_mock_llm(json.dumps(ranked))
     rank_candidates("query", "profile", candidates, enrichments, client)
@@ -117,7 +117,7 @@ def test_rank_candidates_uses_reason_role():
 
 def test_rank_candidates_skips_unknown_titles():
     candidates = [make_meta("Broadchurch")]
-    enrichments = {"Broadchurch": "Desc."}
+    enrichments = {"tv/1": "Desc."}
     ranked = [
         {"title": "Broadchurch", "explanation": "Good.", "score": 0.9},
         {"title": "Phantom Title", "explanation": "Hallucinated.", "score": 0.95},
@@ -160,7 +160,7 @@ def test_ask_excludes_watched_titles():
         cache_dir="/tmp/test_cache",
     )
 
-    with patch('recommender.query_engine.enrich_batch', return_value={"Hinterland": "Welsh noir."}):
+    with patch('recommender.query_engine.enrich_batch', return_value={"tv/2": "Welsh noir."}):
         results = ask("British crime drama", ctx)
 
     titles = [r.title for r in results]
@@ -269,7 +269,7 @@ def test_user_state_excludes_dismissed_and_manual_archive():
         user_state=FakeUserState(),
     )
 
-    with patch("recommender.query_engine.enrich_batch", return_value={"Fresh Pick": "Eligible"}):
+    with patch("recommender.query_engine.enrich_batch", return_value={"tv/333": "Eligible"}):
         results = ask("British crime drama", ctx)
 
     titles = [r.title for r in results]

--- a/tests/test_signals.py
+++ b/tests/test_signals.py
@@ -52,6 +52,14 @@ def test_full_completion_scores_high():
     assert scores["Show"] > 0.6
 
 
+def test_typed_metadata_keys_use_runtime():
+    events = [make_event("Short Movie", "Short Movie", "movie", 45, 0)]
+    string_keyed = {"Short Movie": make_movie_meta("Short Movie", runtime=45)}
+    typed_keyed = {("Short Movie", "movie"): make_movie_meta("Short Movie", runtime=45)}
+
+    assert compute_scores(events, typed_keyed)["Short Movie"] == compute_scores(events, string_keyed)["Short Movie"]
+
+
 def test_partial_watch_scores_lower():
     full_events = [make_event("Show: Season 1: Ep1 (Episode 1)", "Show", "tv", 23, 1)]
     partial_events = [make_event("Show: Season 1: Ep1 (Episode 1)", "Show", "tv", 5, 1)]

--- a/tests/test_tmdb_client.py
+++ b/tests/test_tmdb_client.py
@@ -2,7 +2,7 @@ import json
 import os
 import tempfile
 from unittest.mock import patch, MagicMock
-from recommender.tmdb_client import TmdbClient, TmdbMetadata
+from recommender.tmdb_client import TmdbClient, TmdbMetadata, MatchHints, _title_similarity
 
 
 def make_client(tmp_dir):
@@ -76,7 +76,7 @@ def test_cache_hit_avoids_api_call():
 
         with patch.object(client, "_get") as mock_get:
             mock_get.side_effect = Exception("Should not call API")
-            with patch.object(client, "_search", return_value=42):
+            with patch.object(client, "_ranked_search", return_value=42):
                 meta = client.get_metadata("Avatar: The Last Airbender", "tv")
 
         assert meta is not None
@@ -168,3 +168,186 @@ def test_search_by_filters_movie():
         discover_call = mock_get.call_args_list[0]
         assert discover_call[0][0] == "discover/movie"
         assert discover_call[1]['params']['with_original_language'] == "hi"
+
+
+# --- Candidate ranking tests ---
+
+def test_title_similarity_exact():
+    assert _title_similarity("Honeyland", "Honeyland") == 1.0
+
+
+def test_title_similarity_case_insensitive():
+    assert _title_similarity("honeyland", "Honeyland") == 1.0
+
+
+def test_title_similarity_articles_stripped():
+    assert _title_similarity("The Matrix", "Matrix") == 1.0
+
+
+def test_title_similarity_low_for_mismatch():
+    sim = _title_similarity("Kesari", "The King")
+    assert sim < 0.5
+
+
+def _make_search_result(tmdb_id, title, release_date="", poster_path=None,
+                        vote_count=100, popularity=20):
+    return {
+        "id": tmdb_id,
+        "title": title,
+        "release_date": release_date,
+        "poster_path": poster_path,
+        "vote_count": vote_count,
+        "popularity": popularity,
+    }
+
+
+def _make_details(tmdb_id, title, runtime=None, release_date=""):
+    return {
+        "id": tmdb_id,
+        "title": title,
+        "runtime": runtime,
+        "release_date": release_date,
+        "genres": [],
+        "keywords": {"keywords": []},
+        "credits": {"cast": [], "crew": []},
+        "original_language": "en",
+        "vote_average": 7.0,
+        "vote_count": 100,
+    }
+
+
+def test_year_hint_selects_correct_candidate():
+    """Iceland with release_year=2016 should pick 2016 over 1942."""
+    with tempfile.TemporaryDirectory() as tmp:
+        client = make_client(tmp)
+        hints = MatchHints(release_year=2016)
+
+        cand_1942 = _make_search_result(111, "Iceland", "1942-01-01", "/poster.jpg")
+        cand_2016 = _make_search_result(222, "Iceland", "2016-06-15", "/poster.jpg")
+
+        details_1942 = _make_details(111, "Iceland", runtime=90, release_date="1942-01-01")
+        details_2016 = _make_details(222, "Iceland", runtime=95, release_date="2016-06-15")
+
+        def fake_get(endpoint, params=None):
+            if "search" in endpoint:
+                if params and params.get("primary_release_year") == 2016:
+                    return {"results": [cand_2016]}
+                return {"results": [cand_1942, cand_2016]}
+            if "111" in endpoint:
+                return details_1942
+            if "222" in endpoint:
+                return details_2016
+            return {}
+
+        with patch.object(client, "_get", side_effect=fake_get):
+            meta = client.get_metadata("Iceland", "movie", hints=hints)
+
+        assert meta is not None
+        assert meta.tmdb_id == 222
+
+
+def test_year_hint_selects_honeyland_2019():
+    """Honeyland with release_year=2019 should pick 2019 over 1935."""
+    with tempfile.TemporaryDirectory() as tmp:
+        client = make_client(tmp)
+        hints = MatchHints(release_year=2019)
+
+        cand_1935 = _make_search_result(333, "Honeyland", "1935-01-01", None, vote_count=5, popularity=1)
+        cand_2019 = _make_search_result(444, "Honeyland", "2019-02-01", "/poster.jpg", vote_count=800, popularity=30)
+
+        details_1935 = _make_details(333, "Honeyland", runtime=70, release_date="1935-01-01")
+        details_2019 = _make_details(444, "Honeyland", runtime=85, release_date="2019-02-01")
+
+        def fake_get(endpoint, params=None):
+            if "search" in endpoint:
+                if params and params.get("primary_release_year") == 2019:
+                    return {"results": [cand_2019]}
+                return {"results": [cand_1935, cand_2019]}
+            if "333" in endpoint:
+                return details_1935
+            if "444" in endpoint:
+                return details_2019
+            return {}
+
+        with patch.object(client, "_get", side_effect=fake_get):
+            meta = client.get_metadata("Honeyland", "movie", hints=hints)
+
+        assert meta is not None
+        assert meta.tmdb_id == 444
+
+
+def test_runtime_hint_selects_correct_hum_tum():
+    """Hum Tum with runtime ~140 should pick the 142-min movie over the 123-min one."""
+    with tempfile.TemporaryDirectory() as tmp:
+        client = make_client(tmp)
+        hints = MatchHints(runtime_minutes=140, runtime_is_exact=True)
+
+        cand_123 = _make_search_result(555, "Hum Tum", "2004-05-28", "/poster.jpg")
+        cand_142 = _make_search_result(556, "Hum Tum", "2004-05-28", "/poster.jpg")
+
+        details_123 = _make_details(555, "Hum Tum", runtime=123, release_date="2004-05-28")
+        details_142 = _make_details(556, "Hum Tum", runtime=142, release_date="2004-05-28")
+
+        def fake_get(endpoint, params=None):
+            if "search" in endpoint:
+                return {"results": [cand_123, cand_142]}
+            if "555" in endpoint:
+                return details_123
+            if "556" in endpoint:
+                return details_142
+            return {}
+
+        with patch.object(client, "_get", side_effect=fake_get):
+            meta = client.get_metadata("Hum Tum", "movie", hints=hints)
+
+        assert meta is not None
+        assert meta.tmdb_id == 556
+
+
+def test_title_mismatch_deprioritized():
+    """Kesari should not match 'The King' despite it being first result."""
+    with tempfile.TemporaryDirectory() as tmp:
+        client = make_client(tmp)
+
+        cand_king = _make_search_result(700, "The King", "2019-10-11", "/poster.jpg", vote_count=2000)
+        cand_kesari = _make_search_result(701, "Kesari", "2019-03-21", "/poster.jpg", vote_count=300)
+
+        details_king = _make_details(700, "The King", runtime=140, release_date="2019-10-11")
+        details_kesari = _make_details(701, "Kesari", runtime=150, release_date="2019-03-21")
+
+        def fake_get(endpoint, params=None):
+            if "search" in endpoint:
+                return {"results": [cand_king, cand_kesari]}
+            if "700" in endpoint:
+                return details_king
+            if "701" in endpoint:
+                return details_kesari
+            return {}
+
+        with patch.object(client, "_get", side_effect=fake_get):
+            meta = client.get_metadata("Kesari", "movie")
+
+        assert meta is not None
+        assert meta.tmdb_id == 701
+
+
+def test_no_hints_still_works():
+    """get_metadata without hints should still return a result."""
+    with tempfile.TemporaryDirectory() as tmp:
+        client = make_client(tmp)
+
+        cand = _make_search_result(800, "Inception", "2010-07-16", "/poster.jpg")
+        details = _make_details(800, "Inception", runtime=148, release_date="2010-07-16")
+
+        def fake_get(endpoint, params=None):
+            if "search" in endpoint:
+                return {"results": [cand]}
+            if "800" in endpoint:
+                return details
+            return {}
+
+        with patch.object(client, "_get", side_effect=fake_get):
+            meta = client.get_metadata("Inception", "movie")
+
+        assert meta is not None
+        assert meta.tmdb_id == 800

--- a/tests/test_watch_index.py
+++ b/tests/test_watch_index.py
@@ -68,27 +68,85 @@ def test_build_stores_tmdb_id():
 
 def test_is_watched_by_tmdb_id():
     meta = make_meta(tmdb_id=12345, title="Fleabag", content_type="tv")
-    index = WatchIndex(tmdb_ids={12345}, normalized_titles=set(), entries=[])
+    index = WatchIndex(tmdb_ids={12345}, tmdb_keys={("tv", 12345)}, normalized_titles=set(), entries=[])
     assert index.is_watched(meta) is True
 
 
 def test_is_watched_by_title_fallback():
     meta = make_meta(tmdb_id=0, title="Downton Abbey", content_type="tv")
-    index = WatchIndex(tmdb_ids=set(), normalized_titles={("downton abbey", "tv")}, entries=[])
+    index = WatchIndex(tmdb_ids=set(), tmdb_keys=set(), normalized_titles={("downton abbey", "tv")}, entries=[])
     assert index.is_watched(meta) is True
 
 
 def test_is_watched_false_for_unknown():
     meta = make_meta(tmdb_id=99999, title="Broadchurch", content_type="tv")
-    index = WatchIndex(tmdb_ids={12345}, normalized_titles={("fleabag", "tv")}, entries=[])
+    index = WatchIndex(tmdb_ids={12345}, tmdb_keys={("tv", 12345)}, normalized_titles={("fleabag", "tv")}, entries=[])
     assert index.is_watched(meta) is False
 
 
 def test_is_watched_content_type_aware():
     """A watched TV show should not block a movie with the same title."""
     meta_movie = make_meta(tmdb_id=0, title="Fargo", content_type="movie")
-    index = WatchIndex(tmdb_ids=set(), normalized_titles={("fargo", "tv")}, entries=[])
+    index = WatchIndex(tmdb_ids=set(), tmdb_keys=set(), normalized_titles={("fargo", "tv")}, entries=[])
     assert index.is_watched(meta_movie) is False
+
+
+def test_build_stores_meta_content_type():
+    """build() should use meta.content_type when metadata exists, not the event's type."""
+    events = [make_event("Apollo 11")]  # event says movie
+    meta = make_meta(tmdb_id=55063, title="Apollo 11", content_type="tv")  # TMDB says tv
+    index = wi.build(events, {"Apollo 11": meta})
+    # Entry should use meta's content_type
+    entry = [e for e in index.entries if e["tmdb_id"] == 55063][0]
+    assert entry["content_type"] == "tv"
+
+
+def test_is_watched_typed_identity():
+    """movie/55063 should NOT be treated as watched when only tv/55063 exists."""
+    index = WatchIndex(
+        tmdb_ids={55063},
+        tmdb_keys={("tv", 55063)},
+        normalized_titles=set(),
+        entries=[],
+    )
+    movie_candidate = make_meta(tmdb_id=55063, title="Apollo 11", content_type="movie")
+    tv_candidate = make_meta(tmdb_id=55063, title="Apollo 11", content_type="tv")
+    assert index.is_watched(movie_candidate) is False
+    assert index.is_watched(tv_candidate) is True
+
+
+def test_deduplicate_keeps_different_types_same_id():
+    """movie/407445 and tv/407445 are different titles and should both survive dedupe."""
+    entries = [
+        {"tmdb_id": 407445, "title": "Breathe", "content_type": "movie"},
+        {"tmdb_id": 407445, "title": "Breathe", "content_type": "tv"},
+    ]
+    index = WatchIndex(
+        tmdb_ids={407445},
+        tmdb_keys={("movie", 407445), ("tv", 407445)},
+        normalized_titles={("breathe", "movie"), ("breathe", "tv")},
+        entries=entries,
+    )
+    deduped = wi.deduplicate(index)
+    assert len(deduped.entries) == 2
+    types = {e["content_type"] for e in deduped.entries}
+    assert types == {"movie", "tv"}
+
+
+def test_deduplicate_merges_same_typed_identity():
+    """Two entries with same (content_type, tmdb_id) should merge."""
+    entries = [
+        {"tmdb_id": 123, "title": "Show A", "content_type": "tv"},
+        {"tmdb_id": 123, "title": "Show A S2", "content_type": "tv"},
+    ]
+    index = WatchIndex(
+        tmdb_ids={123},
+        tmdb_keys={("tv", 123)},
+        normalized_titles={("show a", "tv"), ("show a s2", "tv")},
+        entries=entries,
+    )
+    deduped = wi.deduplicate(index)
+    assert len(deduped.entries) == 1
 
 
 def test_save_and_load_roundtrip(tmp_path):
@@ -99,4 +157,5 @@ def test_save_and_load_roundtrip(tmp_path):
     wi.save(index, path)
     loaded = wi.load(path)
     assert 67452 in loaded.tmdb_ids
+    assert ("tv", 67452) in loaded.tmdb_keys
     assert ("fleabag", "tv") in loaded.normalized_titles

--- a/tests/test_watch_index.py
+++ b/tests/test_watch_index.py
@@ -149,6 +149,26 @@ def test_deduplicate_merges_same_typed_identity():
     assert len(deduped.entries) == 1
 
 
+def test_build_dual_existence_titles():
+    """Two events with same title but different content_type should produce separate entries."""
+    events = [
+        make_event("Breathe", content_type="movie"),
+        make_event("Breathe", series_name="Breathe", content_type="tv"),
+    ]
+    meta_movie = make_meta(tmdb_id=407445, title="Breathe", content_type="movie")
+    meta_tv = make_meta(tmdb_id=79145, title="Breathe", content_type="tv")
+    metadata = {
+        ("Breathe", "movie"): meta_movie,
+        ("Breathe", "tv"): meta_tv,
+    }
+    index = wi.build(events, metadata)
+    assert len(index.entries) == 2
+    types = {e["content_type"] for e in index.entries}
+    assert types == {"movie", "tv"}
+    ids = {e["tmdb_id"] for e in index.entries}
+    assert ids == {407445, 79145}
+
+
 def test_save_and_load_roundtrip(tmp_path):
     path = str(tmp_path / "index.json")
     events = [make_event("Fleabag", series_name="Fleabag", content_type="tv")]

--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -209,6 +209,121 @@ class TestStatusObservability:
         assert "ingestion_errors" not in payload
 
 
+class TestTitleDetailFallback:
+    @patch("recommender.web._load_enrichments", return_value={})
+    @patch("recommender.web._load_user_state")
+    @patch("recommender.web._get_context")
+    def test_title_detail_rejects_unrelated_alternate_type_cache(
+        self, mock_ctx, mock_user_state, _mock_enrichments, client
+    ):
+        from recommender.tmdb_client import TmdbMetadata
+
+        user_state = MagicMock()
+        user_state.is_manually_watched.return_value = False
+        user_state.is_in_watchlist.return_value = False
+        user_state.is_dismissed.return_value = False
+        user_state.get_rating.return_value = None
+        mock_user_state.return_value = user_state
+
+        alt_meta = TmdbMetadata(
+            tmdb_id=55063,
+            content_type="tv",
+            title="Man on the Moon: The Epic Journey of Apollo 11",
+        )
+        tmdb_client = MagicMock()
+        tmdb_client.get_cached_by_id.side_effect = lambda tmdb_id, ct: alt_meta if ct == "tv" else None
+
+        mock_ctx.return_value = MagicMock(
+            tmdb_client=tmdb_client,
+            watch_index=MagicMock(
+                tmdb_ids={55063},
+                tmdb_keys={("movie", 55063)},
+                entries=[{"tmdb_id": 55063, "title": "Apollo 11", "content_type": "movie"}],
+            ),
+        )
+
+        resp = client.get("/title/55063?type=movie")
+
+        html = resp.data.decode()
+        assert resp.status_code == 200
+        assert "Title not found in cache" in html
+        assert "Man on the Moon" not in html
+
+    @patch("recommender.web._load_enrichments", return_value={})
+    @patch("recommender.web._load_user_state")
+    @patch("recommender.web._get_context")
+    def test_title_detail_accepts_episode_title_alternate_type_cache(
+        self, mock_ctx, mock_user_state, _mock_enrichments, client
+    ):
+        from recommender.tmdb_client import TmdbMetadata
+
+        user_state = MagicMock()
+        user_state.is_manually_watched.return_value = False
+        user_state.is_in_watchlist.return_value = False
+        user_state.is_dismissed.return_value = False
+        user_state.get_rating.return_value = None
+        mock_user_state.return_value = user_state
+
+        alt_meta = TmdbMetadata(tmdb_id=66732, content_type="tv", title="Stranger Things")
+        tmdb_client = MagicMock()
+        tmdb_client.get_cached_by_id.side_effect = lambda tmdb_id, ct: alt_meta if ct == "tv" else None
+
+        mock_ctx.return_value = MagicMock(
+            tmdb_client=tmdb_client,
+            watch_index=MagicMock(
+                tmdb_ids={66732},
+                tmdb_keys={("movie", 66732)},
+                entries=[{
+                    "tmdb_id": 66732,
+                    "title": "Stranger Things: Stranger Things 4: Chapter One: The Hellfire Club (Episode 1)",
+                    "content_type": "movie",
+                }],
+            ),
+        )
+
+        resp = client.get("/title/66732?type=movie")
+
+        html = resp.data.decode()
+        assert resp.status_code == 200
+        assert "Stranger Things" in html
+        assert "Title not found in cache" not in html
+
+    @patch("recommender.web._load_enrichments", return_value={})
+    @patch("recommender.web._load_user_state")
+    @patch("recommender.web._get_context")
+    def test_title_detail_accepts_exact_short_title_alternate_type_cache(
+        self, mock_ctx, mock_user_state, _mock_enrichments, client
+    ):
+        from recommender.tmdb_client import TmdbMetadata
+
+        user_state = MagicMock()
+        user_state.is_manually_watched.return_value = False
+        user_state.is_in_watchlist.return_value = False
+        user_state.is_dismissed.return_value = False
+        user_state.get_rating.return_value = None
+        mock_user_state.return_value = user_state
+
+        alt_meta = TmdbMetadata(tmdb_id=11, content_type="tv", title="Up")
+        tmdb_client = MagicMock()
+        tmdb_client.get_cached_by_id.side_effect = lambda tmdb_id, ct: alt_meta if ct == "tv" else None
+
+        mock_ctx.return_value = MagicMock(
+            tmdb_client=tmdb_client,
+            watch_index=MagicMock(
+                tmdb_ids={11},
+                tmdb_keys={("movie", 11)},
+                entries=[{"tmdb_id": 11, "title": "Up", "content_type": "movie"}],
+            ),
+        )
+
+        resp = client.get("/title/11?type=movie")
+
+        html = resp.data.decode()
+        assert resp.status_code == 200
+        assert "Up" in html
+        assert "Title not found in cache" not in html
+
+
 # ── /recommend progressive enhancement ────────────────────────────────────────
 
 class TestRecommendProgressive:


### PR DESCRIPTION
## Summary
- **Enrichment rekey**: Switch enrichment index from display-title keys to identity keys (`content_type/tmdb_id` or `unknown/slug`), eliminating mismatches when titles have display-name collisions or formatting differences. Adds `_title_keyed_enrichments()` bridge for taste profile builder compatibility.
- **Brand and nav polish**: Restyle nav brand with inline-flex layout, italic "line" accent in teal, and logo sizing cleanup.
- **Bug fixes**: Treat `tmdb_id=0` as missing throughout the pipeline; add legacy title-keyed fallback in web UI enrichment lookups; fix enrichment lookup in `/history` and `/title/:id` routes.
- **Docs sync**: Update CLAUDE.md, README.md, architecture.md, and AGENTS.md for Apple TV support, OpenAI provider, identity-keyed enrichments, and watchlist management routes.

## Test plan
- [ ] `python3 -m pytest tests/ -v` — all tests pass (enricher key tests, query engine enrichment key lookups)
- [ ] `./recommend setup --refresh-profile` — verify taste profile builds correctly with identity-keyed enrichments
- [ ] Web UI: `/history` shows enrichment descriptions; `/title/:id` loads AI analysis; nav brand renders correctly
- [ ] Verify docs accurately reflect current code (CLAUDE.md, README.md, architecture.md)