### PR TITLE
feat: support multiple exports per provider (#23)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ config.local.yaml
 logs/
 .superpowers/
 .worktrees/
+/.claude

--- a/config.py
+++ b/config.py
@@ -125,24 +125,48 @@ STREAMING_PLATFORMS: list[str] = _cfg.get("streaming_platforms", [])
 _paths = _cfg.get("platform_paths", {})
 
 
-def _resolve_platform_path(platform: str, default: str | None) -> str | None:
-    # Missing keys should keep repo defaults; explicit null/empty disables the source.
+def _resolve_platform_paths(platform: str, default: str | None) -> list[str]:
+    """Normalize a platform_paths entry to a list of absolute path strings.
+
+    Input shapes accepted (from config.yaml or config.local.yaml):
+      - string        -> one path (wrapped in list)
+      - list[str]     -> multiple paths
+      - null / ""     -> disabled (empty list)
+      - empty list    -> disabled (empty list)
+      - missing key   -> repo default path (wrapped in list), or empty list if no default
+
+    Returns an empty list to signal "disabled".
+    """
     if platform not in _paths:
-        return str(_ROOT / default) if default is not None else None
+        # Missing key: keep repo default if one exists.
+        if default is None:
+            return []
+        return [str(_ROOT / default)]
 
-    configured_path = _paths[platform]
-    if configured_path in (None, ""):
-        return None
+    raw = _paths[platform]
 
-    return str(_ROOT / configured_path)
+    # Explicit null or empty string disables the source.
+    if raw in (None, ""):
+        return []
+
+    # Normalize to list.
+    if isinstance(raw, str):
+        paths = [raw]
+    elif isinstance(raw, list):
+        paths = raw
+    else:
+        raise TypeError(f"platform_paths.{platform} must be a string, list, or null, got {type(raw).__name__}")
+
+    # Filter out any empty strings, then resolve against _ROOT.
+    return [str(_ROOT / p) for p in paths if p]
 
 
-PLATFORM_PATHS = {
-    "netflix": _resolve_platform_path("netflix", "data/netflix/export.zip"),
-    "prime": _resolve_platform_path("prime", "data/prime_video/Prime Video.zip"),
-    "apple_tv": _resolve_platform_path("apple_tv", "data/AppleTV/Apple Media Services Information Part 1 of 2.zip"),
-    "disney": None,
-    "hbo": None,
+PLATFORM_PATHS: dict[str, list[str]] = {
+    "netflix": _resolve_platform_paths("netflix", "data/netflix/export.zip"),
+    "prime": _resolve_platform_paths("prime", "data/prime_video/Prime Video.zip"),
+    "apple_tv": _resolve_platform_paths("apple_tv", "data/AppleTV/Apple Media Services Information Part 1 of 2.zip"),
+    "disney": [],
+    "hbo": [],
 }
 MANUAL_TV_PATH = str(_ROOT / _cfg.get("manual_tv_path", "data/manual/tv.csv"))
 MANUAL_MOVIES_PATH = str(_ROOT / _cfg.get("manual_movies_path", "data/manual/movies.csv"))

--- a/recommender/event_store.py
+++ b/recommender/event_store.py
@@ -1,19 +1,23 @@
 """SQLite event store for normalized watch history."""
 
 import hashlib
+import json
+import logging
 import sqlite3
 from datetime import datetime, timedelta
 from pathlib import Path
+
+log = logging.getLogger("recommender.event_store")
 
 from recommender.ingestion.base import WatchEvent
 
 _SCHEMA = """
 CREATE TABLE IF NOT EXISTS imports (
-    id            INTEGER PRIMARY KEY AUTOINCREMENT,
-    provider      TEXT NOT NULL UNIQUE,
-    source_path   TEXT NOT NULL,
-    source_sha256 TEXT NOT NULL,
-    imported_at   TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))
+    id                   INTEGER PRIMARY KEY AUTOINCREMENT,
+    provider             TEXT NOT NULL UNIQUE,
+    source_manifest_json TEXT NOT NULL,
+    snapshot_sha256      TEXT NOT NULL,
+    imported_at          TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))
 );
 
 CREATE TABLE IF NOT EXISTS watch_events (
@@ -40,22 +44,57 @@ def _connect(db_path: str) -> sqlite3.Connection:
 
 
 def _compute_source_hash(
-    provider: str, profile: str, title: str,
+    provider: str, content_type: str, series_name: str, title: str,
     timestamp_iso: str, watched_duration_seconds: int,
 ) -> str:
+    """Compute a dedup hash from event identity fields, excluding profile."""
     raw = "\0".join([
-        provider, profile, title,
+        provider, content_type, series_name, title,
         timestamp_iso, str(watched_duration_seconds),
     ])
     return hashlib.sha256(raw.encode("utf-8")).hexdigest()
 
 
+def _needs_migration(conn: sqlite3.Connection) -> bool:
+    """Return True if the imports table has the legacy schema (source_path column)."""
+    cols = {
+        row[1]
+        for row in conn.execute("PRAGMA table_info(imports)").fetchall()
+    }
+    # Legacy schema has source_path; new schema has source_manifest_json.
+    return "source_path" in cols and "source_manifest_json" not in cols
+
+
+def _migrate_schema(conn: sqlite3.Connection) -> None:
+    """Drop and recreate imports + watch_events while preserving user-store tables."""
+    conn.executescript(f"""
+        DROP TABLE IF EXISTS watch_events;
+        DROP TABLE IF EXISTS imports;
+        {_SCHEMA}
+    """)
+
+
 def init_db(db_path: str) -> None:
-    """Create tables if not present. Create parent directories if needed."""
+    """Create tables if not present. Create parent directories if needed.
+
+    If the legacy schema is detected (source_path column present in imports),
+    drop and recreate only imports and watch_events, preserving user-store tables.
+    """
     Path(db_path).parent.mkdir(parents=True, exist_ok=True)
     conn = _connect(db_path)
     try:
-        conn.executescript(_SCHEMA)
+        # Check whether the imports table exists at all first.
+        tables = {
+            row[0]
+            for row in conn.execute(
+                "SELECT name FROM sqlite_master WHERE type='table'"
+            ).fetchall()
+        }
+        if "imports" in tables and _needs_migration(conn):
+            log.warning("Legacy event-store schema detected — migrating. Watch history will be re-ingested on next setup run.")
+            _migrate_schema(conn)
+        else:
+            conn.executescript(_SCHEMA)
     finally:
         conn.close()
 
@@ -87,27 +126,43 @@ def replace_provider_events(
     db_path: str,
     provider: str,
     events: list[WatchEvent],
-    source_path: str,
-    source_sha256: str,
-) -> int:
+    source_manifest: list[dict],
+    snapshot_sha256: str,
+) -> tuple[int, int]:
     """Replace all events for a provider in a single transaction.
 
-    Returns the number of rows actually persisted (after dedup).
+    Args:
+        db_path: Path to the SQLite database.
+        provider: Provider name (e.g. "netflix").
+        events: Normalized watch events to persist.
+        source_manifest: List of {"path": str, "sha256": str} dicts describing
+            the source files that make up this snapshot.
+        snapshot_sha256: SHA-256 of the normalized manifest, used for change detection.
+
+    Returns:
+        (persisted_count, total_raw_count) tuple. Difference is duplicates removed.
     """
+    manifest_json = json.dumps(source_manifest, separators=(",", ":"))
+    total_raw = len(events)
+
     conn = _connect(db_path)
     try:
         with conn:
-            # Delete existing import for this provider (cascade removes events)
+            # Delete existing import for this provider (cascade removes events).
             conn.execute("DELETE FROM imports WHERE provider = ?", (provider,))
 
-            # Insert new import row
+            # Insert new import row.
             cursor = conn.execute(
-                "INSERT INTO imports (provider, source_path, source_sha256) VALUES (?, ?, ?)",
-                (provider, source_path, source_sha256),
+                "INSERT INTO imports (provider, source_manifest_json, snapshot_sha256) "
+                "VALUES (?, ?, ?)",
+                (provider, manifest_json, snapshot_sha256),
             )
             import_id = cursor.lastrowid
 
-            # Insert events with dedup via INSERT OR IGNORE on source_hash
+            # In-memory set to catch intra-batch duplicates before hitting the DB.
+            # First-seen profile wins for duplicate events; profile is not part of the identity key.
+            seen_hashes: set[str] = set()
+
             for event in events:
                 ts_iso = event.timestamp.isoformat(timespec="seconds")
                 duration_secs = int(event.watched_duration.total_seconds())
@@ -117,9 +172,13 @@ def replace_provider_events(
                     else None
                 )
                 source_hash = _compute_source_hash(
-                    provider, event.profile, event.title,
-                    ts_iso, duration_secs,
+                    provider, event.content_type, event.series_name,
+                    event.title, ts_iso, duration_secs,
                 )
+                if source_hash in seen_hashes:
+                    continue
+                seen_hashes.add(source_hash)
+
                 conn.execute(
                     "INSERT OR IGNORE INTO watch_events "
                     "(provider, title, content_type, series_name, "
@@ -131,12 +190,11 @@ def replace_provider_events(
                      import_id, source_hash),
                 )
 
-            # Return persisted count
-            count = conn.execute(
+            persisted = conn.execute(
                 "SELECT COUNT(*) FROM watch_events WHERE import_id = ?",
                 (import_id,),
             ).fetchone()[0]
-            return count
+            return (persisted, total_raw)
     finally:
         conn.close()
 
@@ -189,16 +247,16 @@ def get_import_info(db_path: str) -> dict[str, dict]:
     conn = _connect(db_path)
     try:
         rows = conn.execute(
-            "SELECT i.provider, i.source_path, i.source_sha256, i.imported_at, "
+            "SELECT i.provider, i.source_manifest_json, i.snapshot_sha256, i.imported_at, "
             "COUNT(e.id) as event_count "
             "FROM imports i LEFT JOIN watch_events e ON e.import_id = i.id "
             "GROUP BY i.provider"
         ).fetchall()
         result = {}
-        for provider, source_path, source_sha256, imported_at, event_count in rows:
+        for provider, manifest_json, snapshot_sha256, imported_at, event_count in rows:
             result[provider] = {
-                "source_path": source_path,
-                "source_sha256": source_sha256,
+                "source_manifest": json.loads(manifest_json),
+                "snapshot_sha256": snapshot_sha256,
                 "imported_at": imported_at,
                 "event_count": event_count,
             }

--- a/recommender/event_store.py
+++ b/recommender/event_store.py
@@ -66,11 +66,17 @@ def _needs_migration(conn: sqlite3.Connection) -> bool:
 
 
 def _migrate_schema(conn: sqlite3.Connection) -> None:
-    """Drop and recreate imports + watch_events while preserving user-store tables."""
-    conn.executescript(f"""
-        DROP TABLE IF EXISTS watch_events;
-        DROP TABLE IF EXISTS imports;
-        {_SCHEMA}
+    """Migrate legacy imports schema in-place, preserving watch_events data.
+
+    Legacy schema has ``source_path`` and ``source_sha256``; new schema needs
+    ``source_manifest_json`` and ``snapshot_sha256``.  We add/rename columns
+    in-place so that watch_events rows (and their foreign-key references to
+    imports.id) are left untouched.
+    """
+    conn.executescript("""
+        ALTER TABLE imports ADD COLUMN source_manifest_json TEXT NOT NULL DEFAULT '{}';
+        ALTER TABLE imports RENAME COLUMN source_sha256 TO snapshot_sha256;
+        ALTER TABLE imports DROP COLUMN source_path;
     """)
 
 
@@ -91,8 +97,11 @@ def init_db(db_path: str) -> None:
             ).fetchall()
         }
         if "imports" in tables and _needs_migration(conn):
-            log.warning("Legacy event-store schema detected — migrating. Watch history will be re-ingested on next setup run.")
+            log.warning("Legacy event-store schema detected — migrating in-place.")
             _migrate_schema(conn)
+            # Run _SCHEMA for any tables/columns the legacy DB may be missing
+            # (CREATE TABLE IF NOT EXISTS is a no-op for existing tables).
+            conn.executescript(_SCHEMA)
         else:
             conn.executescript(_SCHEMA)
     finally:

--- a/recommender/setup.py
+++ b/recommender/setup.py
@@ -49,6 +49,14 @@ def _compute_file_sha256(path: str) -> str:
     return h.hexdigest()
 
 
+def _compute_paths_sha256(paths: list[str]) -> str:
+    """Compute a combined SHA-256 over all files in paths, sorted for stability."""
+    h = hashlib.sha256()
+    for path in sorted(paths):
+        h.update(_compute_file_sha256(path).encode())
+    return h.hexdigest()
+
+
 def _title_keyed_enrichments(
     raw_enrichments: dict[str, str],
     watch_entries: list[dict],
@@ -255,34 +263,40 @@ def _audit_cache_mismatches(
 def _load_platform_events_by_provider(
     fail_on_error: bool = True,
     emit_console: bool = True,
-) -> dict[str, tuple[list, str]]:
+) -> dict[str, tuple[list, list[str]]]:
     """Parse configured provider exports without touching SQLite."""
-    platform_events_by_provider: dict[str, tuple[list, str]] = {}
+    platform_events_by_provider: dict[str, tuple[list, list[str]]] = {}
     ok = True
 
     for platform, parser in _PLATFORM_PARSERS:
-        path = config.PLATFORM_PATHS.get(platform)
-        if not path:
+        paths = config.PLATFORM_PATHS.get(platform) or []
+        if not paths:
             if emit_console:
                 console.print(f"  {platform}: [dim]disabled[/dim]")
             continue
-        try:
-            pevents = parser(path)
-        except (FileNotFoundError, ValueError) as exc:
-            if emit_console:
-                console.print(f"  {platform}: [red]FAIL[/red] {exc}")
-            else:
-                log.warning("Failed to parse %s export during runtime fallback: %s", platform, exc)
-            ok = False
+        all_pevents: list = []
+        platform_ok = True
+        for path in paths:
+            try:
+                all_pevents.extend(parser(path))
+            except (FileNotFoundError, ValueError) as exc:
+                if emit_console:
+                    console.print(f"  {platform}: [red]FAIL[/red] {exc}")
+                else:
+                    log.warning("Failed to parse %s export during runtime fallback: %s", platform, exc)
+                ok = False
+                platform_ok = False
+                break
+        if not platform_ok:
             continue
-        platform_events_by_provider[platform] = (pevents, path)
-        if not pevents:
+        platform_events_by_provider[platform] = (all_pevents, paths)
+        if not all_pevents:
             if emit_console:
                 console.print(f"  {platform}: [green]ok[/green] 0 events (no qualifying watch activity)")
         else:
             if emit_console:
-                dates = [e.timestamp for e in pevents]
-                console.print(f"  {platform}: [green]ok[/green] {len(pevents)} events "
+                dates = [e.timestamp for e in all_pevents]
+                console.print(f"  {platform}: [green]ok[/green] {len(all_pevents)} events "
                               f"({min(dates):%Y-%m-%d} to {max(dates):%Y-%m-%d})")
 
     configured = sum(1 for p in _PLATFORM_PARSERS if config.PLATFORM_PATHS.get(p[0]))
@@ -338,10 +352,11 @@ def ingest_providers(fail_on_error: bool = True) -> list:
     active_platforms = list(platform_events_by_provider.keys())
     event_store.remove_disabled_providers(config.EVENT_DB_PATH, active_platforms)
 
-    for platform, (pevents, path) in platform_events_by_provider.items():
-        source_sha = _compute_file_sha256(path)
+    for platform, (pevents, paths) in platform_events_by_provider.items():
+        source_sha = _compute_paths_sha256(paths)
+        source_path = "|".join(paths)
         persisted = event_store.replace_provider_events(
-            config.EVENT_DB_PATH, platform, pevents, path, source_sha,
+            config.EVENT_DB_PATH, platform, pevents, source_path, source_sha,
         )
         console.print(f"  {platform}: {persisted} events persisted to SQLite")
 

--- a/recommender/setup.py
+++ b/recommender/setup.py
@@ -49,12 +49,43 @@ def _compute_file_sha256(path: str) -> str:
     return h.hexdigest()
 
 
-def _compute_paths_sha256(paths: list[str]) -> str:
-    """Compute a combined SHA-256 over all files in paths, sorted for stability."""
-    h = hashlib.sha256()
-    for path in sorted(paths):
-        h.update(_compute_file_sha256(path).encode())
-    return h.hexdigest()
+def _build_source_manifest(paths: list[str]) -> tuple[list[dict], str]:
+    """Build manifest and snapshot hash for a set of source files.
+
+    Returns (manifest, snapshot_sha256) where manifest is a list of
+    {"path": str, "sha256": str} dicts sorted by path.
+    """
+    manifest = sorted(
+        [{"path": p, "sha256": _compute_file_sha256(p)} for p in paths],
+        key=lambda m: m["path"],
+    )
+    manifest_json = json.dumps(manifest, separators=(",", ":"))
+    snapshot_sha = hashlib.sha256(manifest_json.encode()).hexdigest()
+    return manifest, snapshot_sha
+
+
+def _dedup_events(events: list) -> tuple[list, int]:
+    """Deduplicate watch events in memory using identity key (excludes profile).
+
+    First-seen event wins. Returns (deduped_events, duplicate_count).
+
+    The identity key must match event_store._compute_source_hash fields.
+    """
+    seen: set[tuple] = set()
+    deduped: list = []
+    for e in events:
+        key = (
+            e.platform,
+            e.content_type,
+            e.series_name,
+            e.title,
+            e.timestamp.isoformat(timespec="seconds"),
+            int(e.watched_duration.total_seconds()),
+        )
+        if key not in seen:
+            seen.add(key)
+            deduped.append(e)
+    return deduped, len(events) - len(deduped)
 
 
 def _title_keyed_enrichments(
@@ -264,7 +295,11 @@ def _load_platform_events_by_provider(
     fail_on_error: bool = True,
     emit_console: bool = True,
 ) -> dict[str, tuple[list, list[str]]]:
-    """Parse configured provider exports without touching SQLite."""
+    """Parse configured provider exports without touching SQLite.
+
+    All-or-nothing per provider: parses ALL configured files before accepting
+    any events. If any file fails, that provider is skipped entirely.
+    """
     platform_events_by_provider: dict[str, tuple[list, list[str]]] = {}
     ok = True
 
@@ -274,11 +309,14 @@ def _load_platform_events_by_provider(
             if emit_console:
                 console.print(f"  {platform}: [dim]disabled[/dim]")
             continue
-        all_pevents: list = []
+
+        # Phase 1: parse all files, collecting per-file results
+        per_file_events: list[tuple[str, list]] = []
         platform_ok = True
         for path in paths:
             try:
-                all_pevents.extend(parser(path))
+                file_events = parser(path)
+                per_file_events.append((path, file_events))
             except (FileNotFoundError, ValueError) as exc:
                 if emit_console:
                     console.print(f"  {platform}: [red]FAIL[/red] {exc}")
@@ -287,17 +325,45 @@ def _load_platform_events_by_provider(
                 ok = False
                 platform_ok = False
                 break
+
         if not platform_ok:
             continue
-        platform_events_by_provider[platform] = (all_pevents, paths)
-        if not all_pevents:
-            if emit_console:
+
+        # Phase 2: merge all events for this provider
+        all_pevents: list = []
+        for _path, file_events in per_file_events:
+            all_pevents.extend(file_events)
+
+        # Phase 3: in-memory dedup across files
+        deduped_events, dup_count = _dedup_events(all_pevents)
+
+        platform_events_by_provider[platform] = (deduped_events, paths)
+
+        # Phase 4: console reporting
+        if emit_console:
+            multi_file = len(paths) > 1
+            if not deduped_events and not multi_file:
                 console.print(f"  {platform}: [green]ok[/green] 0 events (no qualifying watch activity)")
-        else:
-            if emit_console:
-                dates = [e.timestamp for e in all_pevents]
-                console.print(f"  {platform}: [green]ok[/green] {len(all_pevents)} events "
+            elif not multi_file:
+                dates = [e.timestamp for e in deduped_events]
+                console.print(f"  {platform}: [green]ok[/green] {len(deduped_events)} events "
                               f"({min(dates):%Y-%m-%d} to {max(dates):%Y-%m-%d})")
+            else:
+                # Multi-file: show per-file breakdown
+                console.print(f"  {platform}: {len(paths)} files")
+                for path, file_events in per_file_events:
+                    fname = Path(path).name
+                    if file_events:
+                        dates = [e.timestamp for e in file_events]
+                        console.print(f"    {fname}: {len(file_events):,} events "
+                                      f"({min(dates):%Y-%m-%d} to {max(dates):%Y-%m-%d})")
+                    else:
+                        console.print(f"    {fname}: 0 events")
+                if dup_count:
+                    console.print(f"  {platform}: {len(deduped_events):,} events after dedup "
+                                  f"({dup_count:,} duplicates removed)")
+                else:
+                    console.print(f"  {platform}: {len(deduped_events):,} events (no duplicates)")
 
     configured = sum(1 for p in _PLATFORM_PARSERS if config.PLATFORM_PATHS.get(p[0]))
     if configured == 0 and fail_on_error:
@@ -353,12 +419,11 @@ def ingest_providers(fail_on_error: bool = True) -> list:
     event_store.remove_disabled_providers(config.EVENT_DB_PATH, active_platforms)
 
     for platform, (pevents, paths) in platform_events_by_provider.items():
-        source_sha = _compute_paths_sha256(paths)
-        source_path = "|".join(paths)
-        persisted = event_store.replace_provider_events(
-            config.EVENT_DB_PATH, platform, pevents, source_path, source_sha,
+        manifest, snapshot_sha = _build_source_manifest(paths)
+        persisted, _total_raw = event_store.replace_provider_events(
+            config.EVENT_DB_PATH, platform, pevents, manifest, snapshot_sha,
         )
-        console.print(f"  {platform}: {persisted} events persisted to SQLite")
+        console.print(f"  {platform}: {persisted:,} events persisted to SQLite")
 
     all_events_from_db = event_store.load_events(config.EVENT_DB_PATH)
     all_events_from_db.extend(manual_events)

--- a/recommender/setup.py
+++ b/recommender/setup.py
@@ -415,8 +415,10 @@ def ingest_providers(fail_on_error: bool = True) -> list:
 
     # Persist to SQLite
     event_store.init_db(config.EVENT_DB_PATH)
-    active_platforms = list(platform_events_by_provider.keys())
-    event_store.remove_disabled_providers(config.EVENT_DB_PATH, active_platforms)
+    # Use configured providers (those with paths set), not just successfully-parsed
+    # ones.  A parse failure should not cause removal of that provider's persisted data.
+    configured_platforms = [p for p, _ in _PLATFORM_PARSERS if config.PLATFORM_PATHS.get(p)]
+    event_store.remove_disabled_providers(config.EVENT_DB_PATH, configured_platforms)
 
     for platform, (pevents, paths) in platform_events_by_provider.items():
         manifest, snapshot_sha = _build_source_manifest(paths)

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,134 @@
+"""Tests for config.py platform_paths normalization.
+
+Tests exercise _resolve_platform_paths directly (imported from config).
+The function is pure given a _paths dict, so we patch config._paths in-place.
+"""
+
+import config
+from pathlib import Path
+
+
+def _resolve(raw_value, platform="netflix", default="data/netflix/export.zip"):
+    """Call _resolve_platform_paths with a controlled _paths dict."""
+    original = config._paths
+    try:
+        config._paths = {platform: raw_value}
+        return config._resolve_platform_paths(platform, default)
+    finally:
+        config._paths = original
+
+
+def _resolve_missing(platform="netflix", default="data/netflix/export.zip"):
+    """Call _resolve_platform_paths when the platform key is absent."""
+    original = config._paths
+    try:
+        config._paths = {}
+        return config._resolve_platform_paths(platform, default)
+    finally:
+        config._paths = original
+
+
+# ---------------------------------------------------------------------------
+# Input shape normalization
+# ---------------------------------------------------------------------------
+
+class TestResolvePlatformPaths:
+
+    def test_string_wraps_in_list(self):
+        result = _resolve("data/netflix/export.zip")
+        assert isinstance(result, list)
+        assert len(result) == 1
+        assert result[0].endswith("data/netflix/export.zip")
+
+    def test_list_of_strings_passthrough(self):
+        result = _resolve(["data/netflix/a.zip", "data/netflix/b.zip"])
+        assert isinstance(result, list)
+        assert len(result) == 2
+        assert result[0].endswith("data/netflix/a.zip")
+        assert result[1].endswith("data/netflix/b.zip")
+
+    def test_null_returns_empty_list(self):
+        assert _resolve(None) == []
+
+    def test_empty_string_returns_empty_list(self):
+        assert _resolve("") == []
+
+    def test_empty_list_returns_empty_list(self):
+        assert _resolve([]) == []
+
+    def test_list_with_empty_strings_filtered(self):
+        result = _resolve(["data/netflix/export.zip", ""])
+        assert len(result) == 1
+        assert result[0].endswith("data/netflix/export.zip")
+
+    def test_disabled_is_falsy(self):
+        """Empty list must be falsy — existing 'if not path:' callers rely on this."""
+        assert not _resolve(None)
+
+    def test_enabled_is_truthy(self):
+        assert _resolve("data/netflix/export.zip")
+
+    def test_string_path_is_absolute(self):
+        result = _resolve("data/netflix/export.zip")
+        assert Path(result[0]).is_absolute()
+
+    def test_list_paths_are_absolute(self):
+        result = _resolve(["data/netflix/a.zip", "data/netflix/b.zip"])
+        for p in result:
+            assert Path(p).is_absolute()
+
+
+# ---------------------------------------------------------------------------
+# Missing key uses repo default
+# ---------------------------------------------------------------------------
+
+class TestMissingKeyUsesDefault:
+
+    def test_missing_key_returns_default(self):
+        result = _resolve_missing("netflix", "data/netflix/export.zip")
+        assert isinstance(result, list)
+        assert len(result) == 1
+        assert result[0].endswith("data/netflix/export.zip")
+
+    def test_missing_key_with_no_default_returns_empty_list(self):
+        result = _resolve_missing("disney", None)
+        assert result == []
+
+    def test_missing_key_default_path_is_absolute(self):
+        result = _resolve_missing("netflix", "data/netflix/export.zip")
+        assert Path(result[0]).is_absolute()
+
+
+# ---------------------------------------------------------------------------
+# PLATFORM_PATHS module-level attribute
+# ---------------------------------------------------------------------------
+
+class TestPlatformPathsAttribute:
+
+    def test_all_values_are_lists(self):
+        for platform, value in config.PLATFORM_PATHS.items():
+            assert isinstance(value, list), (
+                f"PLATFORM_PATHS['{platform}'] should be list, got {type(value)}"
+            )
+
+    def test_known_providers_present(self):
+        for provider in ("netflix", "prime", "apple_tv", "disney", "hbo"):
+            assert provider in config.PLATFORM_PATHS
+
+    def test_disney_disabled_by_default(self):
+        assert config.PLATFORM_PATHS["disney"] == []
+
+    def test_hbo_disabled_by_default(self):
+        assert config.PLATFORM_PATHS["hbo"] == []
+
+    def test_active_providers_truthy(self):
+        """netflix/prime/apple_tv should be truthy unless explicitly disabled in config."""
+        # At least one of the enabled-by-default providers should be truthy
+        # when the repo default paths are in effect (i.e. not overridden to null).
+        enabled = [
+            config.PLATFORM_PATHS.get(p)
+            for p in ("netflix", "prime", "apple_tv")
+        ]
+        # All should be lists (type check), truthiness depends on config.
+        for value in enabled:
+            assert isinstance(value, list)

--- a/tests/test_event_store.py
+++ b/tests/test_event_store.py
@@ -1,10 +1,41 @@
+import json
 import sqlite3
 from datetime import datetime, timedelta
 from pathlib import Path
 
 from recommender.ingestion.base import WatchEvent
-from recommender.event_store import _connect, init_db, replace_provider_events, load_events, get_import_info
+from recommender.event_store import (
+    _connect, _compute_source_hash, init_db, replace_provider_events,
+    load_events, get_import_info,
+)
 
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+_MANIFEST = [{"path": "/exports/export.zip", "sha256": "abc123"}]
+_SNAP_SHA = "snapshot_sha256_value"
+
+
+def _make_event(platform="netflix", title="Succession S1E1", content_type="tv",
+                series_name="Succession", duration_secs=3600, timestamp=None,
+                profile="user1"):
+    return WatchEvent(
+        platform=platform,
+        title=title,
+        content_type=content_type,
+        series_name=series_name,
+        watched_duration=timedelta(seconds=duration_secs),
+        total_duration=None,
+        timestamp=timestamp or datetime(2026, 1, 15, 20, 0, 0),
+        profile=profile,
+    )
+
+
+# ---------------------------------------------------------------------------
+# init_db
+# ---------------------------------------------------------------------------
 
 def test_init_db_creates_tables(tmp_path):
     db_path = str(tmp_path / "test.db")
@@ -44,7 +75,7 @@ def test_init_db_foreign_keys_enabled(tmp_path):
     db_path = str(tmp_path / "test.db")
     init_db(db_path)
 
-    # Use _connect to verify the helper itself enforces FK constraints
+    # Use _connect to verify the helper itself enforces FK constraints.
     conn = _connect(db_path)
     try:
         conn.execute(
@@ -59,22 +90,112 @@ def test_init_db_foreign_keys_enabled(tmp_path):
     conn.close()
 
 
-def _make_event(platform="netflix", title="Succession S1E1", content_type="tv",
-                series_name="Succession", duration_secs=3600, timestamp=None,
-                profile="user1"):
-    return WatchEvent(
-        platform=platform,
-        title=title,
-        content_type=content_type,
-        series_name=series_name,
-        watched_duration=timedelta(seconds=duration_secs),
-        total_duration=None,
-        timestamp=timestamp or datetime(2026, 1, 15, 20, 0, 0),
-        profile=profile,
-    )
+def test_init_db_imports_has_new_columns(tmp_path):
+    db_path = str(tmp_path / "test.db")
+    init_db(db_path)
+
+    conn = sqlite3.connect(db_path)
+    cols = {row[1] for row in conn.execute("PRAGMA table_info(imports)").fetchall()}
+    conn.close()
+
+    assert "source_manifest_json" in cols
+    assert "snapshot_sha256" in cols
+    assert "source_path" not in cols
 
 
-def test_replace_provider_events_inserts_and_returns_count(tmp_path):
+def test_init_db_migrates_legacy_schema(tmp_path):
+    """If the DB has the old source_path schema, init_db should migrate it in place."""
+    db_path = str(tmp_path / "test.db")
+
+    # Bootstrap legacy schema manually.
+    conn = sqlite3.connect(db_path)
+    conn.executescript("""
+        CREATE TABLE imports (
+            id            INTEGER PRIMARY KEY AUTOINCREMENT,
+            provider      TEXT NOT NULL UNIQUE,
+            source_path   TEXT NOT NULL,
+            source_sha256 TEXT NOT NULL,
+            imported_at   TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))
+        );
+        CREATE TABLE watch_events (
+            id                       INTEGER PRIMARY KEY AUTOINCREMENT,
+            provider                 TEXT NOT NULL,
+            title                    TEXT NOT NULL,
+            content_type             TEXT NOT NULL,
+            series_name              TEXT NOT NULL,
+            watched_duration_seconds INTEGER NOT NULL,
+            total_duration_seconds   INTEGER,
+            timestamp_iso            TEXT NOT NULL,
+            profile                  TEXT NOT NULL,
+            import_id                INTEGER NOT NULL,
+            source_hash              TEXT NOT NULL UNIQUE
+        );
+        -- Simulate a user-store table that must survive migration.
+        CREATE TABLE saved_titles (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            title TEXT NOT NULL
+        );
+        INSERT INTO saved_titles (title) VALUES ('Preserved Title');
+        INSERT INTO imports (provider, source_path, source_sha256)
+            VALUES ('netflix', '/old/export.zip', 'oldsha');
+        INSERT INTO watch_events
+            (provider, title, content_type, series_name,
+             watched_duration_seconds, timestamp_iso, profile, import_id, source_hash)
+            VALUES ('netflix', 'Old Show', 'movie', '', 7200, '2026-01-01T00:00:00',
+                    'user', 1, 'oldhash');
+    """)
+    conn.close()
+
+    # Migration should run without error.
+    init_db(db_path)
+
+    conn = sqlite3.connect(db_path)
+    # New schema in place.
+    cols = {row[1] for row in conn.execute("PRAGMA table_info(imports)").fetchall()}
+    assert "source_manifest_json" in cols
+    assert "source_path" not in cols
+
+    # Legacy event data gone (tables were dropped and recreated).
+    events = conn.execute("SELECT * FROM watch_events").fetchall()
+    assert events == []
+
+    # User-store table preserved.
+    rows = conn.execute("SELECT title FROM saved_titles").fetchall()
+    assert rows == [("Preserved Title",)]
+
+    conn.close()
+
+
+# ---------------------------------------------------------------------------
+# _compute_source_hash
+# ---------------------------------------------------------------------------
+
+def test_compute_source_hash_is_deterministic():
+    """Same event, different profile -> same hash."""
+    h1 = _compute_source_hash("netflix", "tv", "Succession", "Succession S1E1",
+                               "2026-01-01T00:00:00", 3600)
+    h2 = _compute_source_hash("netflix", "tv", "Succession", "Succession S1E1",
+                               "2026-01-01T00:00:00", 3600)
+    assert h1 == h2
+
+
+def test_compute_source_hash_differs_by_content_type():
+    h1 = _compute_source_hash("netflix", "tv", "S", "T", "2026-01-01T00:00:00", 3600)
+    h2 = _compute_source_hash("netflix", "movie", "S", "T", "2026-01-01T00:00:00", 3600)
+    assert h1 != h2
+
+
+def test_compute_source_hash_differs_by_series_name():
+    h1 = _compute_source_hash("netflix", "tv", "Series A", "Ep1", "2026-01-01T00:00:00", 3600)
+    h2 = _compute_source_hash("netflix", "tv", "Series B", "Ep1", "2026-01-01T00:00:00", 3600)
+    assert h1 != h2
+
+
+# ---------------------------------------------------------------------------
+# replace_provider_events
+# ---------------------------------------------------------------------------
+
+def test_replace_provider_events_returns_tuple(tmp_path):
     db_path = str(tmp_path / "test.db")
     init_db(db_path)
 
@@ -82,16 +203,17 @@ def test_replace_provider_events_inserts_and_returns_count(tmp_path):
         _make_event(title="Succession S1E1", timestamp=datetime(2026, 1, 1)),
         _make_event(title="Succession S1E2", timestamp=datetime(2026, 1, 2)),
     ]
-    count = replace_provider_events(db_path, "netflix", events, "/path/to/export.zip", "abc123sha")
-    assert count == 2
+    result = replace_provider_events(db_path, "netflix", events, _MANIFEST, _SNAP_SHA)
+    assert result == (2, 2)
 
 
 def test_replace_provider_events_zero_events_persists_import_row(tmp_path):
     db_path = str(tmp_path / "test.db")
     init_db(db_path)
 
-    count = replace_provider_events(db_path, "netflix", [], "/path/to/export.zip", "abc123sha")
-    assert count == 0
+    persisted, total = replace_provider_events(db_path, "netflix", [], _MANIFEST, _SNAP_SHA)
+    assert persisted == 0
+    assert total == 0
 
     conn = sqlite3.connect(db_path)
     rows = conn.execute("SELECT provider FROM imports").fetchall()
@@ -104,25 +226,30 @@ def test_replace_provider_events_replaces_on_reimport(tmp_path):
     db_path = str(tmp_path / "test.db")
     init_db(db_path)
 
+    manifest_v1 = [{"path": "/v1.zip", "sha256": "sha_v1"}]
     events_v1 = [_make_event(title="Old Title", timestamp=datetime(2026, 1, 1))]
-    replace_provider_events(db_path, "netflix", events_v1, "/v1.zip", "sha_v1")
+    replace_provider_events(db_path, "netflix", events_v1, manifest_v1, "snap_v1")
 
+    manifest_v2 = [{"path": "/v2.zip", "sha256": "sha_v2"}]
     events_v2 = [
         _make_event(title="New Title A", timestamp=datetime(2026, 2, 1)),
         _make_event(title="New Title B", timestamp=datetime(2026, 2, 2)),
     ]
-    count = replace_provider_events(db_path, "netflix", events_v2, "/v2.zip", "sha_v2")
-    assert count == 2
+    persisted, total = replace_provider_events(db_path, "netflix", events_v2, manifest_v2, "snap_v2")
+    assert persisted == 2
+    assert total == 2
 
     conn = sqlite3.connect(db_path)
     conn.execute("PRAGMA foreign_keys = ON")
     event_rows = conn.execute("SELECT title FROM watch_events ORDER BY title").fetchall()
-    import_rows = conn.execute("SELECT source_sha256 FROM imports WHERE provider='netflix'").fetchall()
+    import_rows = conn.execute(
+        "SELECT snapshot_sha256 FROM imports WHERE provider='netflix'"
+    ).fetchall()
     conn.close()
 
     assert len(event_rows) == 2
     assert event_rows[0][0] == "New Title A"
-    assert import_rows[0][0] == "sha_v2"
+    assert import_rows[0][0] == "snap_v2"
 
 
 def test_replace_provider_events_isolation(tmp_path):
@@ -131,16 +258,21 @@ def test_replace_provider_events_isolation(tmp_path):
 
     netflix_events = [_make_event(platform="netflix", title="Netflix Show", timestamp=datetime(2026, 1, 1))]
     prime_events = [_make_event(platform="prime", title="Prime Show", timestamp=datetime(2026, 1, 2))]
-    replace_provider_events(db_path, "netflix", netflix_events, "/netflix.zip", "sha_n")
-    replace_provider_events(db_path, "prime", prime_events, "/prime.zip", "sha_p")
+    replace_provider_events(db_path, "netflix", netflix_events,
+                            [{"path": "/netflix.zip", "sha256": "sha_n"}], "snap_n")
+    replace_provider_events(db_path, "prime", prime_events,
+                            [{"path": "/prime.zip", "sha256": "sha_p"}], "snap_p")
 
-    # Replace netflix only
+    # Replace netflix only.
     new_netflix = [_make_event(platform="netflix", title="New Netflix", timestamp=datetime(2026, 3, 1))]
-    replace_provider_events(db_path, "netflix", new_netflix, "/netflix2.zip", "sha_n2")
+    replace_provider_events(db_path, "netflix", new_netflix,
+                            [{"path": "/netflix2.zip", "sha256": "sha_n2"}], "snap_n2")
 
     conn = sqlite3.connect(db_path)
     conn.execute("PRAGMA foreign_keys = ON")
-    all_events = conn.execute("SELECT provider, title FROM watch_events ORDER BY provider, title").fetchall()
+    all_events = conn.execute(
+        "SELECT provider, title FROM watch_events ORDER BY provider, title"
+    ).fetchall()
     conn.close()
 
     assert len(all_events) == 2
@@ -152,13 +284,49 @@ def test_replace_provider_events_dedup_by_source_hash(tmp_path):
     db_path = str(tmp_path / "test.db")
     init_db(db_path)
 
-    # Two events with identical dedup fields
+    # Two events with identical dedup fields (same provider/content_type/series/title/ts/duration).
     ts = datetime(2026, 1, 1, 20, 0, 0)
     dup_event = _make_event(title="Same Title", timestamp=ts, duration_secs=3600)
     events = [dup_event, dup_event]
-    count = replace_provider_events(db_path, "netflix", events, "/export.zip", "sha1")
-    assert count == 1  # one deduplicated away
+    persisted, total = replace_provider_events(db_path, "netflix", events, _MANIFEST, _SNAP_SHA)
+    assert total == 2
+    assert persisted == 1
 
+
+def test_replace_provider_events_profile_not_in_dedup_key(tmp_path):
+    """Same event watched by two profiles -> dedup treats them as one event."""
+    db_path = str(tmp_path / "test.db")
+    init_db(db_path)
+
+    ts = datetime(2026, 1, 1, 20, 0, 0)
+    e1 = _make_event(title="Show X", timestamp=ts, profile="alice")
+    e2 = _make_event(title="Show X", timestamp=ts, profile="bob")
+    persisted, total = replace_provider_events(db_path, "netflix", [e1, e2], _MANIFEST, _SNAP_SHA)
+    assert total == 2
+    assert persisted == 1
+
+
+def test_replace_provider_events_stores_manifest_json(tmp_path):
+    db_path = str(tmp_path / "test.db")
+    init_db(db_path)
+
+    manifest = [{"path": "/a.zip", "sha256": "sha_a"}, {"path": "/b.zip", "sha256": "sha_b"}]
+    replace_provider_events(db_path, "netflix", [], manifest, "snap_multi")
+
+    conn = sqlite3.connect(db_path)
+    row = conn.execute(
+        "SELECT source_manifest_json, snapshot_sha256 FROM imports WHERE provider='netflix'"
+    ).fetchone()
+    conn.close()
+
+    stored_manifest = json.loads(row[0])
+    assert stored_manifest == manifest
+    assert row[1] == "snap_multi"
+
+
+# ---------------------------------------------------------------------------
+# load_events
+# ---------------------------------------------------------------------------
 
 def test_load_events_returns_watch_events_ordered(tmp_path):
     db_path = str(tmp_path / "test.db")
@@ -168,7 +336,7 @@ def test_load_events_returns_watch_events_ordered(tmp_path):
         _make_event(title="Later", timestamp=datetime(2026, 3, 1)),
         _make_event(title="Earlier", timestamp=datetime(2026, 1, 1)),
     ]
-    replace_provider_events(db_path, "netflix", events, "/export.zip", "sha1")
+    replace_provider_events(db_path, "netflix", events, _MANIFEST, _SNAP_SHA)
 
     loaded = load_events(db_path)
     assert len(loaded) == 2
@@ -183,10 +351,10 @@ def test_load_events_provider_filter(tmp_path):
 
     replace_provider_events(db_path, "netflix",
         [_make_event(platform="netflix", title="NF Show", timestamp=datetime(2026, 1, 1))],
-        "/nf.zip", "sha_nf")
+        [{"path": "/nf.zip", "sha256": "sha_nf"}], "snap_nf")
     replace_provider_events(db_path, "prime",
         [_make_event(platform="prime", title="Prime Show", timestamp=datetime(2026, 1, 2))],
-        "/prime.zip", "sha_p")
+        [{"path": "/prime.zip", "sha256": "sha_p"}], "snap_p")
 
     netflix_only = load_events(db_path, provider="netflix")
     assert len(netflix_only) == 1
@@ -215,7 +383,8 @@ def test_load_events_reconstructs_watch_event_fields(tmp_path):
         series_name="The Expanse", duration_secs=2700,
         timestamp=datetime(2026, 6, 15, 14, 30, 0), profile="main",
     )
-    replace_provider_events(db_path, "prime", [original], "/prime.zip", "sha1")
+    replace_provider_events(db_path, "prime", [original],
+                            [{"path": "/prime.zip", "sha256": "sha1"}], "snap1")
 
     loaded = load_events(db_path)
     assert len(loaded) == 1
@@ -230,25 +399,46 @@ def test_load_events_reconstructs_watch_event_fields(tmp_path):
     assert e.profile == "main"
 
 
+# ---------------------------------------------------------------------------
+# get_import_info
+# ---------------------------------------------------------------------------
+
 def test_get_import_info_returns_per_provider_metadata(tmp_path):
     db_path = str(tmp_path / "test.db")
     init_db(db_path)
 
+    nf_manifest = [{"path": "/nf.zip", "sha256": "sha_nf"}]
     replace_provider_events(db_path, "netflix",
         [_make_event(title="Show A", timestamp=datetime(2026, 1, 1)),
          _make_event(title="Show B", timestamp=datetime(2026, 1, 2))],
-        "/nf.zip", "sha_nf")
-    replace_provider_events(db_path, "prime", [], "/prime.zip", "sha_p")
+        nf_manifest, "snap_nf")
+    replace_provider_events(db_path, "prime", [],
+                            [{"path": "/prime.zip", "sha256": "sha_p"}], "snap_p")
 
     info = get_import_info(db_path)
     assert "netflix" in info
-    assert info["netflix"]["source_path"] == "/nf.zip"
-    assert info["netflix"]["source_sha256"] == "sha_nf"
+    assert info["netflix"]["source_manifest"] == nf_manifest
+    assert info["netflix"]["snapshot_sha256"] == "snap_nf"
     assert info["netflix"]["event_count"] == 2
     assert "imported_at" in info["netflix"]
 
     assert "prime" in info
     assert info["prime"]["event_count"] == 0
+
+
+def test_get_import_info_multi_file_manifest(tmp_path):
+    db_path = str(tmp_path / "test.db")
+    init_db(db_path)
+
+    manifest = [
+        {"path": "/jan.zip", "sha256": "sha_jan"},
+        {"path": "/feb.zip", "sha256": "sha_feb"},
+    ]
+    replace_provider_events(db_path, "netflix", [], manifest, "snap_multi")
+
+    info = get_import_info(db_path)
+    assert info["netflix"]["source_manifest"] == manifest
+    assert info["netflix"]["snapshot_sha256"] == "snap_multi"
 
 
 def test_get_import_info_empty_db(tmp_path):

--- a/tests/test_event_store.py
+++ b/tests/test_event_store.py
@@ -155,9 +155,18 @@ def test_init_db_migrates_legacy_schema(tmp_path):
     assert "source_manifest_json" in cols
     assert "source_path" not in cols
 
-    # Legacy event data gone (tables were dropped and recreated).
+    # Legacy event data preserved (in-place migration, not drop+recreate).
     events = conn.execute("SELECT * FROM watch_events").fetchall()
-    assert events == []
+    assert len(events) == 1
+    assert events[0][1] == "netflix"  # provider
+    assert events[0][2] == "Old Show"  # title
+
+    # imports row preserved with new columns defaulted.
+    imports = conn.execute("SELECT provider, source_manifest_json, snapshot_sha256 FROM imports").fetchall()
+    assert len(imports) == 1
+    assert imports[0][0] == "netflix"
+    assert imports[0][1] == "{}"  # default from migration
+    assert imports[0][2] == "oldsha"  # renamed from source_sha256
 
     # User-store table preserved.
     rows = conn.execute("SELECT title FROM saved_titles").fetchall()

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -109,7 +109,7 @@ def test_load_context_returns_lazy_context_regardless_of_platform_paths(monkeypa
     profile_path.write_text('taste profile')
     db_path = str(tmp_path / 'streamline.db')
 
-    monkeypatch.setattr(config, 'PLATFORM_PATHS', {'netflix': '/tmp/missing.zip', 'prime': None, 'apple_tv': None})
+    monkeypatch.setattr(config, 'PLATFORM_PATHS', {'netflix': ['/tmp/missing.zip'], 'prime': [], 'apple_tv': []})
     monkeypatch.setattr(config, 'MANUAL_TV_PATH', None)
     monkeypatch.setattr(config, 'MANUAL_MOVIES_PATH', None)
     monkeypatch.setattr(config, 'WATCH_INDEX_PATH', str(index_path))
@@ -141,7 +141,7 @@ def test_load_context_fallback_does_not_recreate_db(monkeypatch, tmp_path):
     profile_path.write_text("taste profile")
     db_path = tmp_path / "streamline.db"
 
-    monkeypatch.setattr(config, "PLATFORM_PATHS", {"netflix": "/tmp/export.zip", "prime": None, "apple_tv": None})
+    monkeypatch.setattr(config, "PLATFORM_PATHS", {"netflix": ["/tmp/export.zip"], "prime": [], "apple_tv": []})
     monkeypatch.setattr(config, "MANUAL_TV_PATH", None)
     monkeypatch.setattr(config, "MANUAL_MOVIES_PATH", None)
     monkeypatch.setattr(config, "WATCH_INDEX_PATH", str(index_path))
@@ -178,19 +178,19 @@ def test_resolve_platform_path_uses_default_when_key_missing(monkeypatch):
 
     monkeypatch.setattr(config, '_paths', {})
 
-    resolved = config._resolve_platform_path('netflix', 'data/netflix/export.zip')
+    resolved = config._resolve_platform_paths('netflix', 'data/netflix/export.zip')
 
-    assert resolved == str(config._ROOT / 'data/netflix/export.zip')
+    assert resolved == [str(config._ROOT / 'data/netflix/export.zip')]
 
 
 def test_resolve_platform_path_allows_explicit_disable(monkeypatch):
     import config
 
     monkeypatch.setattr(config, '_paths', {'netflix': None})
-    assert config._resolve_platform_path('netflix', 'data/netflix/export.zip') is None
+    assert config._resolve_platform_paths('netflix', 'data/netflix/export.zip') == []
 
     monkeypatch.setattr(config, '_paths', {'netflix': ''})
-    assert config._resolve_platform_path('netflix', 'data/netflix/export.zip') is None
+    assert config._resolve_platform_paths('netflix', 'data/netflix/export.zip') == []
 
 
 def test_merge_dicts_applies_local_overrides_recursively():
@@ -217,7 +217,7 @@ def test_run_ingest_only_exits_if_no_provider_zips_are_configured(monkeypatch, c
     import config
     import recommender.setup as setup
 
-    monkeypatch.setattr(config, 'PLATFORM_PATHS', {'netflix': None, 'prime': None, 'apple_tv': None})
+    monkeypatch.setattr(config, 'PLATFORM_PATHS', {'netflix': [], 'prime': [], 'apple_tv': []})
     monkeypatch.setattr(config, 'MANUAL_TV_PATH', 'manual-tv.csv')
     monkeypatch.setattr(config, 'MANUAL_MOVIES_PATH', 'manual-movies.csv')
     monkeypatch.setattr(setup, 'parse_manual', lambda *_args: [object()])
@@ -258,7 +258,7 @@ def test_run_ingest_only_accepts_empty_provider_export(monkeypatch, capsys, tmp_
     import config
     import recommender.setup as setup
 
-    monkeypatch.setattr(config, 'PLATFORM_PATHS', {'netflix': '/tmp/export.zip', 'prime': None, 'apple_tv': None})
+    monkeypatch.setattr(config, 'PLATFORM_PATHS', {'netflix': ['/tmp/export.zip'], 'prime': [], 'apple_tv': []})
     monkeypatch.setattr(config, 'MANUAL_TV_PATH', None)
     monkeypatch.setattr(config, 'MANUAL_MOVIES_PATH', None)
     monkeypatch.setattr(config, 'EVENT_DB_PATH', str(tmp_path / 'streamline.db'))
@@ -604,7 +604,7 @@ def test_apple_tv_key_present_in_platform_paths():
 def test_resolve_platform_path_with_none_default_returns_none_when_key_missing(monkeypatch):
     import config
     monkeypatch.setattr(config, "_paths", {})
-    assert config._resolve_platform_path("apple_tv", None) is None
+    assert config._resolve_platform_paths("apple_tv", None) == []
 
 
 # ── 3d: config.local.yaml overrides config.yaml when both present ─────────
@@ -704,7 +704,7 @@ def test_run_ingest_only_prints_tv_and_movie_summary(monkeypatch, capsys, tmp_pa
             ),
         ]
 
-    monkeypatch.setattr(config, "PLATFORM_PATHS", {"netflix": "/tmp/export.zip", "prime": None, "apple_tv": None})
+    monkeypatch.setattr(config, "PLATFORM_PATHS", {"netflix": ["/tmp/export.zip"], "prime": [], "apple_tv": []})
     monkeypatch.setattr(config, "MANUAL_TV_PATH", None)
     monkeypatch.setattr(config, "MANUAL_MOVIES_PATH", None)
     monkeypatch.setattr(config, "EVENT_DB_PATH", str(tmp_path / "streamline.db"))
@@ -726,7 +726,7 @@ def test_run_setup_exits_with_no_watch_events_message(monkeypatch, capsys, tmp_p
 
     db_path = str(tmp_path / "streamline.db")
     monkeypatch.setattr(config, "EVENT_DB_PATH", db_path)
-    monkeypatch.setattr(config, "PLATFORM_PATHS", {"netflix": "/tmp/export.zip", "prime": None, "apple_tv": None})
+    monkeypatch.setattr(config, "PLATFORM_PATHS", {"netflix": ["/tmp/export.zip"], "prime": [], "apple_tv": []})
     monkeypatch.setattr(config, "MANUAL_TV_PATH", None)
     monkeypatch.setattr(config, "MANUAL_MOVIES_PATH", None)
     monkeypatch.setattr(config, "TMDB_API_KEY", "fake-tmdb-key")
@@ -757,7 +757,7 @@ def test_load_context_works_with_no_configured_providers(monkeypatch, tmp_path):
     profile_path.write_text("taste profile")
     db_path = tmp_path / "streamline.db"
 
-    monkeypatch.setattr(config, "PLATFORM_PATHS", {"netflix": None, "prime": None, "apple_tv": None})
+    monkeypatch.setattr(config, "PLATFORM_PATHS", {"netflix": [], "prime": [], "apple_tv": []})
     monkeypatch.setattr(config, "MANUAL_TV_PATH", None)
     monkeypatch.setattr(config, "MANUAL_MOVIES_PATH", None)
     monkeypatch.setattr(config, "WATCH_INDEX_PATH", str(index_path))
@@ -795,7 +795,7 @@ def test_refresh_data_reingests_configured_exports(monkeypatch, capsys, tmp_path
 
     monkeypatch.setattr(config, "EVENT_DB_PATH", db_path)
     # Provide a non-None path so the current zip loop WOULD call the parser (making pre-fix test fail)
-    monkeypatch.setattr(config, "PLATFORM_PATHS", {"netflix": "/tmp/netflix_export.zip", "prime": None, "apple_tv": None})
+    monkeypatch.setattr(config, "PLATFORM_PATHS", {"netflix": ["/tmp/netflix_export.zip"], "prime": [], "apple_tv": []})
     monkeypatch.setattr(config, "MANUAL_TV_PATH", None)
     monkeypatch.setattr(config, "MANUAL_MOVIES_PATH", None)
     monkeypatch.setattr(config, "TMDB_API_KEY", "fake-tmdb-key")
@@ -856,7 +856,7 @@ def test_run_setup_zero_events_persists_imports_before_exit(monkeypatch, capsys,
 
     db_path = str(tmp_path / "streamline.db")
     monkeypatch.setattr(config, "EVENT_DB_PATH", db_path)
-    monkeypatch.setattr(config, "PLATFORM_PATHS", {"netflix": "/tmp/export.zip", "prime": None, "apple_tv": None})
+    monkeypatch.setattr(config, "PLATFORM_PATHS", {"netflix": ["/tmp/export.zip"], "prime": [], "apple_tv": []})
     monkeypatch.setattr(config, "MANUAL_TV_PATH", None)
     monkeypatch.setattr(config, "MANUAL_MOVIES_PATH", None)
     monkeypatch.setattr(config, "TMDB_API_KEY", "fake-tmdb-key")
@@ -891,7 +891,7 @@ def test_load_context_does_not_parse_zips(monkeypatch, tmp_path):
     profile_path.write_text("taste profile")
     db_path = str(tmp_path / "streamline.db")
 
-    monkeypatch.setattr(config, "PLATFORM_PATHS", {"netflix": "/tmp/export.zip", "prime": None, "apple_tv": None})
+    monkeypatch.setattr(config, "PLATFORM_PATHS", {"netflix": ["/tmp/export.zip"], "prime": [], "apple_tv": []})
     monkeypatch.setattr(config, "MANUAL_TV_PATH", None)
     monkeypatch.setattr(config, "MANUAL_MOVIES_PATH", None)
     monkeypatch.setattr(config, "WATCH_INDEX_PATH", str(index_path))
@@ -921,7 +921,7 @@ def test_load_context_debug_log_does_not_force_events_load(monkeypatch, tmp_path
     profile_path.write_text("taste profile")
     db_path = str(tmp_path / "streamline.db")
 
-    monkeypatch.setattr(config, "PLATFORM_PATHS", {"netflix": None, "prime": None, "apple_tv": None})
+    monkeypatch.setattr(config, "PLATFORM_PATHS", {"netflix": [], "prime": [], "apple_tv": []})
     monkeypatch.setattr(config, "MANUAL_TV_PATH", None)
     monkeypatch.setattr(config, "MANUAL_MOVIES_PATH", None)
     monkeypatch.setattr(config, "WATCH_INDEX_PATH", str(index_path))

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -791,7 +791,7 @@ def test_refresh_data_reingests_configured_exports(monkeypatch, capsys, tmp_path
         WatchEvent(platform="netflix", title="Succession S1E1", content_type="tv",
                    series_name="Succession", watched_duration=timedelta(hours=1),
                    total_duration=None, timestamp=datetime(2026, 1, 1), profile="user"),
-    ], "/export.zip", "sha1")
+    ], [{"path": "/export.zip", "sha256": "sha1"}], "sha1")
 
     monkeypatch.setattr(config, "EVENT_DB_PATH", db_path)
     # Provide a non-None path so the current zip loop WOULD call the parser (making pre-fix test fail)

--- a/tests/test_setup_ingest.py
+++ b/tests/test_setup_ingest.py
@@ -197,8 +197,8 @@ def test_ingest_dedup_is_order_independent(monkeypatch, tmp_path):
 # Setup ingest: one bad file aborts that provider without deleting previous data
 # ---------------------------------------------------------------------------
 
-def test_ingest_bad_file_aborts_provider_preserves_previous_snapshot(monkeypatch, tmp_path):
-    """A bad file on re-ingest fails gracefully; prior provider snapshot is intact."""
+def test_ingest_bad_file_preserves_previous_snapshot_in_non_strict_mode(monkeypatch, tmp_path):
+    """A bad file on non-strict re-ingest keeps the prior provider snapshot intact."""
     import config
     import recommender.setup as setup
     from recommender.event_store import load_events
@@ -238,12 +238,11 @@ def test_ingest_bad_file_aborts_provider_preserves_previous_snapshot(monkeypatch
     monkeypatch.setattr(setup, "_PLATFORM_PARSERS", [("netflix", flaky_parser)])
     monkeypatch.setattr(setup, "_compute_file_sha256", lambda _path: "sha_v2")
 
-    # Should fail gracefully (not crash the process with fail_on_error=False)
-    with pytest.raises(SystemExit):
-        setup.ingest_providers(fail_on_error=True)
+    result = setup.ingest_providers(fail_on_error=False)
 
     # Previous snapshot is still intact
     loaded_after_fail = {e.title for e in load_events(db_path)}
+    assert {e.title for e in result} == {"Good Show"}
     assert "Good Show" in loaded_after_fail
 
 

--- a/tests/test_setup_ingest.py
+++ b/tests/test_setup_ingest.py
@@ -1,0 +1,379 @@
+"""Tests for multi-export ingest orchestration, _dedup_events, and runtime fallback."""
+import sqlite3
+from datetime import datetime, timedelta
+
+import pytest
+
+from recommender.ingestion.base import WatchEvent
+from recommender.setup import _dedup_events
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_event(
+    platform="netflix",
+    title="Succession S1E1",
+    content_type="tv",
+    series_name="Succession",
+    duration_secs=3600,
+    timestamp=None,
+    profile="user1",
+):
+    return WatchEvent(
+        platform=platform,
+        title=title,
+        content_type=content_type,
+        series_name=series_name,
+        watched_duration=timedelta(seconds=duration_secs),
+        total_duration=None,
+        timestamp=timestamp or datetime(2026, 1, 15, 20, 0, 0),
+        profile=profile,
+    )
+
+
+# ---------------------------------------------------------------------------
+# _dedup_events unit tests
+# ---------------------------------------------------------------------------
+
+def test_dedup_events_removes_exact_duplicate():
+    """Two identical events collapse to one."""
+    e = _make_event()
+    deduped, dup_count = _dedup_events([e, e])
+    assert len(deduped) == 1
+    assert dup_count == 1
+
+
+def test_dedup_events_different_profile_same_event_counts_as_duplicate():
+    """Same event watched by two profiles -> dedup treats them as one."""
+    ts = datetime(2026, 1, 1, 20, 0, 0)
+    e1 = _make_event(title="Show X", timestamp=ts, profile="alice")
+    e2 = _make_event(title="Show X", timestamp=ts, profile="bob")
+    deduped, dup_count = _dedup_events([e1, e2])
+    assert len(deduped) == 1
+    assert dup_count == 1
+
+
+def test_dedup_events_order_independence():
+    """Regardless of input order, the dedup count and final set are the same."""
+    ts = datetime(2026, 3, 10, 18, 0, 0)
+    shared = _make_event(title="Shared", timestamp=ts, profile="user")
+    unique_a = _make_event(title="Only A", timestamp=datetime(2026, 1, 1), profile="user")
+    unique_b = _make_event(title="Only B", timestamp=datetime(2026, 2, 1), profile="user")
+
+    order1, dups1 = _dedup_events([shared, unique_a, shared, unique_b])
+    order2, dups2 = _dedup_events([unique_b, shared, unique_a, shared])
+
+    assert dups1 == dups2 == 1
+    titles1 = {e.title for e in order1}
+    titles2 = {e.title for e in order2}
+    assert titles1 == titles2 == {"Shared", "Only A", "Only B"}
+
+
+def test_dedup_events_no_false_dedup_different_timestamps():
+    """Events with different timestamps are NOT deduplicated."""
+    e1 = _make_event(title="Show Z", timestamp=datetime(2026, 1, 1, 20, 0, 0))
+    e2 = _make_event(title="Show Z", timestamp=datetime(2026, 1, 2, 20, 0, 0))
+    deduped, dup_count = _dedup_events([e1, e2])
+    assert len(deduped) == 2
+    assert dup_count == 0
+
+
+def test_dedup_events_no_false_dedup_different_duration():
+    """Events with different watch durations are NOT deduplicated."""
+    ts = datetime(2026, 5, 1, 10, 0, 0)
+    e1 = _make_event(title="Film", content_type="movie", series_name="Film",
+                     duration_secs=3600, timestamp=ts)
+    e2 = _make_event(title="Film", content_type="movie", series_name="Film",
+                     duration_secs=5400, timestamp=ts)
+    deduped, dup_count = _dedup_events([e1, e2])
+    assert len(deduped) == 2
+    assert dup_count == 0
+
+
+def test_dedup_events_empty_list():
+    deduped, dup_count = _dedup_events([])
+    assert deduped == []
+    assert dup_count == 0
+
+
+# ---------------------------------------------------------------------------
+# Setup ingest: multiple files merge into one provider snapshot
+# ---------------------------------------------------------------------------
+
+def test_ingest_two_paths_for_one_provider_merges_events(monkeypatch, tmp_path):
+    """Configuring two paths for a provider parses both and merges their events."""
+    import config
+    import recommender.setup as setup
+
+    ts1 = datetime(2026, 1, 1, 20, 0, 0)
+    ts2 = datetime(2026, 2, 1, 20, 0, 0)
+
+    events_file1 = [_make_event(title="File1 Show", timestamp=ts1)]
+    events_file2 = [_make_event(title="File2 Show", timestamp=ts2)]
+
+    call_order = []
+
+    def fake_parser(path):
+        call_order.append(path)
+        if "file1" in path:
+            return events_file1
+        return events_file2
+
+    monkeypatch.setattr(config, "PLATFORM_PATHS", {
+        "netflix": ["/fake/file1.zip", "/fake/file2.zip"],
+        "prime": [],
+        "apple_tv": [],
+    })
+    monkeypatch.setattr(config, "MANUAL_TV_PATH", None)
+    monkeypatch.setattr(config, "MANUAL_MOVIES_PATH", None)
+    monkeypatch.setattr(config, "EVENT_DB_PATH", str(tmp_path / "streamline.db"))
+    monkeypatch.setattr(setup, "_PLATFORM_PARSERS", [("netflix", fake_parser)])
+    monkeypatch.setattr(setup, "_compute_file_sha256", lambda _path: "fakesha256")
+
+    setup.ingest_providers(fail_on_error=True)
+
+    # Both paths were parsed
+    assert "/fake/file1.zip" in call_order
+    assert "/fake/file2.zip" in call_order
+
+    # Both events are persisted
+    from recommender.event_store import load_events
+    db_path = str(tmp_path / "streamline.db")
+    loaded = load_events(db_path)
+    titles = {e.title for e in loaded}
+    assert "File1 Show" in titles
+    assert "File2 Show" in titles
+
+
+# ---------------------------------------------------------------------------
+# Setup ingest: dedup result is order-independent
+# ---------------------------------------------------------------------------
+
+def test_ingest_dedup_is_order_independent(monkeypatch, tmp_path):
+    """Two event lists with overlapping events produce the same dedup count regardless of order."""
+    import config
+    import recommender.setup as setup
+    from recommender.event_store import load_events, init_db
+
+    ts_shared = datetime(2026, 3, 10, 12, 0, 0)
+    shared = _make_event(title="Shared Show", timestamp=ts_shared)
+    unique_a = _make_event(title="Unique A", timestamp=datetime(2026, 1, 1))
+    unique_b = _make_event(title="Unique B", timestamp=datetime(2026, 2, 1))
+
+    def run_ingest(file1_events, file2_events, db_path):
+        def fake_parser(path):
+            if "file1" in path:
+                return file1_events
+            return file2_events
+
+        monkeypatch.setattr(config, "PLATFORM_PATHS", {
+            "netflix": ["/fake/file1.zip", "/fake/file2.zip"],
+            "prime": [],
+            "apple_tv": [],
+        })
+        monkeypatch.setattr(config, "MANUAL_TV_PATH", None)
+        monkeypatch.setattr(config, "MANUAL_MOVIES_PATH", None)
+        monkeypatch.setattr(config, "EVENT_DB_PATH", str(db_path))
+        monkeypatch.setattr(setup, "_PLATFORM_PARSERS", [("netflix", fake_parser)])
+        monkeypatch.setattr(setup, "_compute_file_sha256", lambda _path: "sha")
+        setup.ingest_providers(fail_on_error=True)
+        return {e.title for e in load_events(str(db_path))}
+
+    db1 = tmp_path / "db1.db"
+    db2 = tmp_path / "db2.db"
+
+    # Order 1: file1=[shared, unique_a], file2=[shared, unique_b]
+    titles1 = run_ingest([shared, unique_a], [shared, unique_b], db1)
+
+    # Order 2: file1=[shared, unique_b], file2=[unique_a, shared]
+    titles2 = run_ingest([shared, unique_b], [unique_a, shared], db2)
+
+    assert titles1 == titles2 == {"Shared Show", "Unique A", "Unique B"}
+
+
+# ---------------------------------------------------------------------------
+# Setup ingest: one bad file aborts that provider without deleting previous data
+# ---------------------------------------------------------------------------
+
+def test_ingest_bad_file_aborts_provider_preserves_previous_snapshot(monkeypatch, tmp_path):
+    """A bad file on re-ingest fails gracefully; prior provider snapshot is intact."""
+    import config
+    import recommender.setup as setup
+    from recommender.event_store import load_events
+
+    db_path = str(tmp_path / "streamline.db")
+
+    # --- Step 1: successful first ingest with one good file ---
+    good_event = _make_event(title="Good Show", timestamp=datetime(2026, 1, 1))
+
+    monkeypatch.setattr(config, "PLATFORM_PATHS", {
+        "netflix": ["/fake/good.zip"],
+        "prime": [],
+        "apple_tv": [],
+    })
+    monkeypatch.setattr(config, "MANUAL_TV_PATH", None)
+    monkeypatch.setattr(config, "MANUAL_MOVIES_PATH", None)
+    monkeypatch.setattr(config, "EVENT_DB_PATH", db_path)
+    monkeypatch.setattr(setup, "_PLATFORM_PARSERS", [("netflix", lambda _path: [good_event])])
+    monkeypatch.setattr(setup, "_compute_file_sha256", lambda _path: "sha_good")
+
+    setup.ingest_providers(fail_on_error=False)
+
+    loaded_after_first = {e.title for e in load_events(db_path)}
+    assert "Good Show" in loaded_after_first
+
+    # --- Step 2: reconfigure with one good + one bad file; bad file raises ---
+    def flaky_parser(path):
+        if "bad" in path:
+            raise ValueError("Corrupt export file")
+        return [good_event]
+
+    monkeypatch.setattr(config, "PLATFORM_PATHS", {
+        "netflix": ["/fake/good.zip", "/fake/bad.zip"],
+        "prime": [],
+        "apple_tv": [],
+    })
+    monkeypatch.setattr(setup, "_PLATFORM_PARSERS", [("netflix", flaky_parser)])
+    monkeypatch.setattr(setup, "_compute_file_sha256", lambda _path: "sha_v2")
+
+    # Should fail gracefully (not crash the process with fail_on_error=False)
+    with pytest.raises(SystemExit):
+        setup.ingest_providers(fail_on_error=True)
+
+    # Previous snapshot is still intact
+    loaded_after_fail = {e.title for e in load_events(db_path)}
+    assert "Good Show" in loaded_after_fail
+
+
+# ---------------------------------------------------------------------------
+# Runtime fallback: load_platform_events_from_exports handles multi-path config
+# ---------------------------------------------------------------------------
+
+def test_load_platform_events_from_exports_multi_path(monkeypatch, tmp_path):
+    """load_platform_events_from_exports returns merged deduped events from multiple paths."""
+    import config
+    import recommender.setup as setup
+
+    ts_shared = datetime(2026, 6, 1, 12, 0, 0)
+    shared = _make_event(title="Shared", timestamp=ts_shared)
+    file1_unique = _make_event(title="File1 Only", timestamp=datetime(2026, 1, 1))
+    file2_unique = _make_event(title="File2 Only", timestamp=datetime(2026, 2, 1))
+
+    def fake_parser(path):
+        if "file1" in path:
+            return [shared, file1_unique]
+        return [shared, file2_unique]
+
+    monkeypatch.setattr(config, "PLATFORM_PATHS", {
+        "netflix": ["/fake/file1.zip", "/fake/file2.zip"],
+        "prime": [],
+        "apple_tv": [],
+    })
+    monkeypatch.setattr(setup, "_PLATFORM_PARSERS", [("netflix", fake_parser)])
+    monkeypatch.setattr(setup, "_compute_file_sha256", lambda _path: "sha")
+
+    events = setup.load_platform_events_from_exports(fail_on_error=False)
+
+    titles = {e.title for e in events}
+    assert titles == {"Shared", "File1 Only", "File2 Only"}
+    # Shared appears only once (deduped)
+    assert len([e for e in events if e.title == "Shared"]) == 1
+
+
+# ---------------------------------------------------------------------------
+# Event store migration: user-store tables preserved
+# ---------------------------------------------------------------------------
+
+def test_init_db_migration_preserves_user_store_tables(tmp_path):
+    """After schema migration, saved_titles and title_ratings rows survive."""
+    from recommender.event_store import init_db
+
+    db_path = str(tmp_path / "test.db")
+
+    # Bootstrap legacy schema with user-store tables and data
+    conn = sqlite3.connect(db_path)
+    conn.executescript("""
+        CREATE TABLE imports (
+            id            INTEGER PRIMARY KEY AUTOINCREMENT,
+            provider      TEXT NOT NULL UNIQUE,
+            source_path   TEXT NOT NULL,
+            source_sha256 TEXT NOT NULL,
+            imported_at   TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))
+        );
+        CREATE TABLE watch_events (
+            id                       INTEGER PRIMARY KEY AUTOINCREMENT,
+            provider                 TEXT NOT NULL,
+            title                    TEXT NOT NULL,
+            content_type             TEXT NOT NULL,
+            series_name              TEXT NOT NULL,
+            watched_duration_seconds INTEGER NOT NULL,
+            total_duration_seconds   INTEGER,
+            timestamp_iso            TEXT NOT NULL,
+            profile                  TEXT NOT NULL,
+            import_id                INTEGER NOT NULL,
+            source_hash              TEXT NOT NULL UNIQUE
+        );
+        CREATE TABLE saved_titles (
+            id    INTEGER PRIMARY KEY AUTOINCREMENT,
+            title TEXT NOT NULL
+        );
+        CREATE TABLE title_ratings (
+            id     INTEGER PRIMARY KEY AUTOINCREMENT,
+            title  TEXT NOT NULL,
+            rating TEXT NOT NULL
+        );
+        INSERT INTO saved_titles (title) VALUES ('Watchlisted Show');
+        INSERT INTO title_ratings (title, rating) VALUES ('Rated Show', 'liked');
+    """)
+    conn.close()
+
+    # Migration must succeed
+    init_db(db_path)
+
+    conn = sqlite3.connect(db_path)
+
+    # New schema present
+    cols = {row[1] for row in conn.execute("PRAGMA table_info(imports)").fetchall()}
+    assert "source_manifest_json" in cols
+
+    # saved_titles rows preserved
+    saved = conn.execute("SELECT title FROM saved_titles").fetchall()
+    assert ("Watchlisted Show",) in saved
+
+    # title_ratings rows preserved
+    ratings = conn.execute("SELECT title, rating FROM title_ratings").fetchall()
+    assert ("Rated Show", "liked") in ratings
+
+    conn.close()
+
+
+# ---------------------------------------------------------------------------
+# Runtime fallback: all-or-nothing per provider on bad file
+# ---------------------------------------------------------------------------
+
+def test_load_platform_events_from_exports_bad_file_skips_provider(monkeypatch):
+    """If one file for a provider fails to parse, that provider is entirely skipped."""
+    import config
+    from recommender import setup
+
+    good_event = _make_event(title="Good Event", timestamp=datetime(2026, 1, 1))
+
+    def bad_parser(path):
+        if "bad" in path:
+            raise FileNotFoundError(f"Not found: {path}")
+        return [good_event]
+
+    monkeypatch.setattr(config, "PLATFORM_PATHS", {
+        "netflix": ["/fake/good.zip", "/fake/bad.zip"],
+        "prime": [],
+        "apple_tv": [],
+    })
+    monkeypatch.setattr(setup, "_PLATFORM_PARSERS", [("netflix", bad_parser)])
+    monkeypatch.setattr(setup, "_compute_file_sha256", lambda _path: "sha")
+
+    events = setup.load_platform_events_from_exports(fail_on_error=False)
+
+    # Netflix should be entirely skipped, no partial results
+    assert events == []

--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -152,7 +152,7 @@ class TestStatusObservability:
         profile_path.write_text("taste profile")
         db_path = tmp_path / "events.db"
 
-        monkeypatch.setattr(web.config, "PLATFORM_PATHS", {"netflix": "/tmp/export.zip", "prime": None, "apple_tv": None})
+        monkeypatch.setattr(web.config, "PLATFORM_PATHS", {"netflix": ["/tmp/export.zip"], "prime": [], "apple_tv": []})
         monkeypatch.setattr(web.config, "MANUAL_TV_PATH", None)
         monkeypatch.setattr(web.config, "MANUAL_MOVIES_PATH", None)
         monkeypatch.setattr(web.config, "WATCH_INDEX_PATH", str(index_path))


### PR DESCRIPTION
## Summary

- **Config**: `platform_paths` values now accept lists of paths (backward-compatible with strings). `config.py` normalizes all shapes into `dict[str, list[str]]`.
- **Event store**: `imports` table uses `source_manifest_json` + `snapshot_sha256` for provider-snapshot tracking. Dedup key excludes profile so cross-account duplicates merge correctly. Targeted migration preserves user-state tables (`saved_titles`, `title_ratings`, etc.).
- **Setup ingest**: Multi-path loop with all-or-nothing failure per provider. In-memory dedup before DB insertion. Console reports per-file counts and dedup summary for multi-file providers.
- **Runtime fallback**: `load_platform_events_from_exports()` is list-aware with same all-or-nothing semantics.
- **Tests**: 38 new tests across `test_config.py`, `test_event_store.py`, and `test_setup_ingest.py`. 337 total passing.

Closes #23

## Test plan

- [ ] Run `python3 -m pytest tests/ -v` — 337 passing
- [ ] Verify single-path config still works (no config.local.yaml changes needed)
- [ ] When multi-export zips arrive, add list paths to `config.local.yaml` and run `./recommend setup`
- [ ] Confirm dedup reporting shows per-file counts and duplicate removal
- [ ] Verify `./recommend setup --refresh-profile` loads from SQLite (no zip dependency)