### PR TITLE
feat(llm): local model support with latency tracking

### DIFF
--- a/config.py
+++ b/config.py
@@ -48,6 +48,7 @@ LLM_DEFAULT_API_KEY_ENVS: dict[str, str] = {
     "anthropic": "ANTHROPIC_API_KEY",
     "gemini": "GEMINI_API_KEY",
     "openai": "OPENAI_API_KEY",
+    "local": "OPENAI_API_KEY",  # local endpoints don't require a real key
 }
 
 # ── LLM settings ──
@@ -56,6 +57,7 @@ LLM_MODELS: dict[str, dict[str, str]] = _cfg.get("models", {
     "anthropic": {"fast": "claude-haiku-4-5-20251001", "reason": "claude-sonnet-4-6"},
     "gemini": {"fast": "gemini-2.5-flash", "reason": "gemini-2.5-flash"},
     "openai": {"fast": "gpt-4.1-mini", "reason": "gpt-4.1", "base_url": None},
+    "local": {"fast": "llama3.2", "reason": "llama3.2", "base_url": "http://localhost:11434/v1"},
 })
 
 

--- a/config.yaml
+++ b/config.yaml
@@ -15,6 +15,12 @@ models:
     fast: gpt-4.1-mini
     reason: gpt-4.1
     base_url:                           # empty = api.openai.com, or custom endpoint
+  local:
+    fast: llama3.2                      # model name as listed by `ollama list`
+    reason: llama3.2
+    base_url: http://localhost:11434/v1 # Ollama default; adjust for LM Studio/vLLM
+    timeout_scale: 5                    # multiply all timeouts by this factor (local models are slower)
+    # thinking: true                    # uncomment for reasoning models (gemma4, deepseek-r1, etc.)
 llm:
   timeout_fast: 30
   timeout_reason: 60

--- a/recommender/llm.py
+++ b/recommender/llm.py
@@ -38,13 +38,16 @@ class UsageStats:
     output_tokens: int = 0
     thinking_tokens: int = 0
     cost_usd: float = 0.0
+    total_latency_ms: float = 0.0
     _by_model: dict = field(default_factory=dict)
 
-    def record(self, model: str, input_t: int, output_t: int, thinking_t: int = 0) -> None:
+    def record(self, model: str, input_t: int, output_t: int, thinking_t: int = 0,
+               latency_ms: float = 0.0) -> None:
         self.calls += 1
         self.input_tokens += input_t
         self.output_tokens += output_t
         self.thinking_tokens += thinking_t
+        self.total_latency_ms += latency_ms
 
         pricing = _PRICING.get(model, {"input": 0, "output": 0, "thinking": 0})
         cost = (
@@ -55,18 +58,26 @@ class UsageStats:
         self.cost_usd += cost
 
         if model not in self._by_model:
-            self._by_model[model] = {"calls": 0, "input": 0, "output": 0, "thinking": 0, "cost": 0.0}
+            self._by_model[model] = {"calls": 0, "input": 0, "output": 0, "thinking": 0,
+                                     "cost": 0.0, "latency_ms": 0.0}
         self._by_model[model]["calls"] += 1
         self._by_model[model]["input"] += input_t
         self._by_model[model]["output"] += output_t
         self._by_model[model]["thinking"] += thinking_t
         self._by_model[model]["cost"] += cost
+        self._by_model[model]["latency_ms"] += latency_ms
+
+    def avg_latency_ms(self) -> float:
+        """Average latency per call in milliseconds. 0.0 if no calls recorded."""
+        return self.total_latency_ms / self.calls if self.calls else 0.0
 
     def summary(self) -> str:
         parts = [f"{self.calls} calls"]
         parts.append(f"{self.input_tokens:,} in / {self.output_tokens:,} out")
         if self.thinking_tokens:
             parts.append(f"{self.thinking_tokens:,} thinking")
+        if self.total_latency_ms:
+            parts.append(f"{self.avg_latency_ms():.0f}ms avg latency")
         parts.append(f"~${self.cost_usd:.4f}")
         return " | ".join(parts)
 
@@ -117,16 +128,19 @@ class AnthropicClient(LLMClient):
     def generate(self, prompt: str, role: str = "reason",
                  max_tokens: int = 1000, timeout: float = 30.0) -> str:
         model = self.models.get(role, self.models.get("reason", "claude-sonnet-4-6"))
+        t0 = time.monotonic()
         message = self._client.messages.create(
             model=model,
             max_tokens=max_tokens,
             timeout=timeout,
             messages=[{"role": "user", "content": prompt}],
         )
+        latency_ms = (time.monotonic() - t0) * 1000
         self.usage.record(
             model=model,
             input_t=message.usage.input_tokens,
             output_t=message.usage.output_tokens,
+            latency_ms=latency_ms,
         )
         self.was_truncated = message.stop_reason == "max_tokens"
         if self.was_truncated:
@@ -177,6 +191,7 @@ class GeminiClient(LLMClient):
         )
 
         # Retry on rate limit and timeouts
+        t0 = time.monotonic()
         for attempt in range(3):
             try:
                 response = self._client.models.generate_content(
@@ -193,6 +208,7 @@ class GeminiClient(LLMClient):
                     time.sleep(wait)
                     continue
                 raise
+        latency_ms = (time.monotonic() - t0) * 1000
 
         # Track usage
         um = getattr(response, "usage_metadata", None)
@@ -202,6 +218,7 @@ class GeminiClient(LLMClient):
                 input_t=getattr(um, "prompt_token_count", 0) or 0,
                 output_t=getattr(um, "candidates_token_count", 0) or 0,
                 thinking_t=getattr(um, "thoughts_token_count", 0) or 0,
+                latency_ms=latency_ms,
             )
 
         self.was_truncated = False
@@ -230,24 +247,28 @@ class OpenAIClient(LLMClient):
         self._client = OpenAI(**kwargs)
         self.models = models
         self.usage = UsageStats()
-        self._is_thinking_model = False
+        self._is_thinking_model = bool(models.get("thinking"))
+        self._timeout_scale: float = float(models.get("timeout_scale") or 1.0)
         endpoint = base_url or "api.openai.com"
-        log.info("Using OpenAI-compatible provider (endpoint=%s, fast=%s, reason=%s)",
-                 endpoint, models.get("fast"), models.get("reason"))
+        log.info("Using OpenAI-compatible provider (endpoint=%s, fast=%s, reason=%s, timeout_scale=%.1f)",
+                 endpoint, models.get("fast"), models.get("reason"), self._timeout_scale)
 
     def generate(self, prompt: str, role: str = "reason",
                  max_tokens: int = 1000, timeout: float = 30.0) -> str:
         model = self.models.get(role, self.models.get("reason", "gpt-4.1-mini"))
 
-        # Thinking models (GLM, o-series) need more tokens for reasoning
-        adjusted_tokens = max(max_tokens * 3, 4000) if self._is_thinking_model else max_tokens
+        # Thinking models (GLM, o-series, gemma4) spend tokens on reasoning before
+        # the actual response. 6x with an 8000-token floor keeps the answer intact.
+        adjusted_tokens = max(max_tokens * 6, 8000) if self._is_thinking_model else max_tokens
+        scaled_timeout = timeout * self._timeout_scale
 
+        t0 = time.monotonic()
         for attempt in range(3):
             try:
                 response = self._client.chat.completions.create(
                     model=model,
                     max_tokens=adjusted_tokens,
-                    timeout=timeout,
+                    timeout=scaled_timeout,
                     messages=[{"role": "user", "content": prompt}],
                 )
                 break
@@ -259,6 +280,7 @@ class OpenAIClient(LLMClient):
                     time.sleep(wait)
                     continue
                 raise
+        latency_ms = (time.monotonic() - t0) * 1000
 
         choice = response.choices[0]
         text = choice.message.content or ""
@@ -269,13 +291,18 @@ class OpenAIClient(LLMClient):
                 model=model,
                 input_t=response.usage.prompt_tokens or 0,
                 output_t=response.usage.completion_tokens or 0,
+                latency_ms=latency_ms,
             )
 
-        # Auto-detect thinking models (GLM, o-series) for future token scaling
-        if hasattr(choice.message, "reasoning_content") and choice.message.reasoning_content:
-            if not self._is_thinking_model:
-                log.info("Detected thinking model (%s), enabling token scaling.", model)
-                self._is_thinking_model = True
+        # Auto-detect thinking models (GLM, o-series, gemma4) for future token scaling.
+        # OpenAI uses 'reasoning_content', Ollama uses 'reasoning'.
+        has_reasoning = (
+            (hasattr(choice.message, "reasoning_content") and choice.message.reasoning_content)
+            or (hasattr(choice.message, "reasoning") and choice.message.reasoning)
+        )
+        if has_reasoning and not self._is_thinking_model:
+            log.info("Detected thinking model (%s), enabling token scaling.", model)
+            self._is_thinking_model = True
 
         self.was_truncated = choice.finish_reason == "length"
         if self.was_truncated:
@@ -290,29 +317,45 @@ def create_client(provider: str | None = None) -> LLMClient:
 
     Args:
         provider: Override provider name. If None, uses config.LLM_PROVIDER.
+
+    Supported providers: 'anthropic', 'gemini', 'openai', 'local'.
+    'local' is an alias for 'openai' with base_url pointing to a local endpoint
+    (Ollama, LM Studio, vLLM, etc.). The API key is not required for local endpoints.
     """
     import config
 
     provider = provider or config.LLM_PROVIDER
-    models = config.LLM_MODELS.get(provider, {})
+
+    # 'local' is an alias for 'openai' with a local base_url
+    config_key = "openai" if provider == "local" else provider
+    models = config.LLM_MODELS.get(provider, config.LLM_MODELS.get(config_key, {}))
 
     if not models:
         raise ValueError(f"No model config for provider '{provider}' in config.yaml")
 
-    api_key_env = config.get_llm_api_key_env(provider)
+    base_url = models.get("base_url") or None
+    is_local = provider == "local" or (
+        base_url and any(base_url.startswith(p) for p in ("http://localhost", "http://127.0.0.1"))
+    )
+
+    api_key_env = config.get_llm_api_key_env(config_key)
     if api_key_env in config.LLM_DEFAULT_API_KEY_ENVS.values():
         api_key = getattr(config, api_key_env, os.environ.get(api_key_env, ""))
     else:
         api_key = os.environ.get(api_key_env, "")
+
     if not api_key:
-        raise RuntimeError(f"{api_key_env} not set. Export it or add to .env.")
+        if is_local:
+            # Local endpoints (Ollama, LM Studio, vLLM) don't need a real API key.
+            api_key = "local"
+        else:
+            raise RuntimeError(f"{api_key_env} not set. Export it or add to .env.")
 
     if provider == "gemini":
         return GeminiClient(api_key=api_key, models=models)
     elif provider == "anthropic":
         return AnthropicClient(api_key=api_key, models=models)
-    elif provider == "openai":
-        base_url = models.get("base_url") or None
+    elif provider in ("openai", "local"):
         return OpenAIClient(api_key=api_key, models=models, base_url=base_url)
     else:
-        raise ValueError(f"Unknown LLM provider: {provider}. Use 'anthropic', 'gemini', or 'openai'.")
+        raise ValueError(f"Unknown LLM provider: {provider}. Use 'anthropic', 'gemini', 'openai', or 'local'.")

--- a/recommender/main.py
+++ b/recommender/main.py
@@ -166,7 +166,7 @@ def main() -> None:
     parser.add_argument("--type", choices=["tv", "movie"], default="tv",
                         help="Content type for --add (default: tv)")
     parser.add_argument("--history", action="store_true", help="Show recent query history")
-    parser.add_argument("--provider", choices=["anthropic", "gemini", "openai"],
+    parser.add_argument("--provider", choices=["anthropic", "gemini", "openai", "local"],
                         help="LLM provider (default: from config/env)")
     args = parser.parse_args()
 

--- a/recommender/query_engine.py
+++ b/recommender/query_engine.py
@@ -525,11 +525,11 @@ def ask(
     for c in candidates:
         seen_ids.add(c.tmdb_id)
 
-    # Source 2: Claude suggestions (semantic, taste-aware — always runs)
-    log.debug("Fetching Claude suggestions for semantic coverage (similar_to=%s)", intent.similar_to)
+    # Source 2: LLM suggestions (semantic, taste-aware — always runs)
+    log.debug("Fetching LLM suggestions for semantic coverage (similar_to=%s)", intent.similar_to)
     suggestions = _generate_suggestions(query, ctx.taste_profile, ctx.llm,
                                          similar_to=intent.similar_to)
-    log.debug("Claude suggested %d titles: %s", len(suggestions), suggestions[:10])
+    log.debug("LLM suggested %d titles: %s", len(suggestions), suggestions[:10])
     suggestion_count = 0
     for title in suggestions:
         for ct in content_types:
@@ -545,7 +545,7 @@ def ask(
                 candidates.append(meta)
                 seen_ids.add(meta.tmdb_id)
                 suggestion_count += 1
-    log.debug("Claude suggestions added %d new candidates", suggestion_count)
+    log.debug("LLM suggestions added %d new candidates", suggestion_count)
 
     if log.isEnabledFor(logging.DEBUG) and candidates:
         log.debug("Final candidate pool (%d): %s",
@@ -576,7 +576,7 @@ def ask(
         unfiltered = []
         for rec in results:
             meta = meta_by_title.get(rec.title)
-            if meta:
+            if meta and meta.content_type:
                 providers = ctx.tmdb_client.get_watch_providers(
                     meta.tmdb_id, meta.content_type,
                     ctx.watch_region, ctx.providers_cache_dir,

--- a/recommender/setup.py
+++ b/recommender/setup.py
@@ -450,7 +450,7 @@ def run_ingest_only() -> None:
     console.print("\n[green]All configured providers validated and persisted.[/green]")
 
 
-def run_setup(refresh_profile: bool = False, refresh_data: bool = False, provider: str | None = None) -> None:
+def run_setup(refresh_profile: bool = False, refresh_data: bool = False, provider: str | None = None, profile_path: str | None = None) -> None:
     if not config.TMDB_API_KEY:
         console.print("[red]Error: TMDB_API_KEY not set. Export it and re-run.[/red]")
         sys.exit(1)
@@ -616,15 +616,16 @@ def run_setup(refresh_profile: bool = False, refresh_data: bool = False, provide
                           f"{removed['enrichment_index']} index entries, "
                           f"{removed['providers']} provider files)")
 
-        with console.status(f"[bold magenta]Enriching {len(metadata)} titles with Claude Haiku...[/bold magenta]", spinner="dots"):
+        with console.status(f"[bold magenta]Enriching {len(metadata)} titles...[/bold magenta]", spinner="dots"):
             raw_enrichments = enrich_batch(metadata, config.ENRICHMENT_CACHE_DIR, llm)
         enrichments_index_path.write_text(json.dumps(raw_enrichments))
         console.print(f"  {len(raw_enrichments)} descriptions cached → {config.ENRICHMENT_CACHE_DIR}")
 
         enrichments = _title_keyed_enrichments(raw_enrichments, index.entries, metadata)
 
-    profile_path = Path(config.TASTE_PROFILE_PATH)
-    if refresh_profile or not profile_path.exists():
+    using_custom_path = profile_path is not None
+    resolved_profile_path = Path(profile_path) if using_custom_path else Path(config.TASTE_PROFILE_PATH)
+    if refresh_profile or not resolved_profile_path.exists():
         user_store.ensure_user_store(config.EVENT_DB_PATH, config.FEEDBACK_PATH)
         ratings = user_store.load_ratings(config.EVENT_DB_PATH)
         liked_count = sum(1 for r in ratings if r["rating"] == "liked")
@@ -632,7 +633,7 @@ def run_setup(refresh_profile: bool = False, refresh_data: bool = False, provide
         if liked_count or disliked_count:
             console.print(f"  Applying feedback: {liked_count} liked, {disliked_count} disliked titles")
 
-        with console.status("[bold magenta]Building taste profile with Claude Sonnet...[/bold magenta]", spinner="dots"):
+        with console.status("[bold magenta]Building taste profile...[/bold magenta]", spinner="dots"):
             scores = compute_scores(events, metadata, config.RECENCY_HALF_LIFE_DAYS)
             scores = user_store.apply_rating_multipliers(scores, ratings)
             negative_prefs = user_store.get_disliked_titles(config.EVENT_DB_PATH)
@@ -643,16 +644,17 @@ def run_setup(refresh_profile: bool = False, refresh_data: bool = False, provide
                 console.print(f"\n[red]{exc}[/red]")
                 console.print("[yellow]Previous profile kept unchanged.[/yellow]")
                 sys.exit(1)
-        profile_path.parent.mkdir(parents=True, exist_ok=True)
-        # Auto-backup previous profile before overwriting
-        if profile_path.exists():
+        resolved_profile_path.parent.mkdir(parents=True, exist_ok=True)
+        # Auto-backup previous profile before overwriting, but only for the canonical path.
+        # When writing to a custom path we are creating a new file alongside the default, not replacing it.
+        if not using_custom_path and resolved_profile_path.exists():
             from datetime import datetime
             ts = datetime.now().strftime("%Y%m%d_%H%M%S")
-            backup = profile_path.with_name(f"taste_profile_{ts}.txt")
-            profile_path.rename(backup)
+            backup = resolved_profile_path.with_name(f"taste_profile_{ts}.txt")
+            resolved_profile_path.rename(backup)
             console.print(f"  Previous profile backed up → {backup.name}")
-        profile_path.write_text(profile)
-        console.print(f"  Taste profile saved → {config.TASTE_PROFILE_PATH}")
+        resolved_profile_path.write_text(profile)
+        console.print(f"  Taste profile saved → {resolved_profile_path}")
     else:
         console.print("\nTaste profile exists, skipping (use --refresh-profile to rebuild).")
 
@@ -669,8 +671,10 @@ if __name__ == "__main__":
                         help="Load and report on ingested data without TMDB or LLM calls")
     parser.add_argument("--debug", action="store_true",
                         help="Enable debug logging")
-    parser.add_argument("--provider", choices=["anthropic", "gemini", "openai"],
+    parser.add_argument("--provider", choices=["anthropic", "gemini", "openai", "local"],
                         help="LLM provider (default: from config/env)")
+    parser.add_argument("--profile-path", type=str, default=None,
+                        help="Write taste profile to this path instead of the default")
     args = parser.parse_args()
     from recommender.log import setup_logging
     setup_logging(level_override="DEBUG" if args.debug else None)
@@ -678,4 +682,4 @@ if __name__ == "__main__":
         run_ingest_only()
     else:
         run_setup(refresh_profile=args.refresh_profile, refresh_data=args.refresh_data,
-                  provider=args.provider)
+                  provider=args.provider, profile_path=args.profile_path)

--- a/recommender/tmdb_client.py
+++ b/recommender/tmdb_client.py
@@ -543,6 +543,8 @@ class TmdbClient:
         Results are cached in providers_cache_dir to avoid repeated API calls.
         Returns an empty list if no provider data is available.
         """
+        if not content_type or not providers_cache_dir:
+            return []
         cache_path = Path(providers_cache_dir) / content_type / region / f"{tmdb_id}.json"
         if cache_path.exists():
             cached = json.loads(cache_path.read_text())

--- a/tools/compare_providers.py
+++ b/tools/compare_providers.py
@@ -1,0 +1,253 @@
+#!/usr/bin/env python3
+"""Compare recommendation output between two LLM providers side-by-side.
+
+Usage:
+    .venv/bin/python tools/compare_providers.py
+
+Runs a fixed set of queries against both 'anthropic' and 'local' providers,
+then writes a human-readable side-by-side comparison to comparison_results.txt.
+"""
+
+import os
+import sys
+import time
+import traceback
+from pathlib import Path
+
+# Resolve project root (one level up from tools/)
+PROJECT_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(PROJECT_ROOT))
+
+# Load .env before importing any project code
+_env_path = PROJECT_ROOT / ".env"
+if _env_path.exists():
+    with open(_env_path) as _f:
+        for _line in _f:
+            _line = _line.strip()
+            if _line and not _line.startswith("#") and "=" in _line:
+                _k, _, _v = _line.partition("=")
+                os.environ.setdefault(_k.strip(), _v.strip())
+
+import config
+from recommender.llm import create_client
+from recommender.tmdb_client import TmdbClient
+from recommender.query_engine import RecommendContext, ask
+from recommender.user_state import UserStateIndex
+from recommender import watch_index as wi
+from recommender import user_store
+from recommender.event_store import load_events
+
+
+QUERIES = [
+    "British crime drama",
+    "Korean thriller",
+    "feel-good comedy",
+    "sci-fi mystery",
+    "documentary about nature",
+]
+
+PROVIDERS = ["anthropic", "local"]
+
+OUTPUT_PATH = PROJECT_ROOT / "comparison_results.txt"
+
+
+def _events_loader() -> list:
+    events = load_events(config.EVENT_DB_PATH)
+    if not events and not Path(config.EVENT_DB_PATH).exists():
+        from recommender.setup import load_platform_events_from_exports
+        return load_platform_events_from_exports(fail_on_error=False)
+    return events
+
+
+def _load_user_state():
+    if Path(config.EVENT_DB_PATH).exists():
+        user_store.ensure_user_store(config.EVENT_DB_PATH, config.FEEDBACK_PATH)
+    return UserStateIndex.load(config.EVENT_DB_PATH)
+
+
+def load_shared_resources():
+    """Load resources shared across both providers (watch index, taste profile, tmdb)."""
+    index_path = Path(config.WATCH_INDEX_PATH)
+    profile_path = Path(config.TASTE_PROFILE_PATH)
+
+    if not index_path.exists():
+        print("ERROR: Watch index not found. Run: ./recommend setup", file=sys.stderr)
+        sys.exit(1)
+    if not profile_path.exists():
+        print("ERROR: Taste profile not found. Run: ./recommend setup", file=sys.stderr)
+        sys.exit(1)
+
+    taste_profile = profile_path.read_text()
+    watch_index = wi.load(config.WATCH_INDEX_PATH)
+    tmdb_client = TmdbClient(api_key=config.TMDB_API_KEY, cache_dir=config.CACHE_DIR)
+    user_state = _load_user_state()
+    return taste_profile, watch_index, tmdb_client, user_state
+
+
+def build_context(provider: str, taste_profile, watch_index, tmdb_client, user_state) -> RecommendContext:
+    llm = create_client(provider)
+    return RecommendContext(
+        taste_profile=taste_profile,
+        watch_index=watch_index,
+        tmdb_client=tmdb_client,
+        llm=llm,
+        cache_dir=config.ENRICHMENT_CACHE_DIR,
+        _events_loader=_events_loader,
+        providers_cache_dir=config.PROVIDERS_CACHE_DIR,
+        watch_region=config.WATCH_REGION,
+        streaming_platforms=list(config.STREAMING_PLATFORMS),
+        user_state=user_state,
+    )
+
+
+def run_query_for_provider(ctx: RecommendContext, query: str, provider: str) -> dict:
+    """Run a single query and return a result dict."""
+    ctx.llm.usage.reset()
+    start = time.monotonic()
+    try:
+        results = ask(query, ctx)
+        elapsed_ms = (time.monotonic() - start) * 1000
+        return {
+            "provider": provider,
+            "query": query,
+            "results": results,
+            "total_latency_ms": elapsed_ms,
+            "llm_total_latency_ms": ctx.llm.usage.total_latency_ms,
+            "llm_avg_latency_ms": ctx.llm.usage.avg_latency_ms(),
+            "llm_calls": ctx.llm.usage.calls,
+            "error": None,
+        }
+    except Exception as exc:
+        elapsed_ms = (time.monotonic() - start) * 1000
+        return {
+            "provider": provider,
+            "query": query,
+            "results": [],
+            "total_latency_ms": elapsed_ms,
+            "llm_total_latency_ms": 0.0,
+            "llm_avg_latency_ms": 0.0,
+            "llm_calls": 0,
+            "error": f"{type(exc).__name__}: {exc}",
+        }
+
+
+def format_results_block(result: dict) -> list[str]:
+    """Format a single provider result as lines."""
+    lines = []
+    if result["error"]:
+        lines.append(f"  FAILED: {result['error']}")
+    elif not result["results"]:
+        lines.append("  (no recommendations returned)")
+    else:
+        for i, rec in enumerate(result["results"], 1):
+            genres = ", ".join(rec.genres[:3]) if rec.genres else "unknown genre"
+            lines.append(f"  {i}. {rec.title}  [score: {rec.score:.2f}]  [{genres}]")
+            if rec.explanation:
+                # Wrap explanation at ~80 chars, indent
+                explanation = rec.explanation.replace("\n", " ").strip()
+                if len(explanation) > 200:
+                    explanation = explanation[:197] + "..."
+                lines.append(f"     {explanation}")
+    lines.append(f"  Latency: {result['total_latency_ms']:.0f}ms total | "
+                 f"{result['llm_total_latency_ms']:.0f}ms LLM | "
+                 f"{result['llm_avg_latency_ms']:.0f}ms avg/call | "
+                 f"{result['llm_calls']} LLM calls")
+    return lines
+
+
+def write_report(all_results: list[dict]) -> None:
+    """Write comparison_results.txt with side-by-side layout per query."""
+    lines = []
+    lines.append("=" * 80)
+    lines.append("PROVIDER COMPARISON REPORT")
+    lines.append(f"Queries tested: {len(QUERIES)}")
+    lines.append(f"Providers: {', '.join(PROVIDERS)}")
+    lines.append("=" * 80)
+    lines.append("")
+
+    # Group by query
+    by_query: dict[str, dict[str, dict]] = {}
+    for r in all_results:
+        by_query.setdefault(r["query"], {})[r["provider"]] = r
+
+    for query in QUERIES:
+        lines.append(f"QUERY: \"{query}\"")
+        lines.append("-" * 80)
+        provider_results = by_query.get(query, {})
+        for provider in PROVIDERS:
+            lines.append(f"  [{provider.upper()}]")
+            result = provider_results.get(provider)
+            if result is None:
+                lines.append("  (not run)")
+            else:
+                lines.extend(format_results_block(result))
+            lines.append("")
+        lines.append("=" * 80)
+        lines.append("")
+
+    OUTPUT_PATH.write_text("\n".join(lines))
+
+
+def main():
+    if not config.TMDB_API_KEY:
+        print("ERROR: TMDB_API_KEY not set.", file=sys.stderr)
+        sys.exit(1)
+
+    print("Loading shared resources (watch index, taste profile, TMDB)...", file=sys.stderr)
+    taste_profile, watch_index, tmdb_client, user_state = load_shared_resources()
+    print(f"Watch index: {len(watch_index.entries)} entries", file=sys.stderr)
+
+    # Build contexts, catching per-provider init failures
+    contexts: dict[str, RecommendContext | None] = {}
+    init_errors: dict[str, str] = {}
+    for provider in PROVIDERS:
+        print(f"Initializing {provider} provider...", file=sys.stderr)
+        try:
+            ctx = build_context(provider, taste_profile, watch_index, tmdb_client, user_state)
+            contexts[provider] = ctx
+            print(f"  {provider}: OK", file=sys.stderr)
+        except Exception as exc:
+            contexts[provider] = None
+            init_errors[provider] = f"{type(exc).__name__}: {exc}"
+            print(f"  {provider}: FAILED — {exc}", file=sys.stderr)
+
+    all_results = []
+
+    # Pre-populate error results for failed inits
+    for provider, error in init_errors.items():
+        for query in QUERIES:
+            all_results.append({
+                "provider": provider,
+                "query": query,
+                "results": [],
+                "total_latency_ms": 0.0,
+                "llm_total_latency_ms": 0.0,
+                "llm_avg_latency_ms": 0.0,
+                "llm_calls": 0,
+                "error": error,
+            })
+
+    total = len(QUERIES) * sum(1 for p in PROVIDERS if contexts.get(p) is not None)
+    done = 0
+
+    for query in QUERIES:
+        for provider in PROVIDERS:
+            ctx = contexts.get(provider)
+            if ctx is None:
+                continue  # already recorded init error above
+            done += 1
+            print(f"[{done}/{total}] {provider}: \"{query}\"...", file=sys.stderr)
+            result = run_query_for_provider(ctx, query, provider)
+            all_results.append(result)
+            if result["error"]:
+                print(f"  FAILED: {result['error']}", file=sys.stderr)
+            else:
+                titles = [r.title for r in result["results"]]
+                print(f"  OK: {titles} ({result['total_latency_ms']:.0f}ms)", file=sys.stderr)
+
+    write_report(all_results)
+    print(f"\nResults written to: {OUTPUT_PATH}", file=sys.stderr)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

- Add `local` provider alias for OpenAI-compatible local endpoints (Ollama, LM Studio, vLLM) — no API key required
- Add `timeout_scale` config for slow models and `thinking` flag for reasoning models (gemma4, deepseek-r1) with 6x token scaling
- Auto-detect thinking models via both OpenAI (`reasoning_content`) and Ollama (`reasoning`) response formats
- Track per-call latency in `UsageStats`, surfaced in the summary line as avg latency
- Add `--profile-path` flag to setup for writing taste profiles to alternate paths (comparison testing)
- Fix `PosixPath / None` crash in watch provider lookups when `content_type` is missing
- Replace hardcoded "Claude" references in logs and spinners with provider-neutral labels
- Add `tools/compare_providers.py` for side-by-side query comparison across providers

## Usage

```bash
# Run with local Ollama model
./recommend --provider local "British crime drama"

# Generate taste profile to alternate path for comparison
./recommend setup --refresh-profile --provider local --profile-path recommender/cache/taste_profile_local.txt

# Compare providers side-by-side
.venv/bin/python tools/compare_providers.py
```

## Test plan

- [x] 337 existing tests pass
- [x] Tested with Ollama (qwen2.5:14b, gemma4:26b) — full query pipeline completes
- [x] Tested taste profile generation with local model (9 batches + merge)
- [x] Verified latency tracking appears in usage summary
- [x] Verified thinking model token scaling works (gemma4 reasoning tokens)
- [x] Verified PosixPath/None fix prevents crash on missing content_type