### PR TITLE
fix(tmdb): bypass ambiguity check when runner-up has the same name

### DIFF
--- a/recommender/tmdb_client.py
+++ b/recommender/tmdb_client.py
@@ -412,12 +412,7 @@ class TmdbClient:
 
         if len(scored) > 1:
             margin = best_total - scored[1][1]
-            second_sim = scored[1][0]
-            # If the runner-up has the same name as the top hit, the "ambiguity"
-            # is two TMDB entries for the same show (e.g. separate season entries).
-            # Pick the highest-scored one rather than failing the lookup.
-            same_name = _title_similarity(best_cand_title, scored[1][3]) >= 0.95
-            if margin < _MARGIN_THRESHOLD and not same_name:
+            if margin < _MARGIN_THRESHOLD:
                 log.debug(
                     "resolve_title_confident: ambiguous match for %r -> %r vs %r (margin=%.1f)",
                     title, best_cand_title, scored[1][3], margin,

--- a/recommender/tmdb_client.py
+++ b/recommender/tmdb_client.py
@@ -412,7 +412,12 @@ class TmdbClient:
 
         if len(scored) > 1:
             margin = best_total - scored[1][1]
-            if margin < _MARGIN_THRESHOLD:
+            second_sim = scored[1][0]
+            # If the runner-up has the same name as the top hit, the "ambiguity"
+            # is two TMDB entries for the same show (e.g. separate season entries).
+            # Pick the highest-scored one rather than failing the lookup.
+            same_name = _title_similarity(best_cand_title, scored[1][3]) >= 0.95
+            if margin < _MARGIN_THRESHOLD and not same_name:
                 log.debug(
                     "resolve_title_confident: ambiguous match for %r -> %r vs %r (margin=%.1f)",
                     title, best_cand_title, scored[1][3], margin,

--- a/tests/test_tmdb_client.py
+++ b/tests/test_tmdb_client.py
@@ -201,6 +201,18 @@ def _make_search_result(tmdb_id, title, release_date="", poster_path=None,
     }
 
 
+def _make_tv_search_result(tmdb_id, name, first_air_date="", poster_path=None,
+                           vote_count=100, popularity=20):
+    return {
+        "id": tmdb_id,
+        "name": name,
+        "first_air_date": first_air_date,
+        "poster_path": poster_path,
+        "vote_count": vote_count,
+        "popularity": popularity,
+    }
+
+
 def _make_details(tmdb_id, title, runtime=None, release_date=""):
     return {
         "id": tmdb_id,
@@ -351,3 +363,25 @@ def test_no_hints_still_works():
 
         assert meta is not None
         assert meta.tmdb_id == 800
+
+
+def test_resolve_title_confident_keeps_same_title_close_results_ambiguous():
+    """Same-title TMDB results need a score margin before persisting an ID."""
+    with tempfile.TemporaryDirectory() as tmp:
+        client = make_client(tmp)
+        candidates = [
+            _make_tv_search_result(
+                2316, "The Office", "2001-07-09", "/uk.jpg",
+                vote_count=1000, popularity=20,
+            ),
+            _make_tv_search_result(
+                69735, "The Office", "1995-03-11", "/variant.jpg",
+                vote_count=1000, popularity=18,
+            ),
+        ]
+
+        with patch.object(client, "_search_candidates", return_value=candidates):
+            tmdb_id, resolved_type = client.resolve_title_confident("The Office", "tv")
+
+        assert tmdb_id is None
+        assert resolved_type == "tv"


### PR DESCRIPTION
## Summary

- `resolve_title_confident` was returning `None` for shows that TMDB has registered twice under the same name (e.g. *Next Level Chef* has two entries, IDs 129500 and 218161)
- The score margin between the two identical-name entries was 3.0 — below the 5.0 ambiguity threshold — so the lookup failed and no `tmdb_id` was stored
- Manual archive entries added in this state had no posters or descriptions in the archive view

The fix: when the runner-up candidate's name is the same as the top hit (≥ 0.95 title similarity), skip the margin check and return the highest-scored entry. Same-name duplicates aren't genuine ambiguity.

## Test plan

- [ ] Add a show that has duplicate TMDB entries (e.g. *Next Level Chef*) via the manual archive UI — verify it gets a `tmdb_id`, poster, and description
- [ ] Add a show with genuinely distinct near-matches — verify the ambiguity check still fires and returns `None` correctly
- [ ] Existing archive entries with `NULL` tmdb_id (pre-fix) still need manual backfill or re-add via UI

🤖 Generated with [Claude Code](https://claude.com/claude-code)