### PR TITLE
fix: improve similar-title recommendation quality

### DIFF
--- a/recommender/query_engine.py
+++ b/recommender/query_engine.py
@@ -483,17 +483,18 @@ def _candidate_allowed(
 
 def _append_candidate(
     candidates: list[TmdbMetadata],
-    seen_ids: set[int],
+    seen_ids: set[tuple[str, int]],
     candidate: TmdbMetadata,
     ctx: "RecommendContext",
     extra_excludes: set[str],
 ) -> bool:
-    if candidate.tmdb_id in seen_ids:
+    key = (candidate.content_type, candidate.tmdb_id)
+    if key in seen_ids:
         return False
     if not _candidate_allowed(candidate, ctx, extra_excludes):
         return False
     candidates.append(candidate)
-    seen_ids.add(candidate.tmdb_id)
+    seen_ids.add(key)
     return True
 
 
@@ -534,7 +535,7 @@ def ask(
         return _handle_abandoned(query, intent, ctx)
 
     content_types = ['tv', 'movie'] if intent.content_type == 'both' else [intent.content_type]
-    seen_ids: set[int] = set()
+    seen_ids: set[tuple[str, int]] = set()
 
     # Source 1: TMDB Discover (structured metadata filter)
     candidates: list[TmdbMetadata] = []

--- a/recommender/query_engine.py
+++ b/recommender/query_engine.py
@@ -55,6 +55,8 @@ PLATFORM_ALIASES: dict[str, str] = {
     "now": "Now TV",
 }
 
+MIN_QUERY_MATCH_SCORE = 0.5
+
 
 @dataclass
 class QueryIntent:
@@ -243,7 +245,9 @@ def rank_candidates(
         f'- title: string (exact title from candidates)\n'
         f'- explanation: string (1-2 sentences why this fits the query and this user)\n'
         f'- score: float 0-1 (how well it matches the QUERY, boosted slightly by taste fit)\n\n'
-        f'Return EXACTLY the top {top_n} ranked candidates, no more.'
+        f'Return up to {top_n} ranked candidates, no more. '
+        f'Omit any candidate that does not genuinely match the query. '
+        f'Never include weak matches just to fill the requested count.'
     )
     # Scale output tokens based on result count
     rank_tokens = max(config.TOKENS_RANKING, top_n * 200 + 200)
@@ -262,11 +266,15 @@ def rank_candidates(
         if title not in meta_by_title:
             log.debug("Ranked title not in candidates, skipping: %r", title)
             continue
+        score = float(item.get('score', 0))
+        if score < MIN_QUERY_MATCH_SCORE:
+            log.debug("Ranked title below query threshold, skipping: %r (score=%.2f)", title, score)
+            continue
         meta = meta_by_title[title]
         results.append(Recommendation(
             title=title,
             content_type=meta.content_type,
-            score=float(item.get('score', 0)),
+            score=score,
             vote_average=meta.vote_average,
             genres=meta.genres,
             explanation=item.get('explanation', ''),

--- a/recommender/query_engine.py
+++ b/recommender/query_engine.py
@@ -442,6 +442,53 @@ _WHAT_ELSE_PATTERNS = re.compile(
 _MORE_LIKE_N = re.compile(r'^more like #?(\d+)', re.IGNORECASE)
 
 
+def _has_discover_filters(intent: "QueryIntent") -> bool:
+    """Return True when TMDB Discover has user-specified narrowing filters."""
+    return bool(
+        intent.genres
+        or intent.origin_countries
+        or intent.languages
+        or intent.year_from
+        or intent.year_to
+    )
+
+
+def _candidate_allowed(
+    candidate: TmdbMetadata,
+    ctx: "RecommendContext",
+    extra_excludes: set[str],
+) -> bool:
+    if ctx.watch_index.is_watched(candidate):
+        return False
+    if candidate.title in extra_excludes:
+        return False
+    if ctx.user_state and ctx.user_state.is_manually_watched(candidate):
+        return False
+    if ctx.user_state and ctx.user_state.is_dismissed(candidate):
+        return False
+    if config.MIN_RATING > 0 and candidate.vote_average < config.MIN_RATING:
+        return False
+    if config.MIN_YEAR > 0 and candidate.release_year and candidate.release_year < config.MIN_YEAR:
+        return False
+    return True
+
+
+def _append_candidate(
+    candidates: list[TmdbMetadata],
+    seen_ids: set[int],
+    candidate: TmdbMetadata,
+    ctx: "RecommendContext",
+    extra_excludes: set[str],
+) -> bool:
+    if candidate.tmdb_id in seen_ids:
+        return False
+    if not _candidate_allowed(candidate, ctx, extra_excludes):
+        return False
+    candidates.append(candidate)
+    seen_ids.add(candidate.tmdb_id)
+    return True
+
+
 def ask(
     query: str,
     ctx: RecommendContext,
@@ -483,7 +530,11 @@ def ask(
 
     # Source 1: TMDB Discover (structured metadata filter)
     candidates: list[TmdbMetadata] = []
-    for ct in content_types:
+    run_discover = _has_discover_filters(intent) or not intent.similar_to
+    if not run_discover:
+        log.debug("Skipping unfiltered TMDB Discover for similar_to-only query")
+
+    for ct in (content_types if run_discover else []):
         log.debug("TMDB discover: type=%s genres=%s countries=%s languages=%s years=%s-%s",
                    ct, intent.genres, intent.origin_countries, intent.languages,
                    intent.year_from, intent.year_to)
@@ -504,26 +555,29 @@ def ask(
         candidates.extend(batch)
 
     pre_filter = len(candidates)
-    candidates = [
-        c for c in candidates
-        if not ctx.watch_index.is_watched(c)
-        and c.title not in extra_excludes
-        and not (ctx.user_state and ctx.user_state.is_manually_watched(c))
-        and not (ctx.user_state and ctx.user_state.is_dismissed(c))
-    ]
-    log.debug("Watch filter: %d -> %d candidates (%d excluded)",
+    filtered_candidates: list[TmdbMetadata] = []
+    for candidate in candidates:
+        _append_candidate(filtered_candidates, seen_ids, candidate, ctx, extra_excludes)
+    candidates = filtered_candidates
+    log.debug("Candidate filters: %d -> %d candidates (%d excluded)",
               pre_filter, len(candidates), pre_filter - len(candidates))
 
-    # Apply min rating filter (min_year is already pushed into TMDB discover)
-    pre_quality = len(candidates)
-    if config.MIN_RATING > 0:
-        candidates = [c for c in candidates if c.vote_average >= config.MIN_RATING]
-    if len(candidates) < pre_quality:
-        log.debug("Rating filter: %d -> %d candidates (min_rating=%.1f)",
-                  pre_quality, len(candidates), config.MIN_RATING)
-
-    for c in candidates:
-        seen_ids.add(c.tmdb_id)
+    if intent.similar_to:
+        related_added = 0
+        for seed_title in intent.similar_to:
+            for ct in content_types:
+                seed_meta = ctx.tmdb_client.get_metadata(seed_title, ct)
+                if not seed_meta:
+                    continue
+                related = ctx.tmdb_client.get_related_titles(
+                    seed_meta.tmdb_id,
+                    seed_meta.content_type,
+                    size=30,
+                )
+                for candidate in related:
+                    if _append_candidate(candidates, seen_ids, candidate, ctx, extra_excludes):
+                        related_added += 1
+        log.debug("TMDB related titles added %d new candidates", related_added)
 
     # Source 2: LLM suggestions (semantic, taste-aware — always runs)
     log.debug("Fetching LLM suggestions for semantic coverage (similar_to=%s)", intent.similar_to)
@@ -534,16 +588,7 @@ def ask(
     for title in suggestions:
         for ct in content_types:
             meta = ctx.tmdb_client.get_metadata(title, ct)
-            if (meta and meta.tmdb_id not in seen_ids and not ctx.watch_index.is_watched(meta)
-                    and meta.title not in extra_excludes
-                    and not (ctx.user_state and ctx.user_state.is_manually_watched(meta))
-                    and not (ctx.user_state and ctx.user_state.is_dismissed(meta))):
-                if config.MIN_RATING > 0 and meta.vote_average < config.MIN_RATING:
-                    continue
-                if config.MIN_YEAR > 0 and meta.release_year and meta.release_year < config.MIN_YEAR:
-                    continue
-                candidates.append(meta)
-                seen_ids.add(meta.tmdb_id)
+            if meta and _append_candidate(candidates, seen_ids, meta, ctx, extra_excludes):
                 suggestion_count += 1
     log.debug("LLM suggestions added %d new candidates", suggestion_count)
 

--- a/recommender/tmdb_client.py
+++ b/recommender/tmdb_client.py
@@ -256,6 +256,57 @@ class TmdbClient:
         endpoint = f"tv/{tmdb_id}" if content_type == "tv" else f"movie/{tmdb_id}"
         return self._get(endpoint, {"append_to_response": "keywords,credits"})
 
+    def get_related_titles(
+        self,
+        tmdb_id: int,
+        content_type: str,
+        size: int = 30,
+    ) -> list["TmdbMetadata"]:
+        """Fetch TMDB recommendations and similar titles for one seed title."""
+        prefix = "tv" if content_type == "tv" else "movie"
+        endpoints = (
+            f"{prefix}/{tmdb_id}/recommendations",
+            f"{prefix}/{tmdb_id}/similar",
+        )
+
+        related: dict[int, "TmdbMetadata"] = {}
+        for endpoint in endpoints:
+            page = 1
+            while len(related) < size and page <= MAX_DISCOVER_PAGES:
+                data = self._get(endpoint, {"page": page})
+                results = data.get("results", [])
+                if not results:
+                    break
+                total_pages = min(int(data.get("total_pages", page)), MAX_DISCOVER_PAGES)
+                for item in results:
+                    related_id = item["id"]
+                    if related_id in related:
+                        continue
+                    cached = self._load_cache(content_type, related_id)
+                    if cached:
+                        related[related_id] = self._parse_metadata(cached, content_type)
+                    else:
+                        try:
+                            details = self._fetch_details(related_id, content_type)
+                            self._save_cache(content_type, related_id, details)
+                            related[related_id] = self._parse_metadata(details, content_type)
+                            time.sleep(0.05)
+                        except Exception as exc:
+                            log.warning("TMDB related fetch failed for ID %d: %s", related_id, exc)
+                            continue
+                    if len(related) >= size:
+                        break
+                if page >= total_pages:
+                    break
+                page += 1
+        log.debug(
+            "Related titles returned %d candidates for %s/%d",
+            len(related),
+            content_type,
+            tmdb_id,
+        )
+        return list(related.values())
+
     def _parse_metadata(self, data: dict, content_type: str) -> TmdbMetadata:
         title = data.get("name") or data.get("title", "")
         genres = [g["name"] for g in data.get("genres", [])]

--- a/tests/test_query_engine.py
+++ b/tests/test_query_engine.py
@@ -276,3 +276,59 @@ def test_user_state_excludes_dismissed_and_manual_archive():
     assert "Dismissed Show" not in titles
     assert "Already Watched" not in titles
     assert titles == ["Fresh Pick"]
+
+
+def test_ask_similar_to_only_uses_related_candidates_not_generic_discover():
+    seed = make_meta("Sherlock Holmes", tmdb_id=10528, content_type="movie", genres=["Mystery"])
+    related = make_meta(
+        "The Hound of the Baskervilles",
+        tmdb_id=101,
+        content_type="movie",
+        genres=["Mystery", "Crime"],
+        vote_avg=7.4,
+    )
+    generic = make_meta(
+        "Spirited Away",
+        tmdb_id=129,
+        content_type="movie",
+        genres=["Animation", "Fantasy"],
+        vote_avg=8.5,
+    )
+
+    mock_tmdb = MagicMock()
+    mock_tmdb.search_by_filters.return_value = [generic]
+    mock_tmdb.get_metadata.return_value = seed
+    mock_tmdb.get_related_titles.return_value = [related]
+
+    intent_json = json.dumps({
+        "genres": [], "origin_countries": [], "languages": [],
+        "mood_descriptors": [], "similar_to": ["Sherlock Holmes"],
+        "max_runtime_minutes": None, "year_from": None, "year_to": None,
+        "unwatched_only": True, "special_intent": None,
+        "content_type": "movie", "top_n": 10, "platforms": [],
+    })
+    suggestions_json = json.dumps([])
+    ranked_json = json.dumps([
+        {
+            "title": "The Hound of the Baskervilles",
+            "explanation": "A genuine Holmes-adjacent detective mystery.",
+            "score": 0.91,
+        }
+    ])
+    mock_llm = make_mock_llm_sequence([intent_json, suggestions_json, ranked_json])
+
+    ctx = RecommendContext(
+        taste_profile="taste profile text",
+        watch_index=WatchIndex(tmdb_ids=set(), tmdb_keys=set(), normalized_titles=set(), entries=[]),
+        events=[],
+        tmdb_client=mock_tmdb,
+        llm=mock_llm,
+        cache_dir="/tmp/test_cache",
+    )
+
+    with patch("recommender.query_engine.enrich_batch", return_value={"movie/101": "Detective mystery."}):
+        results = ask("Suggest me 10 movies like Sherlock Holmes", ctx)
+
+    assert [r.title for r in results] == ["The Hound of the Baskervilles"]
+    mock_tmdb.search_by_filters.assert_not_called()
+    mock_tmdb.get_related_titles.assert_called_once_with(10528, "movie", size=30)

--- a/tests/test_query_engine.py
+++ b/tests/test_query_engine.py
@@ -387,3 +387,49 @@ def test_ask_similar_to_only_uses_related_candidates_not_generic_discover():
     assert [r.title for r in results] == ["The Hound of the Baskervilles"]
     mock_tmdb.search_by_filters.assert_not_called()
     mock_tmdb.get_related_titles.assert_called_once_with(10528, "movie", size=30)
+
+
+def test_ask_both_content_types_keeps_tv_and_movie_with_same_tmdb_id():
+    """TMDB IDs are not globally unique; a TV show and movie can share one."""
+    shared_id = 999
+    tv_meta = make_meta("Shared ID Show", tmdb_id=shared_id, content_type="tv")
+    movie_meta = make_meta("Shared ID Movie", tmdb_id=shared_id, content_type="movie")
+
+    mock_tmdb = MagicMock()
+    mock_tmdb.search_by_filters.side_effect = [
+        [tv_meta],    # tv Discover call
+        [movie_meta], # movie Discover call
+    ]
+    mock_tmdb.get_metadata.return_value = None
+
+    intent_json = json.dumps({
+        "genres": ["drama"], "origin_countries": [], "languages": [],
+        "mood_descriptors": [], "similar_to": [],
+        "max_runtime_minutes": None, "year_from": None, "year_to": None,
+        "unwatched_only": True, "special_intent": None,
+        "content_type": "both", "top_n": 10, "platforms": [],
+    })
+    suggestions_json = json.dumps([])
+    ranked_json = json.dumps([
+        {"title": "Shared ID Show", "explanation": "Good TV.", "score": 0.85},
+        {"title": "Shared ID Movie", "explanation": "Good movie.", "score": 0.82},
+    ])
+    mock_llm = make_mock_llm_sequence([intent_json, suggestions_json, ranked_json])
+
+    ctx = RecommendContext(
+        taste_profile="taste profile text",
+        watch_index=WatchIndex(tmdb_ids=set(), tmdb_keys=set(), normalized_titles=set(), entries=[]),
+        events=[],
+        tmdb_client=mock_tmdb,
+        llm=mock_llm,
+        cache_dir="/tmp/test_cache",
+    )
+
+    with patch("recommender.query_engine.enrich_batch", return_value={
+        "tv/999": "Drama series.", "movie/999": "Drama film.",
+    }):
+        results = ask("drama", ctx)
+
+    titles = [r.title for r in results]
+    assert "Shared ID Show" in titles
+    assert "Shared ID Movie" in titles

--- a/tests/test_query_engine.py
+++ b/tests/test_query_engine.py
@@ -129,6 +129,61 @@ def test_rank_candidates_skips_unknown_titles():
     assert "Broadchurch" in titles
 
 
+def test_rank_candidates_omits_low_score_query_mismatches():
+    candidates = [
+        make_meta("The Hound of the Baskervilles", tmdb_id=101, content_type="movie", genres=["Mystery"]),
+        make_meta("Spirited Away", tmdb_id=129, content_type="movie", genres=["Animation", "Fantasy"]),
+    ]
+    enrichments = {
+        "movie/101": "Sherlock Holmes detective mystery.",
+        "movie/129": "Japanese animated fantasy.",
+    }
+    ranked = [
+        {
+            "title": "The Hound of the Baskervilles",
+            "explanation": "A genuine Holmes-adjacent detective mystery.",
+            "score": 0.91,
+        },
+        {
+            "title": "Spirited Away",
+            "explanation": "A weak query match included only to fill the list.",
+            "score": 0.32,
+        },
+    ]
+    client = make_mock_llm(json.dumps(ranked))
+
+    results = rank_candidates(
+        "Suggest me 10 movies like Sherlock Holmes",
+        "taste profile",
+        candidates,
+        enrichments,
+        client,
+        top_n=10,
+    )
+
+    assert [r.title for r in results] == ["The Hound of the Baskervilles"]
+
+
+def test_rank_candidates_prompt_allows_fewer_than_top_n():
+    candidates = [make_meta("The Hound of the Baskervilles", tmdb_id=101)]
+    enrichments = {"tv/101": "Detective mystery."}
+    ranked = [
+        {
+            "title": "The Hound of the Baskervilles",
+            "explanation": "A strong match.",
+            "score": 0.9,
+        }
+    ]
+    client = make_mock_llm(json.dumps(ranked))
+
+    rank_candidates("movies like Sherlock Holmes", "profile", candidates, enrichments, client, top_n=10)
+
+    prompt = client.generate.call_args.args[0]
+    assert "Return up to 10 ranked candidates" in prompt
+    assert "Never include weak matches just to fill the requested count." in prompt
+    assert "Return EXACTLY" not in prompt
+
+
 def test_ask_excludes_watched_titles():
     meta_watched = make_meta("Broadchurch", tmdb_id=1)
     meta_new = make_meta("Hinterland", tmdb_id=2)

--- a/tests/test_tmdb_client.py
+++ b/tests/test_tmdb_client.py
@@ -170,6 +170,64 @@ def test_search_by_filters_movie():
         assert discover_call[1]['params']['with_original_language'] == "hi"
 
 
+def test_get_related_titles_merges_recommendations_and_similar():
+    with tempfile.TemporaryDirectory() as tmp:
+        client = make_client(tmp)
+
+        recommendations_response = {"results": [{"id": 101}, {"id": 102}]}
+        similar_response = {"results": [{"id": 102}, {"id": 103}]}
+
+        detail_101 = {
+            "id": 101, "title": "The Hound of the Baskervilles",
+            "genres": [{"name": "Mystery"}],
+            "keywords": {"keywords": []}, "credits": {"cast": [], "crew": []},
+            "runtime": 100, "original_language": "en",
+            "vote_average": 7.2, "vote_count": 300,
+            "release_date": "2002-01-01",
+        }
+        detail_102 = {
+            "id": 102, "title": "Without a Clue",
+            "genres": [{"name": "Comedy"}, {"name": "Mystery"}],
+            "keywords": {"keywords": []}, "credits": {"cast": [], "crew": []},
+            "runtime": 107, "original_language": "en",
+            "vote_average": 7.0, "vote_count": 350,
+            "release_date": "1988-10-21",
+        }
+        detail_103 = {
+            "id": 103, "title": "Young Sherlock Holmes",
+            "genres": [{"name": "Adventure"}, {"name": "Mystery"}],
+            "keywords": {"keywords": []}, "credits": {"cast": [], "crew": []},
+            "runtime": 109, "original_language": "en",
+            "vote_average": 6.8, "vote_count": 400,
+            "release_date": "1985-12-04",
+        }
+
+        with patch.object(client, "_get") as mock_get:
+            mock_get.side_effect = [
+                recommendations_response,
+                detail_101,
+                detail_102,
+                similar_response,
+                detail_103,
+            ]
+            results = client.get_related_titles(10528, "movie", size=3)
+
+    assert [r.tmdb_id for r in results] == [101, 102, 103]
+    assert [r.title for r in results] == [
+        "The Hound of the Baskervilles",
+        "Without a Clue",
+        "Young Sherlock Holmes",
+    ]
+    endpoints = [call.args[0] for call in mock_get.call_args_list]
+    assert endpoints == [
+        "movie/10528/recommendations",
+        "movie/101",
+        "movie/102",
+        "movie/10528/similar",
+        "movie/103",
+    ]
+
+
 # --- Candidate ranking tests ---
 
 def test_title_similarity_exact():


### PR DESCRIPTION
## Summary

- Add `get_related_titles()` to `TmdbClient` — merges TMDB `recommendations` and `similar` endpoints for a seed title, returning full `TmdbMetadata` objects with deduplication
- Route `similar_to`-only queries away from generic unfiltered TMDB Discover; use related-title candidates as the primary structured source instead
- Let the ranker omit weak query matches — changed prompt from `Return EXACTLY top N` to `Return up to N`, and drop any ranked item with `score < 0.5`

## Test Plan
- [ ] `tests/test_tmdb_client.py::test_get_related_titles_merges_recommendations_and_similar` — new: verifies endpoint order, dedup, and metadata shape
- [ ] `tests/test_query_engine.py::test_ask_similar_to_only_uses_related_candidates_not_generic_discover` — new: verifies `search_by_filters` is skipped and `get_related_titles` is called for a `similar_to`-only query
- [ ] `tests/test_query_engine.py::test_rank_candidates_omits_low_score_query_mismatches` — new: verifies low-score rows are dropped
- [ ] `tests/test_query_engine.py::test_rank_candidates_prompt_allows_fewer_than_top_n` — new: verifies prompt contract
- [ ] Full suite: 357 passed
- [ ] Live regression: `./recommend --debug "Suggest me 10 movies like Sherlock Holmes"` returns ≤10 results with no generic filler (no Spirited Away, Your Name., Attack on Titan)