### PR TITLE
Mobile nav redesign + port 5051 default + stop hardening

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -33,7 +33,7 @@ Runs a CLI recommendation query.
 ./recommend-web start
 ```
 
-Starts the Flask web UI on `http://localhost:5050`.
+Starts the Flask web UI on `http://localhost:5051`.
 
 ```bash
 python3 -m pytest -q

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -44,7 +44,7 @@ python3 -m pytest tests/test_query_engine.py -v
 ./recommend --add "Title" --type tv            # add to watch history
 
 # Web UI
-./recommend-web start                          # http://localhost:5050
+./recommend-web start                          # http://localhost:5051
 ./recommend-web stop
 ./recommend-web restart
 ```

--- a/README.md
+++ b/README.md
@@ -129,7 +129,7 @@ Each query prints token usage and estimated cost at the end.
 ## Web UI
 
 ```bash
-./recommend-web start                           # http://localhost:5050
+./recommend-web start                           # http://localhost:5051
 ./recommend-web stop
 ./recommend-web status
 ./recommend-web restart

--- a/recommend-web
+++ b/recommend-web
@@ -4,14 +4,15 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 PIDFILE="$SCRIPT_DIR/.web.pid"
 LOGFILE="$SCRIPT_DIR/logs/web.log"
-PORT="${STREAMLINE_PORT:-5051}"
-HOST="${STREAMLINE_HOST:-127.0.0.1}"
 VENV="$SCRIPT_DIR/.venv"
 
-# Load environment
+# Load environment first so .env can override STREAMLINE_PORT/HOST below.
 if [ -f "$SCRIPT_DIR/.env" ]; then
     set -a; source "$SCRIPT_DIR/.env"; set +a
 fi
+
+PORT="${STREAMLINE_PORT:-5051}"
+HOST="${STREAMLINE_HOST:-127.0.0.1}"
 
 # Activate venv
 if [ ! -d "$VENV" ]; then
@@ -171,14 +172,30 @@ stop() {
         rm -f "$PIDFILE"
     fi
 
-    # Sweep any orphaned gunicorn workers bound to our port.
+    # Sweep any orphaned Streamline gunicorn workers still bound to our port.
+    # Filter strictly by command line so we never touch unrelated services that
+    # happen to be on $PORT (e.g. a custom app, or a coworker's process).
+    streamline_pids_on_port() {
+        local raw filtered=""
+        raw=$(lsof -nP -iTCP:"$PORT" -sTCP:LISTEN -t 2>/dev/null || true)
+        for p in $raw; do
+            local cmd
+            cmd=$(ps -o command= -p "$p" 2>/dev/null || true)
+            # Match our gunicorn invocation (recommender.web:app) or our venv's gunicorn binary.
+            if echo "$cmd" | grep -Eq 'recommender\.web:app|'"$VENV"'/bin/gunicorn'; then
+                filtered+="$p "
+            fi
+        done
+        echo "$filtered"
+    }
+
     local stragglers
-    stragglers=$(lsof -nP -iTCP:"$PORT" -sTCP:LISTEN -t 2>/dev/null || true)
+    stragglers=$(streamline_pids_on_port)
     if [ -n "$stragglers" ]; then
-        echo "Cleaning orphaned listener(s) on port $PORT: $stragglers"
+        echo "Cleaning orphaned Streamline worker(s) on port $PORT: $stragglers"
         kill -TERM $stragglers 2>/dev/null || true
         sleep 1
-        stragglers=$(lsof -nP -iTCP:"$PORT" -sTCP:LISTEN -t 2>/dev/null || true)
+        stragglers=$(streamline_pids_on_port)
         [ -n "$stragglers" ] && kill -9 $stragglers 2>/dev/null || true
     fi
 

--- a/recommend-web
+++ b/recommend-web
@@ -4,7 +4,7 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 PIDFILE="$SCRIPT_DIR/.web.pid"
 LOGFILE="$SCRIPT_DIR/logs/web.log"
-PORT="${STREAMLINE_PORT:-5050}"
+PORT="${STREAMLINE_PORT:-5051}"
 HOST="${STREAMLINE_HOST:-127.0.0.1}"
 VENV="$SCRIPT_DIR/.venv"
 
@@ -135,33 +135,60 @@ start() {
     fi
 }
 
+port_free() {
+    ! python3 -c "import socket; s=socket.socket(); s.settimeout(1); s.connect(('$HOST', $PORT)); s.close()" 2>/dev/null
+}
+
 stop() {
-    if ! is_running; then
-        echo "Not running."
-        rm -f "$PIDFILE"
-        return 0
+    local pid=""
+    if [ -f "$PIDFILE" ]; then
+        pid=$(cat "$PIDFILE")
     fi
 
-    local pid
-    pid=$(cat "$PIDFILE")
-    echo "Stopping (PID $pid)..."
+    if [ -z "$pid" ] || ! kill -0 "$pid" 2>/dev/null; then
+        # Master gone, but a worker may still hold the port — sweep by name.
+        pid=""
+    fi
 
-    # Graceful shutdown
-    kill "$pid" 2>/dev/null
+    if [ -z "$pid" ]; then
+        echo "Not running."
+        rm -f "$PIDFILE"
+    else
+        echo "Stopping (PID $pid)..."
+        # Graceful: TERM master and its children (gunicorn workers).
+        pkill -TERM -P "$pid" 2>/dev/null || true
+        kill -TERM "$pid" 2>/dev/null || true
+        local waited=0
+        while [ $waited -lt 5 ] && kill -0 "$pid" 2>/dev/null; do
+            sleep 1
+            waited=$((waited + 1))
+        done
+        if kill -0 "$pid" 2>/dev/null; then
+            echo "Forcing stop..."
+            pkill -KILL -P "$pid" 2>/dev/null || true
+            kill -9 "$pid" 2>/dev/null || true
+        fi
+        rm -f "$PIDFILE"
+    fi
+
+    # Sweep any orphaned gunicorn workers bound to our port.
+    local stragglers
+    stragglers=$(lsof -nP -iTCP:"$PORT" -sTCP:LISTEN -t 2>/dev/null || true)
+    if [ -n "$stragglers" ]; then
+        echo "Cleaning orphaned listener(s) on port $PORT: $stragglers"
+        kill -TERM $stragglers 2>/dev/null || true
+        sleep 1
+        stragglers=$(lsof -nP -iTCP:"$PORT" -sTCP:LISTEN -t 2>/dev/null || true)
+        [ -n "$stragglers" ] && kill -9 $stragglers 2>/dev/null || true
+    fi
+
+    # Wait for the socket to actually free.
     local waited=0
-    while [ $waited -lt 5 ] && kill -0 "$pid" 2>/dev/null; do
+    while [ $waited -lt 5 ] && ! port_free; do
         sleep 1
         waited=$((waited + 1))
     done
 
-    # Force kill if still alive
-    if kill -0 "$pid" 2>/dev/null; then
-        echo "Forcing stop..."
-        kill -9 "$pid" 2>/dev/null
-        sleep 1
-    fi
-
-    rm -f "$PIDFILE"
     echo "Stopped."
 }
 

--- a/recommender/templates/base.html
+++ b/recommender/templates/base.html
@@ -289,6 +289,47 @@
       transition: color 0.15s;
     }
     .result-link:hover { color: var(--accent); text-decoration: none; }
+
+    /* Mobile nav: deliberate two-tier editorial masthead.
+       Row 1: brand (left) + system/utility links (right).
+       Row 2: primary nav as a sub-bar with hairline top divider; scrolls horizontally if needed. */
+    @media (max-width: 720px) {
+      nav {
+        flex-wrap: wrap;
+        height: auto;
+        column-gap: 1rem;
+        row-gap: 0;
+        padding: 0.7rem 1.1rem 0;
+        align-items: center;
+      }
+      .nav-brand {
+        margin-right: auto;
+        font-size: 1.22rem;
+      }
+      .nav-group-system {
+        padding-left: 0;
+        border-left: none;
+        gap: 0.9rem;
+      }
+      .nav-group-system .nav-link { font-size: 0.58rem; }
+      .nav-group {
+        order: 3;
+        flex: 1 1 100%;
+        gap: 1.1rem;
+        margin-top: 0.6rem;
+        padding: 0.55rem 0 0.6rem;
+        border-top: 1px solid var(--border);
+        overflow-x: auto;
+        overflow-y: hidden;
+        scrollbar-width: none;
+        -webkit-overflow-scrolling: touch;
+        mask-image: linear-gradient(to right, #000 0, #000 calc(100% - 18px), transparent 100%);
+      }
+      .nav-group::-webkit-scrollbar { display: none; }
+      .nav-group .nav-link { white-space: nowrap; }
+      main { padding: 1.75rem 1rem 4rem !important; }
+      footer { padding: 1.25rem 1rem !important; }
+    }
   </style>
 </head>
 

--- a/recommender/web.py
+++ b/recommender/web.py
@@ -1274,7 +1274,7 @@ def run() -> None:
         print(f"Error: {exc}", file=sys.stderr)
         sys.exit(1)
     host = os.environ.get("STREAMLINE_HOST", "127.0.0.1")
-    port = int(os.environ.get("STREAMLINE_PORT", "5050"))
+    port = int(os.environ.get("STREAMLINE_PORT", "5051"))
     print(f"Starting Streamline web UI at http://{host}:{port}")
     app.run(debug=False, host=host, port=port)
 


### PR DESCRIPTION
## Summary
- Redesign mobile nav as a deliberate two-tier editorial masthead (brand + utility on row 1, primary nav as scrollable sub-bar on row 2). Replaces the earlier flex-wrap fix that collapsed the content/system group hierarchy.
- Bump default web UI port from 5050 to 5051 — 5050 conflicts with the Tenable Nessus agent on managed Macs. Updated launcher, Python default, and docs.
- Harden \`recommend-web stop\`: gunicorn workers were being orphaned when the master got SIGKILL'd, holding the port and breaking immediate restart. Now TERMs the master's children, sweeps any straggling listener on the port via \`lsof\`, and waits for the socket to free before returning.

## Test plan
- [ ] Open the web UI on a narrow viewport (DevTools mobile preview, ≤720px) and confirm nav renders as two tiers with no horizontal overflow.
- [ ] Confirm primary nav (Home / Searches / Watchlist / Archive) is horizontally scrollable on the narrowest phones with a soft right-edge fade.
- [ ] Confirm system group (Settings / Logs / Help) sits on row 1 right-aligned alongside the brand.
- [ ] \`./recommend-web start\` defaults to 5051 and reaches the UI at http://localhost:5051.
- [ ] \`./recommend-web restart\` works without "port already in use" on the second cycle (validates orphan cleanup).
- [ ] Desktop nav (>720px) still renders as the original single-line masthead with the vertical divider intact.