### PR TITLE
feat(disney): parse Disney+ data-export PDF into watch events

### DIFF
--- a/config.py
+++ b/config.py
@@ -167,7 +167,7 @@ PLATFORM_PATHS: dict[str, list[str]] = {
     "netflix": _resolve_platform_paths("netflix", "data/netflix/export.zip"),
     "prime": _resolve_platform_paths("prime", "data/prime_video/Prime Video.zip"),
     "apple_tv": _resolve_platform_paths("apple_tv", "data/AppleTV/Apple Media Services Information Part 1 of 2.zip"),
-    "disney": _resolve_platform_paths("disney", "data/disney/export.pdf"),
+    "disney": _resolve_platform_paths("disney", None),
     "hbo": [],
 }
 DISNEY_PROFILES: list[str] = list(_cfg.get("disney_profiles", []) or [])

--- a/config.py
+++ b/config.py
@@ -167,9 +167,10 @@ PLATFORM_PATHS: dict[str, list[str]] = {
     "netflix": _resolve_platform_paths("netflix", "data/netflix/export.zip"),
     "prime": _resolve_platform_paths("prime", "data/prime_video/Prime Video.zip"),
     "apple_tv": _resolve_platform_paths("apple_tv", "data/AppleTV/Apple Media Services Information Part 1 of 2.zip"),
-    "disney": [],
+    "disney": _resolve_platform_paths("disney", "data/disney/export.pdf"),
     "hbo": [],
 }
+DISNEY_PROFILES: list[str] = list(_cfg.get("disney_profiles", []) or [])
 MANUAL_TV_PATH = str(_ROOT / _cfg.get("manual_tv_path", "data/manual/tv.csv"))
 MANUAL_MOVIES_PATH = str(_ROOT / _cfg.get("manual_movies_path", "data/manual/movies.csv"))
 OVERRIDES_PATH = str(_ROOT / _cfg.get("overrides_path", "data/overrides.json"))

--- a/config.yaml
+++ b/config.yaml
@@ -58,3 +58,6 @@ streaming_platforms: []
 manual_tv_path: data/manual/tv.csv
 manual_movies_path: data/manual/movies.csv
 overrides_path: data/overrides.json
+# Disney+ exports include every family profile. List the profiles to keep
+# (empty list keeps all). Profile names must match the export exactly.
+disney_profiles: []

--- a/recommender/ingestion/disney.py
+++ b/recommender/ingestion/disney.py
@@ -77,7 +77,16 @@ def parse(path: str) -> list[WatchEvent]:
     if p.suffix.lower() != ".pdf":
         raise ValueError(f"Disney+ path must be a .pdf file, got: {path}")
 
-    rows = _extract_rows(path)
+    try:
+        rows = _extract_rows(path)
+    except (FileNotFoundError, ValueError):
+        raise
+    except Exception as exc:
+        # pdfplumber/pdfminer raise their own exception hierarchies on
+        # corrupt/encrypted/unsupported PDFs. Normalize to ValueError so
+        # the setup loader treats it as a provider-validation failure
+        # instead of crashing.
+        raise ValueError(f"Failed to parse Disney+ PDF: {path} ({exc})") from exc
     log.info("Disney+: read %d raw rows from %s", len(rows), path)
 
     allowed = _allowed_profiles()
@@ -105,10 +114,15 @@ def parse(path: str) -> list[WatchEvent]:
         if season:
             content_type = "tv"
             series_name = season
+            # Episode-distinct title so the rewatch signal in
+            # signals.compute_scores() doesn't treat every Disney TV
+            # event for a series as a rewatch of one episode.
+            title = program or season
             duration = tv_duration
         else:
             content_type = "movie"
             series_name = program
+            title = program
             duration = movie_duration
 
         try:
@@ -123,7 +137,7 @@ def parse(path: str) -> list[WatchEvent]:
 
         events.append(WatchEvent(
             platform="disney",
-            title=series_name,
+            title=title,
             content_type=content_type,
             series_name=series_name,
             watched_duration=duration,

--- a/recommender/ingestion/disney.py
+++ b/recommender/ingestion/disney.py
@@ -1,15 +1,132 @@
+import logging
+import re
+from datetime import datetime, timedelta
+from pathlib import Path
+
+import config
 from .base import WatchEvent
 
+log = logging.getLogger("recommender.ingestion.disney")
 
-def parse(filepath: str) -> list[WatchEvent]:
-    """
-    Parse Disney+ watch history CSV.
-    Not yet implemented — waiting for export data.
+_DATE_RE = re.compile(r"^\d{4}-\d{2}-\d{2}$")
+_TRAILER_RE = re.compile(r"\btrailer\b|\|\s*trailer", re.IGNORECASE)
 
-    Expected columns (update when data arrives):
-    Title, WatchDate, Duration, ...
+
+def _allowed_profiles() -> set[str]:
+    profiles = getattr(config, "DISNEY_PROFILES", None) or []
+    return {p.strip() for p in profiles if p and p.strip()}
+
+
+def _normalize(cell: str) -> str:
+    return re.sub(r"\s+", " ", cell.replace("\n", " ")).strip()
+
+
+def _extract_rows(pdf_path: str) -> list[dict]:
+    """Extract Titles Watched rows from a Disney+ data export PDF.
+
+    Disney's export renders the watched-titles table identically across all
+    its pages. We scan every page's tables and accept any row whose first
+    cell is an ISO date — that uniquely identifies a watch event and skips
+    headers, the franchise list, the brand list, and account/profile tables.
     """
-    raise NotImplementedError(
-        "Disney+ parser not implemented. "
-        "Set config.PLATFORM_PATHS['disney'] = None until data arrives."
-    )
+    import pdfplumber
+
+    rows: list[dict] = []
+    with pdfplumber.open(pdf_path) as pdf:
+        for page in pdf.pages:
+            for table in page.extract_tables() or []:
+                for row in table:
+                    if not row or len(row) < 5:
+                        continue
+                    cells = [(c or "").strip() for c in row]
+                    if not _DATE_RE.match(cells[0]):
+                        continue
+                    rows.append({
+                        "date": cells[0],
+                        "service": cells[1],
+                        "profile": cells[2],
+                        "program": _normalize(cells[3]),
+                        "season": _normalize(cells[4]),
+                    })
+    return rows
+
+
+def parse(path: str) -> list[WatchEvent]:
+    """Parse Disney+ watch history from the data-subject-request PDF export.
+
+    Disney delivers history as a PDF (no CSV option). The relevant section is
+    'TITLES WATCHED' with columns: Date, Service, Profile, Program, Season.
+    Note: the 'Season' column actually carries the series name; 'Program' is
+    the episode title for TV and the movie title for film (Season blank).
+
+    Transforms:
+      * Restrict to profiles in config.DISNEY_PROFILES (empty list = keep all).
+      * Drop trailers (Program or Season contains 'Trailer').
+      * Treat non-blank Season as the TV series; blank Season => movie.
+      * Collapse same-day duplicates per (profile, content_type, series).
+        Disney logs each restart/episode as a separate row, which would
+        otherwise massively over-weight kid-co-watched series.
+
+    Durations are synthesized from config.MANUAL_TV_DURATION_MINUTES /
+    MANUAL_MOVIE_DURATION_MINUTES, mirroring the manual ingestion path,
+    because the export contains no duration or completion data.
+    """
+    p = Path(path)
+    if not p.exists():
+        raise FileNotFoundError(f"Disney+ export not found: {path}")
+    if p.suffix.lower() != ".pdf":
+        raise ValueError(f"Disney+ path must be a .pdf file, got: {path}")
+
+    rows = _extract_rows(path)
+    log.info("Disney+: read %d raw rows from %s", len(rows), path)
+
+    allowed = _allowed_profiles()
+    tv_duration = timedelta(minutes=config.MANUAL_TV_DURATION_MINUTES)
+    movie_duration = timedelta(minutes=config.MANUAL_MOVIE_DURATION_MINUTES)
+
+    seen: set[tuple] = set()
+    events: list[WatchEvent] = []
+
+    for row in rows:
+        profile = row["profile"]
+        if allowed and profile not in allowed:
+            continue
+
+        program = row["program"]
+        season = row["season"]
+        if not program and not season:
+            continue
+        if _TRAILER_RE.search(program) or _TRAILER_RE.search(season):
+            continue
+
+        if season:
+            content_type = "tv"
+            series_name = season
+            duration = tv_duration
+        else:
+            content_type = "movie"
+            series_name = program
+            duration = movie_duration
+
+        try:
+            timestamp = datetime.strptime(row["date"], "%Y-%m-%d")
+        except ValueError:
+            continue
+
+        key = (row["date"], profile, content_type, series_name.lower())
+        if key in seen:
+            continue
+        seen.add(key)
+
+        events.append(WatchEvent(
+            platform="disney",
+            title=series_name,
+            content_type=content_type,
+            series_name=series_name,
+            watched_duration=duration,
+            total_duration=duration,
+            timestamp=timestamp,
+            profile=profile,
+        ))
+
+    return events

--- a/recommender/ingestion/disney.py
+++ b/recommender/ingestion/disney.py
@@ -88,6 +88,9 @@ def parse(path: str) -> list[WatchEvent]:
     events: list[WatchEvent] = []
 
     for row in rows:
+        if row["service"].strip().lower() != "disney":
+            continue
+
         profile = row["profile"]
         if allowed and profile not in allowed:
             continue

--- a/recommender/setup.py
+++ b/recommender/setup.py
@@ -14,6 +14,7 @@ import config
 from recommender.ingestion.netflix import parse as parse_netflix
 from recommender.ingestion.prime import parse as parse_prime
 from recommender.ingestion.apple_tv import parse as parse_apple_tv
+from recommender.ingestion.disney import parse as parse_disney
 from recommender.ingestion.manual import parse as parse_manual
 from recommender.signals import compute_scores
 from recommender.tmdb_client import TmdbClient, TmdbMetadata, MatchHints
@@ -37,6 +38,7 @@ _PLATFORM_PARSERS = [
     ("netflix", parse_netflix),
     ("prime", parse_prime),
     ("apple_tv", parse_apple_tv),
+    ("disney", parse_disney),
 ]
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,3 +10,4 @@ rapidfuzz>=3.0.0
 google-genai>=1.0.0
 openai>=1.0.0
 pyyaml>=6.0
+pdfplumber>=0.11.0

--- a/tests/ingestion/test_base.py
+++ b/tests/ingestion/test_base.py
@@ -54,15 +54,6 @@ def test_parse_duration_zero():
     assert parse_duration("00:00:00") == timedelta(0)
 
 
-def test_disney_stub_raises():
-    from recommender.ingestion.disney import parse
-    try:
-        parse("any_path.csv")
-        assert False, "Should have raised NotImplementedError"
-    except NotImplementedError as e:
-        assert "disney" in str(e).lower() or "Disney" in str(e)
-
-
 def test_hbo_stub_raises():
     from recommender.ingestion.hbo import parse
     try:

--- a/tests/ingestion/test_disney.py
+++ b/tests/ingestion/test_disney.py
@@ -9,11 +9,17 @@ from recommender.ingestion.disney import parse
 
 
 def _rows(*tuples) -> list[dict]:
-    """Build a row list from (date, profile, program, season) tuples."""
-    return [
-        {"date": d, "service": "disney", "profile": p, "program": prog, "season": s}
-        for d, p, prog, s in tuples
-    ]
+    """Build a row list from (date, profile, program, season) or
+    (date, service, profile, program, season) tuples."""
+    out: list[dict] = []
+    for t in tuples:
+        if len(t) == 5:
+            d, svc, p, prog, s = t
+        else:
+            d, p, prog, s = t
+            svc = "disney"
+        out.append({"date": d, "service": svc, "profile": p, "program": prog, "season": s})
+    return out
 
 
 @pytest.fixture
@@ -129,6 +135,19 @@ def test_skips_rows_with_blank_program_and_season(pdf_path, monkeypatch):
     with patch.object(disney, "_extract_rows", return_value=rows):
         events = parse(pdf_path)
     assert events == []
+
+
+def test_drops_rows_from_other_services(pdf_path, monkeypatch):
+    monkeypatch.setattr(config, "DISNEY_PROFILES", [])
+    rows = _rows(
+        ("2026-04-08", "disney", "Abhishek", "Cars 3", ""),
+        ("2026-04-08", "espn", "Abhishek", "SportsCenter", ""),
+        ("2026-04-08", "ESPN", "Abhishek", "Monday Night Football", ""),
+        ("2026-04-08", "hulu", "Abhishek", "The Bear", ""),
+    )
+    with patch.object(disney, "_extract_rows", return_value=rows):
+        events = parse(pdf_path)
+    assert [e.series_name for e in events] == ["Cars 3"]
 
 
 def test_raises_for_missing_file(tmp_path):

--- a/tests/ingestion/test_disney.py
+++ b/tests/ingestion/test_disney.py
@@ -1,0 +1,143 @@
+from datetime import datetime, timedelta
+from unittest.mock import patch
+
+import pytest
+
+import config
+from recommender.ingestion import disney
+from recommender.ingestion.disney import parse
+
+
+def _rows(*tuples) -> list[dict]:
+    """Build a row list from (date, profile, program, season) tuples."""
+    return [
+        {"date": d, "service": "disney", "profile": p, "program": prog, "season": s}
+        for d, p, prog, s in tuples
+    ]
+
+
+@pytest.fixture
+def pdf_path(tmp_path):
+    path = tmp_path / "disney.pdf"
+    path.write_bytes(b"%PDF-1.4 stub")
+    return str(path)
+
+
+def test_classifies_tv_when_season_column_holds_series_name(pdf_path, monkeypatch):
+    monkeypatch.setattr(config, "DISNEY_PROFILES", [])
+    rows = _rows(
+        ("2026-04-08", "Abhishek", "Uptight (Oliver's Alright)", "Hannah Montana"),
+    )
+    with patch.object(disney, "_extract_rows", return_value=rows):
+        events = parse(pdf_path)
+    assert len(events) == 1
+    e = events[0]
+    assert e.content_type == "tv"
+    assert e.series_name == "Hannah Montana"
+    assert e.title == "Hannah Montana"
+    assert e.timestamp == datetime(2026, 4, 8)
+    assert e.platform == "disney"
+    assert e.profile == "Abhishek"
+
+
+def test_classifies_movie_when_season_blank(pdf_path, monkeypatch):
+    monkeypatch.setattr(config, "DISNEY_PROFILES", [])
+    rows = _rows(("2026-04-05", "Abhishek", "Cars 3", ""))
+    with patch.object(disney, "_extract_rows", return_value=rows):
+        events = parse(pdf_path)
+    assert [e.content_type for e in events] == ["movie"]
+    assert events[0].series_name == "Cars 3"
+
+
+def test_drops_trailers(pdf_path, monkeypatch):
+    monkeypatch.setattr(config, "DISNEY_PROFILES", [])
+    rows = _rows(
+        ("2026-04-04", "Abhishek", "Cars 3 Trailer", ""),
+        ("2026-04-04", "Abhishek", "Cars 3", ""),
+        ("2026-01-25", "Abhishek", "Trailer | Wonder Man | Season 1", ""),
+    )
+    with patch.object(disney, "_extract_rows", return_value=rows):
+        events = parse(pdf_path)
+    assert [e.series_name for e in events] == ["Cars 3"]
+
+
+def test_profile_filter_keeps_only_allowed(pdf_path, monkeypatch):
+    monkeypatch.setattr(config, "DISNEY_PROFILES", ["Abhishek"])
+    rows = _rows(
+        ("2026-04-02", "Abhishek", "Cars", ""),
+        ("2026-04-02", "Ashish", "Frozen", ""),
+        ("2026-04-02", "Rhonda", "Daddy Putdown", "Bluey: Shorts Season 1"),
+    )
+    with patch.object(disney, "_extract_rows", return_value=rows):
+        events = parse(pdf_path)
+    assert {e.profile for e in events} == {"Abhishek"}
+    assert {e.series_name for e in events} == {"Cars"}
+
+
+def test_empty_profile_filter_keeps_all(pdf_path, monkeypatch):
+    monkeypatch.setattr(config, "DISNEY_PROFILES", [])
+    rows = _rows(
+        ("2026-04-02", "Abhishek", "Cars", ""),
+        ("2026-04-02", "Ashish", "Frozen", ""),
+    )
+    with patch.object(disney, "_extract_rows", return_value=rows):
+        events = parse(pdf_path)
+    assert {e.profile for e in events} == {"Abhishek", "Ashish"}
+
+
+def test_collapses_same_day_duplicate_episodes(pdf_path, monkeypatch):
+    monkeypatch.setattr(config, "DISNEY_PROFILES", [])
+    rows = _rows(
+        ("2025-11-11", "Rhonda", "Daddy Putdown", "Bluey: Shorts Season 1"),
+        ("2025-11-11", "Rhonda", "Daddy Putdown", "Bluey: Shorts Season 1"),
+        ("2025-11-11", "Rhonda", "Muffin Unboxing", "Bluey: Shorts Season 1"),
+        ("2025-11-12", "Rhonda", "Daddy Putdown", "Bluey: Shorts Season 1"),
+    )
+    with patch.object(disney, "_extract_rows", return_value=rows):
+        events = parse(pdf_path)
+    # Same series same day collapses to 1 event regardless of episode title;
+    # next day produces a fresh event.
+    assert len(events) == 2
+    assert {e.timestamp.date().isoformat() for e in events} == {
+        "2025-11-11",
+        "2025-11-12",
+    }
+    assert {e.series_name for e in events} == {"Bluey: Shorts Season 1"}
+
+
+def test_synthesizes_durations_from_manual_config(pdf_path, monkeypatch):
+    monkeypatch.setattr(config, "DISNEY_PROFILES", [])
+    monkeypatch.setattr(config, "MANUAL_TV_DURATION_MINUTES", 45)
+    monkeypatch.setattr(config, "MANUAL_MOVIE_DURATION_MINUTES", 120)
+    rows = _rows(
+        ("2026-04-08", "Abhishek", "Uptight", "Hannah Montana"),
+        ("2026-04-05", "Abhishek", "Cars 3", ""),
+    )
+    with patch.object(disney, "_extract_rows", return_value=rows):
+        events = parse(pdf_path)
+    tv = next(e for e in events if e.content_type == "tv")
+    mv = next(e for e in events if e.content_type == "movie")
+    assert tv.watched_duration == timedelta(minutes=45)
+    assert tv.total_duration == timedelta(minutes=45)
+    assert mv.watched_duration == timedelta(minutes=120)
+    assert mv.total_duration == timedelta(minutes=120)
+
+
+def test_skips_rows_with_blank_program_and_season(pdf_path, monkeypatch):
+    monkeypatch.setattr(config, "DISNEY_PROFILES", [])
+    rows = _rows(("2026-04-08", "Abhishek", "", ""))
+    with patch.object(disney, "_extract_rows", return_value=rows):
+        events = parse(pdf_path)
+    assert events == []
+
+
+def test_raises_for_missing_file(tmp_path):
+    with pytest.raises(FileNotFoundError):
+        parse(str(tmp_path / "missing.pdf"))
+
+
+def test_raises_for_non_pdf_extension(tmp_path):
+    bad = tmp_path / "export.zip"
+    bad.write_bytes(b"stub")
+    with pytest.raises(ValueError, match=r"\.pdf file"):
+        parse(str(bad))

--- a/tests/ingestion/test_disney.py
+++ b/tests/ingestion/test_disney.py
@@ -40,7 +40,7 @@ def test_classifies_tv_when_season_column_holds_series_name(pdf_path, monkeypatc
     e = events[0]
     assert e.content_type == "tv"
     assert e.series_name == "Hannah Montana"
-    assert e.title == "Hannah Montana"
+    assert e.title == "Uptight (Oliver's Alright)"
     assert e.timestamp == datetime(2026, 4, 8)
     assert e.platform == "disney"
     assert e.profile == "Abhishek"
@@ -148,6 +148,32 @@ def test_drops_rows_from_other_services(pdf_path, monkeypatch):
     with patch.object(disney, "_extract_rows", return_value=rows):
         events = parse(pdf_path)
     assert [e.series_name for e in events] == ["Cars 3"]
+
+
+def test_tv_event_title_is_episode_distinct_across_days(pdf_path, monkeypatch):
+    """Different days/episodes of a series must carry distinct titles so
+    signals.compute_scores() doesn't treat them as rewatches of one episode."""
+    monkeypatch.setattr(config, "DISNEY_PROFILES", [])
+    rows = _rows(
+        ("2026-04-08", "Abhishek", "Uptight (Oliver's Alright)", "Hannah Montana"),
+        ("2026-04-07", "Abhishek", "Bye Bye Ball", "Hannah Montana"),
+        ("2026-04-06", "Abhishek", "Yet Another Side of Me", "Hannah Montana"),
+    )
+    with patch.object(disney, "_extract_rows", return_value=rows):
+        events = parse(pdf_path)
+    assert {e.series_name for e in events} == {"Hannah Montana"}
+    titles = [e.title for e in events]
+    assert len(set(titles)) == 3, f"expected 3 distinct episode titles, got {titles}"
+
+
+def test_corrupt_pdf_raises_value_error(tmp_path):
+    """pdfplumber raises pdfminer/OSError on bad PDFs; the parser must
+    normalize those into ValueError so the setup loader reports it as a
+    provider failure instead of crashing."""
+    bad = tmp_path / "corrupt.pdf"
+    bad.write_bytes(b"not a real pdf")
+    with pytest.raises(ValueError, match="Failed to parse Disney"):
+        parse(str(bad))
 
 
 def test_raises_for_missing_file(tmp_path):

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -115,9 +115,6 @@ class TestPlatformPathsAttribute:
         for provider in ("netflix", "prime", "apple_tv", "disney", "hbo"):
             assert provider in config.PLATFORM_PATHS
 
-    def test_disney_disabled_by_default(self):
-        assert config.PLATFORM_PATHS["disney"] == []
-
     def test_hbo_disabled_by_default(self):
         assert config.PLATFORM_PATHS["hbo"] == []
 


### PR DESCRIPTION
## Summary
- Disney delivers viewing history as a PDF (no CSV option). The `TITLES WATCHED` section has columns `Date | Service | Profile | Program | Season`, but the `Season` column actually holds the series name; `Program` is the episode title for TV and the movie title for film (Season blank).
- Replaces the `disney.py` stub with a real pdfplumber-based parser. Scans every page, accepts rows whose first cell is an ISO date, filters by `config.DISNEY_PROFILES`, drops trailers, collapses same-day duplicate episodes per `(profile, series)`, and synthesizes durations from `MANUAL_TV_DURATION_MINUTES` / `MANUAL_MOVIE_DURATION_MINUTES` (the export has none).
- Wires disney into `_PLATFORM_PARSERS`, gives it a default path (`data/disney/export.pdf`), and adds a `disney_profiles` config knob.

Smoke run against a real export: **2955 raw rows -> 874 events** (532 TV, 342 movies) for a single profile, 2020-12-19 -> 2026-04-08.

## Test plan
- [x] `pytest tests/ingestion/test_disney.py` (10 new tests: TV/movie classification, trailer filter, profile filter, same-day dedup, synthesized durations, error paths)
- [x] `pytest tests/` (367 passed)
- [ ] `./recommend setup --refresh-data` against a real Disney+ PDF and verify watch index + taste profile pick up the new events