### PR TITLE
feat(hbo): parse WBD/Max data-export bundle into watch events

### DIFF
--- a/config.py
+++ b/config.py
@@ -168,7 +168,7 @@ PLATFORM_PATHS: dict[str, list[str]] = {
     "prime": _resolve_platform_paths("prime", "data/prime_video/Prime Video.zip"),
     "apple_tv": _resolve_platform_paths("apple_tv", "data/AppleTV/Apple Media Services Information Part 1 of 2.zip"),
     "disney": _resolve_platform_paths("disney", None),
-    "hbo": [],
+    "hbo": _resolve_platform_paths("hbo", None),
 }
 DISNEY_PROFILES: list[str] = list(_cfg.get("disney_profiles", []) or [])
 MANUAL_TV_PATH = str(_ROOT / _cfg.get("manual_tv_path", "data/manual/tv.csv"))

--- a/recommender/ingestion/hbo.py
+++ b/recommender/ingestion/hbo.py
@@ -1,15 +1,163 @@
+"""Parser for the WBD/Max data-export bundle.
+
+The bundle is a directory of CSVs (not a zip). The only file containing watch
+history is `*_engagement_data.csv`, which is unusual in shape: each row is a
+single feature value, and values that happen to be lists are written with the
+Python-repr `[item1, item2, ...]` syntax. That repr collides with the comma
+delimiter, so the list spans multiple CSV columns. We reassemble it by joining
+the row and stripping the brackets.
+
+Titles in the list use the form `series name-s<N>-e<M>` for TV episodes and a
+bare title for movies. The export gives no per-play timestamp, completion
+percentage, or device. We synthesize a single ingestion timestamp (same scheme
+as `manual.py`) and emit one WatchEvent per unique title.
+"""
+
+import csv
+import logging
+import re
+from datetime import datetime, timedelta
+from pathlib import Path
+
+import config
+
 from .base import WatchEvent
 
+log = logging.getLogger("recommender.ingestion.hbo")
 
-def parse(filepath: str) -> list[WatchEvent]:
-    """
-    Parse HBO Max watch history CSV.
-    Not yet implemented — waiting for export data.
+_EPISODE_RE = re.compile(r"^(?P<show>.+?)-s(?P<season>\d+)-e(?P<episode>\d+)$")
+_TRAILER_HINTS = ("trailer", "promo_", "teaser")
 
-    Expected columns (update when data arrives):
-    Title, WatchDate, Duration, ...
+
+def _ingest_timestamp() -> datetime:
+    ts = config.MANUAL_TIMESTAMP
+    if ts == "now":
+        return datetime.now()
+    try:
+        return datetime.strptime(ts, "%Y-%m-%d")
+    except ValueError:
+        return datetime.now()
+
+
+def _find_engagement_csv(directory: Path) -> Path | None:
+    """Pick the engagement_data CSV that contains the title list.
+
+    The bundle may include multiple `*_engagement_data.csv` files; only one
+    holds the title arrays. We choose by file size (the title-bearing file is
+    materially larger than the segment-only or empty variants).
     """
-    raise NotImplementedError(
-        "HBO Max parser not implemented. "
-        "Set config.PLATFORM_PATHS['hbo'] = None until data arrives."
-    )
+    candidates = sorted(directory.glob("*_engagement_data.csv"))
+    if not candidates:
+        return None
+    return max(candidates, key=lambda p: p.stat().st_size)
+
+
+def _extract_title_rows(filepath: Path) -> list[list[str]]:
+    """Return rows whose items look like a real title list.
+
+    A row qualifies if any cell matches the `-sNN-eNN` episode pattern.
+    """
+    rows: list[list[str]] = []
+    with open(filepath, newline="", encoding="utf-8") as f:
+        for row in csv.reader(f):
+            joined = ",".join(row)
+            if "-s" in joined and re.search(r"-s\d+-e\d+", joined):
+                rows.append(row)
+    return rows
+
+
+def _normalize_items(row: list[str]) -> list[str]:
+    """Strip brackets/whitespace from a comma-split list row."""
+    items = []
+    for raw in row:
+        item = raw.strip().lstrip("[").rstrip("]").strip()
+        if item:
+            items.append(item)
+    return items
+
+
+def _classify(item: str) -> tuple[str, str, str] | None:
+    """Return (content_type, series_name, display_title) or None to skip.
+
+    Drops trailers and other promotional content. Strips the optional
+    `movie_` / `series_` / `promo_` type-prefix used in the typed
+    "recently-watched" row.
+    """
+    lower = item.lower()
+    if any(h in lower for h in _TRAILER_HINTS):
+        return None
+
+    if lower.startswith("movie_"):
+        item = item[6:].strip()
+    elif lower.startswith("series_"):
+        item = item[7:].strip()
+    elif lower.startswith("promo_"):
+        return None
+
+    if not item:
+        return None
+
+    match = _EPISODE_RE.match(item)
+    if match:
+        show = match.group("show").strip()
+        return "tv", show, item
+    return "movie", item, item
+
+
+def parse(path: str) -> list[WatchEvent]:
+    """Parse the Max/WBD bundle directory and return WatchEvents.
+
+    Args:
+        path: Directory containing the WBD CSV export.
+
+    Raises:
+        FileNotFoundError: directory does not exist.
+        ValueError: bundle is not a directory or has no engagement file.
+    """
+    p = Path(path)
+    if not p.exists():
+        raise FileNotFoundError(f"Max export directory not found: {path}")
+    if not p.is_dir():
+        raise ValueError(f"Max path must be a directory, got: {path}")
+
+    engagement = _find_engagement_csv(p)
+    if engagement is None:
+        raise ValueError(f"No *_engagement_data.csv found in {path}")
+
+    log.debug("Max: reading %s", engagement)
+    title_rows = _extract_title_rows(engagement)
+    if not title_rows:
+        log.warning("Max engagement file %s has no title rows", engagement)
+        return []
+
+    timestamp = _ingest_timestamp()
+    tv_duration = timedelta(minutes=config.MANUAL_TV_DURATION_MINUTES)
+    movie_duration = timedelta(minutes=config.MANUAL_MOVIE_DURATION_MINUTES)
+
+    seen: set[tuple[str, str]] = set()
+    events: list[WatchEvent] = []
+
+    for row in title_rows:
+        for item in _normalize_items(row):
+            classified = _classify(item)
+            if classified is None:
+                continue
+            content_type, series_name, display_title = classified
+            key = (content_type, display_title.lower())
+            if key in seen:
+                continue
+            seen.add(key)
+            duration = tv_duration if content_type == "tv" else movie_duration
+            events.append(WatchEvent(
+                platform="hbo",
+                title=display_title,
+                content_type=content_type,
+                series_name=series_name,
+                watched_duration=duration,
+                total_duration=duration,
+                timestamp=timestamp,
+                profile="",
+            ))
+
+    log.debug("Max: parsed %d events from %s", len(events), engagement.name)
+    return events

--- a/recommender/setup.py
+++ b/recommender/setup.py
@@ -15,6 +15,7 @@ from recommender.ingestion.netflix import parse as parse_netflix
 from recommender.ingestion.prime import parse as parse_prime
 from recommender.ingestion.apple_tv import parse as parse_apple_tv
 from recommender.ingestion.disney import parse as parse_disney
+from recommender.ingestion.hbo import parse as parse_hbo
 from recommender.ingestion.manual import parse as parse_manual
 from recommender.signals import compute_scores
 from recommender.tmdb_client import TmdbClient, TmdbMetadata, MatchHints
@@ -39,11 +40,31 @@ _PLATFORM_PARSERS = [
     ("prime", parse_prime),
     ("apple_tv", parse_apple_tv),
     ("disney", parse_disney),
+    ("hbo", parse_hbo),
 ]
 
 
 def _compute_file_sha256(path: str) -> str:
-    """Compute SHA-256 of a file using chunked reads."""
+    """Compute SHA-256 of a file using chunked reads.
+
+    If `path` is a directory, hash a composite digest over each contained
+    file's relative path and content so that any change inside the bundle
+    invalidates the snapshot. Used for export sources that ship as a folder
+    of CSVs (e.g. the WBD/Max bundle) rather than a single zip.
+    """
+    from pathlib import Path as _Path
+    p = _Path(path)
+    if p.is_dir():
+        composite = hashlib.sha256()
+        for child in sorted(f for f in p.rglob("*") if f.is_file()):
+            rel = child.relative_to(p).as_posix()
+            composite.update(rel.encode("utf-8"))
+            composite.update(b"\0")
+            with open(child, "rb") as f:
+                while chunk := f.read(8192):
+                    composite.update(chunk)
+            composite.update(b"\0")
+        return composite.hexdigest()
     h = hashlib.sha256()
     with open(path, "rb") as f:
         while chunk := f.read(8192):

--- a/tests/ingestion/test_base.py
+++ b/tests/ingestion/test_base.py
@@ -54,10 +54,3 @@ def test_parse_duration_zero():
     assert parse_duration("00:00:00") == timedelta(0)
 
 
-def test_hbo_stub_raises():
-    from recommender.ingestion.hbo import parse
-    try:
-        parse("any_path.csv")
-        assert False, "Should have raised NotImplementedError"
-    except NotImplementedError as e:
-        assert "hbo" in str(e).lower() or "HBO" in str(e)

--- a/tests/ingestion/test_hbo.py
+++ b/tests/ingestion/test_hbo.py
@@ -1,0 +1,128 @@
+from datetime import datetime, timedelta
+from pathlib import Path
+
+import pytest
+
+from recommender.ingestion.hbo import parse
+
+
+def _write_engagement(directory: Path, lines: list[str]) -> Path:
+    """Write a fake engagement_data CSV. Each entry in `lines` becomes one row."""
+    path = directory / "ABC123_engagement_data.csv"
+    path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+    return path
+
+
+@pytest.fixture
+def bundle(tmp_path):
+    return tmp_path
+
+
+def test_parses_movies_and_tv_episodes(bundle):
+    _write_engagement(bundle, [
+        "roku",
+        "[roku, web]",
+        "4",
+        "[some movie, show name-s1-e1, show name-s1-e2]",
+    ])
+    events = parse(str(bundle))
+    by_title = {e.title: e for e in events}
+    assert set(by_title.keys()) == {"some movie", "show name-s1-e1", "show name-s1-e2"}
+
+    movie = by_title["some movie"]
+    assert movie.content_type == "movie"
+    assert movie.series_name == "some movie"
+    assert movie.platform == "hbo"
+
+    ep = by_title["show name-s1-e1"]
+    assert ep.content_type == "tv"
+    assert ep.series_name == "show name"
+
+
+def test_filters_trailers_and_promos(bundle):
+    _write_engagement(bundle, [
+        "[real movie, real show-s1-e1, eddington trailer, promo_foo bar]",
+    ])
+    events = parse(str(bundle))
+    titles = {e.title for e in events}
+    assert titles == {"real movie", "real show-s1-e1"}
+
+
+def test_strips_typed_prefixes(bundle):
+    _write_engagement(bundle, [
+        "[movie_one battle after another, series_succession-s4-e10, real show-s1-e1]",
+    ])
+    events = parse(str(bundle))
+    by_title = {e.title: e.content_type for e in events}
+    assert by_title["one battle after another"] == "movie"
+    assert by_title["succession-s4-e10"] == "tv"
+
+
+def test_dedupes_across_multiple_title_rows(bundle):
+    _write_engagement(bundle, [
+        "[movie a, show-s1-e1]",
+        "[show-s1-e1, movie a, movie b]",
+    ])
+    events = parse(str(bundle))
+    titles = sorted(e.title for e in events)
+    assert titles == ["movie a", "movie b", "show-s1-e1"]
+
+
+def test_handles_titles_with_special_chars(bundle):
+    _write_engagement(bundle, [
+        "[who's talking to chris wallace?-s1-e22, blue valentine]",
+    ])
+    events = parse(str(bundle))
+    by_title = {e.title: e for e in events}
+    assert "who's talking to chris wallace?-s1-e22" in by_title
+    assert by_title["who's talking to chris wallace?-s1-e22"].series_name == "who's talking to chris wallace?"
+
+
+def test_picks_largest_engagement_file(bundle):
+    # Small segment-only file
+    (bundle / "AAA_engagement_data.csv").write_text("Prestige Superfans\n", encoding="utf-8")
+    # Larger title-bearing file
+    _write_engagement(bundle, [
+        "[real movie, real show-s1-e1]",
+    ])
+    events = parse(str(bundle))
+    titles = {e.title for e in events}
+    assert titles == {"real movie", "real show-s1-e1"}
+
+
+def test_returns_empty_when_no_title_rows(bundle):
+    _write_engagement(bundle, ["Prestige Superfans", "false", "1.0"])
+    events = parse(str(bundle))
+    assert events == []
+
+
+def test_raises_when_directory_missing(tmp_path):
+    with pytest.raises(FileNotFoundError):
+        parse(str(tmp_path / "does-not-exist"))
+
+
+def test_raises_when_path_is_a_file(tmp_path):
+    f = tmp_path / "a.csv"
+    f.write_text("x", encoding="utf-8")
+    with pytest.raises(ValueError, match="must be a directory"):
+        parse(str(f))
+
+
+def test_raises_when_no_engagement_file(tmp_path):
+    (tmp_path / "other.csv").write_text("x", encoding="utf-8")
+    with pytest.raises(ValueError, match="No \\*_engagement_data.csv"):
+        parse(str(tmp_path))
+
+
+def test_event_fields_use_manual_defaults(bundle, monkeypatch):
+    import config as cfg
+    monkeypatch.setattr(cfg, "MANUAL_TV_DURATION_MINUTES", 30)
+    monkeypatch.setattr(cfg, "MANUAL_MOVIE_DURATION_MINUTES", 100)
+    monkeypatch.setattr(cfg, "MANUAL_TIMESTAMP", "2025-01-15")
+    _write_engagement(bundle, ["[some movie, show-s1-e1]"])
+    events = parse(str(bundle))
+    movie = next(e for e in events if e.content_type == "movie")
+    tv = next(e for e in events if e.content_type == "tv")
+    assert movie.watched_duration == timedelta(minutes=100)
+    assert tv.watched_duration == timedelta(minutes=30)
+    assert movie.timestamp == datetime(2025, 1, 15)

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -115,8 +115,9 @@ class TestPlatformPathsAttribute:
         for provider in ("netflix", "prime", "apple_tv", "disney", "hbo"):
             assert provider in config.PLATFORM_PATHS
 
-    def test_hbo_disabled_by_default(self):
-        assert config.PLATFORM_PATHS["hbo"] == []
+    def test_hbo_disabled_without_explicit_config(self):
+        """hbo has no repo default path; absent any override it must resolve to []."""
+        assert _resolve_missing("hbo", None) == []
 
     def test_active_providers_truthy(self):
         """netflix/prime/apple_tv should be truthy unless explicitly disabled in config."""


### PR DESCRIPTION
## Summary

- New `recommender/ingestion/hbo.py` parser turns the WBD/Max privacy-export bundle (a directory of CSVs) into `WatchEvent`s. Pulls titles out of `*_engagement_data.csv`, reassembles bracketed list rows that span multiple CSV columns, classifies `show-sNN-eNN` items as TV and bare titles as movies, dedupes across the multiple title-bearing rows, and drops trailers / `promo_` entries.
- The export carries no per-play timestamps, so events fall back to the same `config.MANUAL_*` timestamp/duration defaults used by the manual-titles parser.
- Bug fix in `config.py`: `platform_paths.hbo` was hardcoded to `[]`, so user overrides were silently ignored. It now goes through `_resolve_platform_paths` like the other providers (still defaults to disabled when no path is configured).
- `setup._compute_file_sha256` is now directory-aware (composite hash over relative path + content for every file in the bundle), so folder-based exports work with the source-manifest snapshot.
- Registered `hbo` in `_PLATFORM_PARSERS` so the existing setup pipeline picks it up.

End-to-end on the real export: 28 events (25 TV episodes across 8 series, 3 movies) flow cleanly into the event store alongside the other platforms.

## Test plan

- [x] `pytest tests/ -q` — 380 tests pass (11 new for hbo, 369 existing)
- [x] Dry-run `setup.load_platform_events_from_exports()` against `data/Max/` — 28 hbo events parsed, expected series/movies present
- [x] Removed the now-stale `test_hbo_stub_raises` and rewrote `test_hbo_disabled_by_default` to assert resolution semantics rather than global module state