### PR TITLE
feat: concierge wizard — guided recommendation mode

### DIFF
--- a/config.py
+++ b/config.py
@@ -119,6 +119,10 @@ MIN_RATING = float(_cfg.get("min_rating", 0))
 MIN_YEAR = int(_cfg.get("min_year", 0))
 RECENCY_HALF_LIFE_DAYS = _cfg.get("recency_half_life_days", 90)
 
+# ── Concierge wizard ──
+_wizard = _cfg.get("wizard", {})
+WIZARD_MAX_QUESTIONS = int(_wizard.get("max_questions", 4))
+
 # ── Streaming availability ──
 WATCH_REGION = _cfg.get("watch_region", "US")
 STREAMING_PLATFORMS: list[str] = _cfg.get("streaming_platforms", [])

--- a/config.py
+++ b/config.py
@@ -119,9 +119,13 @@ MIN_RATING = float(_cfg.get("min_rating", 0))
 MIN_YEAR = int(_cfg.get("min_year", 0))
 RECENCY_HALF_LIFE_DAYS = _cfg.get("recency_half_life_days", 90)
 
-# ── Concierge wizard ──
+# ── Mood Match wizard ──
 _wizard = _cfg.get("wizard", {})
 WIZARD_MAX_QUESTIONS = int(_wizard.get("max_questions", 4))
+# Output-token ceiling for each wizard turn. The finalize turn emits a full
+# QueryIntent JSON (summary + intent + context_note), which overflows the
+# smaller intent-parsing budget and gets truncated, so it needs its own limit.
+WIZARD_MAX_TOKENS = int(_wizard.get("max_tokens", 1200))
 
 # ── Streaming availability ──
 WATCH_REGION = _cfg.get("watch_region", "US")

--- a/config.py
+++ b/config.py
@@ -114,6 +114,11 @@ MANUAL_MOVIE_DURATION_MINUTES = _manual.get("movie_duration_minutes", 120)
 # ── Recommendation settings ──
 DEFAULT_TOP_N = _cfg.get("default_top_n", 3)
 CANDIDATE_POOL_SIZE = _cfg.get("candidate_pool_size", 500)
+# Upper bound on how many candidates get LLM enrichment + ranking. Enrichment is
+# one serial LLM call per uncached title, so a broad query (e.g. from the Mood
+# Match wizard) can otherwise enrich 100+ titles and take minutes. Filtered
+# queries normally stay well under this, so they are unaffected.
+MAX_ENRICH_CANDIDATES = int(_cfg.get("max_enrich_candidates", 40))
 MIN_VOTE_COUNT = _cfg.get("min_vote_count", 20)
 MIN_RATING = float(_cfg.get("min_rating", 0))
 MIN_YEAR = int(_cfg.get("min_year", 0))

--- a/config.yaml
+++ b/config.yaml
@@ -43,7 +43,7 @@ min_rating: 6.5
 min_year: 2000
 recency_half_life_days: 90
 wizard:
-  max_questions: 4
+  max_questions: 10
 scoring:
   weight_completion: 0.5
   weight_rewatch: 0.3

--- a/config.yaml
+++ b/config.yaml
@@ -42,6 +42,8 @@ min_vote_count: 20
 min_rating: 6.5
 min_year: 2000
 recency_half_life_days: 90
+wizard:
+  max_questions: 4
 scoring:
   weight_completion: 0.5
   weight_rewatch: 0.3

--- a/config.yaml
+++ b/config.yaml
@@ -44,6 +44,7 @@ min_year: 2000
 recency_half_life_days: 90
 wizard:
   max_questions: 10
+  max_tokens: 1200
 scoring:
   weight_completion: 0.5
   weight_rewatch: 0.3

--- a/docs/superpowers/plans/2026-06-28-concierge-wizard.md
+++ b/docs/superpowers/plans/2026-06-28-concierge-wizard.md
@@ -1,0 +1,949 @@
+# Concierge Wizard Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a guided, adaptive Q&A "concierge" mode to the web UI that probes today's viewing context and produces recommendations without requiring a seed title or typed query.
+
+**Architecture:** A thin new front-end (`recommender/wizard.py` + Flask routes + templates) runs an adaptive LLM question loop. State is carried client-side as JSON in a hidden form field (stateless server). On finish it synthesizes a `QueryIntent` plus a free-text `context_note` and hands off to a lightly-refactored `query_engine.ask()` that skips `parse_intent` and reuses the whole online pipeline. The slow final recommendation runs through the existing background-job registry, matching `/recommend`.
+
+**Tech Stack:** Python 3.14, Flask + HTMX (server-rendered partials), Jinja2 templates, pytest. LLM via the existing `LLMClient` abstraction (`role="reason"`).
+
+## Global Constraints
+
+- No emoji in code or documentation.
+- No new third-party dependencies; reuse Flask/HTMX/Jinja already in the project.
+- Match the existing dark-editorial aesthetic: `DM Serif Display` headlines, `DM Sans` body, `JetBrains Mono` uppercase micro-labels; colors via the CSS variables in `base.html` (`--accent #e85d4a`, `--teal`, `--lavender`, `--surface`, `--border`, `--muted`, `--body`, `--text`). Do not introduce a new theme.
+- CSRF: HTMX requests auto-send `X-CSRF-Token` (see `base.html`); POST routes are covered by the existing `_check_csrf()` before-request hook. Forms still include `<input type="hidden" name="_csrf_token" value="{{ csrf_token }}">` to match existing templates.
+- Question cap is config-driven (`config.WIZARD_MAX_QUESTIONS`, default 4) and enforced server-side regardless of LLM output.
+- Soft signals (runtime, energy, company) are ranking nudges via `context_note`, never hard filters. Do not add new `QueryIntent` fields.
+- TDD: write the failing test first, watch it fail, implement minimally, watch it pass, commit. Run tests with the project venv: `python3 -m pytest`.
+
+---
+
+### Task 1: Thread `context_note` and `intent_override` through the query pipeline
+
+Adds two optional parameters to the online pipeline so the wizard can inject a pre-built intent (skipping `parse_intent`) and a free-text ranking nudge. No behavior change for existing callers.
+
+**Files:**
+- Modify: `recommender/query_engine.py` (`rank_candidates` ~228-264; `ask` 510-671)
+- Test: `tests/test_query_engine.py`
+
+**Interfaces:**
+- Produces:
+  - `rank_candidates(query, taste_profile, candidates, enrichments, client, top_n=1, context_note: str | None = None) -> list[Recommendation]`
+  - `ask(query, ctx, top_n_override=None, conv_ctx=None, intent_override: "QueryIntent | None" = None, context_note: str | None = None) -> list[Recommendation]`
+
+- [ ] **Step 1: Write the failing test for `context_note` in the rank prompt**
+
+Add to `tests/test_query_engine.py`:
+
+```python
+def test_rank_candidates_includes_context_note_in_prompt():
+    from recommender import query_engine
+    from recommender.tmdb_client import TmdbMetadata
+
+    captured = {}
+
+    class FakeLLM:
+        provider = "fake"
+        def generate(self, prompt, role="reason", max_tokens=1000, timeout=30.0):
+            captured["prompt"] = prompt
+            return "[]"
+
+    cand = TmdbMetadata(
+        tmdb_id=1, title="Example", content_type="movie", genres=["drama"],
+        vote_average=7.0, vote_count=100, popularity=10.0, release_year=2020,
+        overview="", poster_path=None, original_language="en", original_title="Example",
+        runtime=100,
+    )
+    query_engine.rank_candidates(
+        "something", "PROFILE", [cand], {}, FakeLLM(), top_n=1,
+        context_note="Wants something short and low-energy tonight.",
+    )
+    assert "short and low-energy" in captured["prompt"]
+```
+
+(If `TmdbMetadata`'s constructor differs, build it the way other tests in this file already do — copy an existing construction from `tests/test_query_engine.py`.)
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `python3 -m pytest tests/test_query_engine.py::test_rank_candidates_includes_context_note_in_prompt -v`
+Expected: FAIL — `rank_candidates() got an unexpected keyword argument 'context_note'`.
+
+- [ ] **Step 3: Add the `context_note` parameter to `rank_candidates`**
+
+Change the signature (line ~228-235) to add `context_note`:
+
+```python
+def rank_candidates(
+    query: str,
+    taste_profile: str,
+    candidates: list[TmdbMetadata],
+    enrichments: dict[str, str],
+    client: LLMClient,
+    top_n: int = 1,
+    context_note: str | None = None,
+) -> list[Recommendation]:
+```
+
+In the prompt construction (line ~246-260), insert the note just after the `QUERY:` line. Replace:
+
+```python
+        f'QUERY: "{query}"\n\n'
+        f'TASTE PROFILE:\n{taste_profile}\n\n'
+```
+
+with:
+
+```python
+        f'QUERY: "{query}"\n\n'
+        + (f'TONIGHT\'S CONTEXT (use to nudge ordering, not as a hard filter):\n{context_note}\n\n'
+           if context_note else '')
+        + f'TASTE PROFILE:\n{taste_profile}\n\n'
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `python3 -m pytest tests/test_query_engine.py::test_rank_candidates_includes_context_note_in_prompt -v`
+Expected: PASS.
+
+- [ ] **Step 5: Write the failing test for `ask(intent_override=...)` skipping `parse_intent`**
+
+Add to `tests/test_query_engine.py`:
+
+```python
+def test_ask_with_intent_override_skips_parse_intent(monkeypatch):
+    from recommender import query_engine
+    from recommender.query_engine import QueryIntent, RecommendContext
+
+    def boom(*a, **k):
+        raise AssertionError("parse_intent must not be called when intent_override is given")
+    monkeypatch.setattr(query_engine, "parse_intent", boom)
+
+    class FakeTmdb:
+        def search_by_filters(self, **k):
+            return []
+    class FakeLLM:
+        provider = "fake"
+        def generate(self, prompt, role="reason", max_tokens=1000, timeout=30.0):
+            return "[]"   # no LLM suggestions
+
+    ctx = RecommendContext(
+        taste_profile="PROFILE", watch_index=None, tmdb_client=FakeTmdb(),
+        llm=FakeLLM(), cache_dir="", events=[],
+    )
+    intent = QueryIntent(
+        genres=[], origin_countries=[], languages=[], mood_descriptors=[],
+        similar_to=[], max_runtime_minutes=None, year_from=None, year_to=None,
+        unwatched_only=True, special_intent=None, content_type="movie",
+        top_n=3, platforms=[],
+    )
+    results = query_engine.ask("ignored", ctx, intent_override=intent,
+                               context_note="low energy")
+    assert results == []   # no candidates -> empty, but parse_intent never ran
+```
+
+- [ ] **Step 6: Run the test to verify it fails**
+
+Run: `python3 -m pytest tests/test_query_engine.py::test_ask_with_intent_override_skips_parse_intent -v`
+Expected: FAIL — `ask() got an unexpected keyword argument 'intent_override'`.
+
+- [ ] **Step 7: Add `intent_override` and `context_note` to `ask` and thread them**
+
+Change the `ask` signature (line 510-515) to:
+
+```python
+def ask(
+    query: str,
+    ctx: RecommendContext,
+    top_n_override: int | None = None,
+    conv_ctx: "ConversationContext | None" = None,
+    intent_override: "QueryIntent | None" = None,
+    context_note: str | None = None,
+) -> list[Recommendation]:
+```
+
+At the start of the `else` branch that builds intent (the block containing line 539 `intent = parse_intent(...)`), short-circuit when an override is supplied. Replace the existing `intent = parse_intent(query, ctx.llm, conv_ctx=conv_ctx)` / `top_n_override` block with:
+
+```python
+        if intent_override is not None:
+            intent = intent_override
+        else:
+            intent = parse_intent(query, ctx.llm, conv_ctx=conv_ctx)
+        if top_n_override is not None:
+            intent.top_n = top_n_override
+```
+
+Then pass `context_note` into BOTH `rank_candidates` calls. Line ~638:
+
+```python
+        results = rank_candidates(query, profile_for_prompt, candidates, enrichments,
+                                  ctx.llm, rank_size, context_note=context_note)
+```
+
+Line ~668:
+
+```python
+    results = rank_candidates(query, profile_for_prompt, candidates, enrichments,
+                              ctx.llm, intent.top_n, context_note=context_note)
+```
+
+- [ ] **Step 8: Run both new tests plus the full query-engine suite**
+
+Run: `python3 -m pytest tests/test_query_engine.py -v`
+Expected: PASS (all, including the two new tests).
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add recommender/query_engine.py tests/test_query_engine.py
+git commit -m "feat(query): support intent_override and context_note in ask/rank"
+```
+
+---
+
+### Task 2: Wizard engine module + config knob
+
+The adaptive question loop. One `role=reason` LLM call per turn returns either the next question or a finish signal carrying a synthesized intent and ranking note. Cap is enforced here.
+
+**Files:**
+- Modify: `config.py` (after line 120, the recommendation-settings block), `config.yaml` (top level)
+- Create: `recommender/wizard.py`
+- Test: `tests/test_wizard.py`
+
+**Interfaces:**
+- Consumes: `config.WIZARD_MAX_QUESTIONS: int`; `query_engine._safe_query_intent`, `query_engine._parse_json_response`; `RecommendContext` (uses `.taste_profile`, `.llm`).
+- Produces:
+  - `@dataclass class WizardState` with fields `turns: list[dict]` (each `{"prompt": str, "selected": list[str], "free_text": str}`) and `turn_count: int`; classmethod `from_json(raw: str) -> WizardState` (returns an empty state on any parse error) and method `to_json() -> str`.
+  - `next_turn(state: WizardState, ctx, force_finish: bool = False) -> dict` returning either `{"action": "ask", "prompt", "subtext", "chips": [{"label","value"}], "multi": bool, "allow_free_text": bool}` or `{"action": "recommend", "summary": str, "intent": QueryIntent, "context_note": str}`.
+
+- [ ] **Step 1: Add the config knob (failing import-level expectation)**
+
+Add to `config.py` immediately after the recommendation-settings block (after line 120):
+
+```python
+# ── Concierge wizard ──
+_wizard = _cfg.get("wizard", {})
+WIZARD_MAX_QUESTIONS = int(_wizard.get("max_questions", 4))
+```
+
+Add to `config.yaml` at top level (after the `default_top_n` group, e.g. after line 44):
+
+```yaml
+wizard:
+  max_questions: 4
+```
+
+- [ ] **Step 2: Write the failing test for an "ask" turn**
+
+Create `tests/test_wizard.py`:
+
+```python
+import json
+from recommender import wizard
+from recommender.wizard import WizardState
+from recommender.query_engine import RecommendContext, QueryIntent
+
+
+class FakeLLM:
+    def __init__(self, responses):
+        self._responses = list(responses)
+        self.calls = []
+    def generate(self, prompt, role="reason", max_tokens=1000, timeout=30.0):
+        self.calls.append(prompt)
+        return self._responses.pop(0)
+
+
+def _ctx(llm):
+    return RecommendContext(
+        taste_profile="Loves slow-burn British crime drama.",
+        watch_index=None, tmdb_client=None, llm=llm, cache_dir="", events=[],
+    )
+
+
+def test_next_turn_returns_ask_question():
+    llm = FakeLLM([json.dumps({
+        "action": "ask",
+        "prompt": "What's the vibe tonight?",
+        "subtext": "Pick any that fit.",
+        "chips": [{"label": "Light", "value": "light"}, {"label": "Tense", "value": "tense"}],
+        "multi": True,
+        "allow_free_text": True,
+    })])
+    out = wizard.next_turn(WizardState(turns=[], turn_count=0), _ctx(llm))
+    assert out["action"] == "ask"
+    assert out["chips"][0]["value"] == "light"
+    assert out["multi"] is True
+```
+
+- [ ] **Step 3: Run the test to verify it fails**
+
+Run: `python3 -m pytest tests/test_wizard.py::test_next_turn_returns_ask_question -v`
+Expected: FAIL — `ModuleNotFoundError: No module named 'recommender.wizard'`.
+
+- [ ] **Step 4: Implement `recommender/wizard.py`**
+
+Create `recommender/wizard.py`:
+
+```python
+"""Concierge wizard: adaptive guided-recommendation question loop.
+
+One role=reason LLM call per turn. The model sees the taste profile as a prior
+and the answers so far, and returns either the next question or a finish signal
+carrying a synthesized QueryIntent plus a free-text ranking note. The question
+cap is enforced here, independent of what the model returns.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from dataclasses import dataclass, field
+
+import config
+from recommender.query_engine import _parse_json_response, _safe_query_intent
+
+log = logging.getLogger(__name__)
+
+
+@dataclass
+class WizardState:
+    turns: list[dict] = field(default_factory=list)
+    turn_count: int = 0
+
+    @classmethod
+    def from_json(cls, raw: str) -> "WizardState":
+        try:
+            data = json.loads(raw) if raw else {}
+            turns = data.get("turns", [])
+            if not isinstance(turns, list):
+                raise ValueError("turns must be a list")
+            return cls(turns=turns, turn_count=int(data.get("turn_count", len(turns))))
+        except (json.JSONDecodeError, ValueError, TypeError) as exc:
+            log.warning("Resetting wizard state, could not parse: %s", exc)
+            return cls(turns=[], turn_count=0)
+
+    def to_json(self) -> str:
+        return json.dumps({"turns": self.turns, "turn_count": self.turn_count})
+
+
+def _qa_so_far(state: WizardState) -> str:
+    if not state.turns:
+        return "(no answers yet)"
+    lines = []
+    for t in state.turns:
+        picks = ", ".join(t.get("selected", []))
+        free = (t.get("free_text") or "").strip()
+        answer = " / ".join(p for p in (picks, free) if p) or "(skipped)"
+        lines.append(f'Q: {t.get("prompt", "")}\nA: {answer}')
+    return "\n".join(lines)
+
+
+def _prompt(state: WizardState, profile: str, force_finish: bool) -> str:
+    cap = config.WIZARD_MAX_QUESTIONS
+    finish_clause = (
+        "You MUST finish now: return the recommend action. Do not ask another question.\n"
+        if force_finish else
+        f"You may ask at most {cap} questions total ({state.turn_count} asked so far). "
+        "Ask another only if it would materially change the recommendation; otherwise finish.\n"
+    )
+    return (
+        "You are a film/TV concierge helping someone who cannot decide what to watch. "
+        "Use their taste profile as a PRIOR: do not ask what it already implies; probe only "
+        "tonight's context (mood, energy, time available, alone or with others, novelty vs comfort).\n\n"
+        f"TASTE PROFILE:\n{profile}\n\n"
+        f"ANSWERS SO FAR:\n{_qa_so_far(state)}\n\n"
+        f"{finish_clause}"
+        "Return ONLY valid JSON, exactly one of:\n"
+        '1) {"action":"ask","prompt":str,"subtext":str,'
+        '"chips":[{"label":str,"value":str}],"multi":bool,"allow_free_text":bool}\n'
+        "   3-5 short, tappable chips. Set multi=true when several answers can co-apply.\n"
+        '2) {"action":"recommend","summary":str,'
+        '"intent":{"genres":[],"origin_countries":[],"languages":[],"mood_descriptors":[],'
+        '"similar_to":[],"max_runtime_minutes":null,"year_from":null,"year_to":null,'
+        '"unwatched_only":true,"special_intent":null,"content_type":"both","top_n":5,'
+        '"platforms":[]},"context_note":str}\n'
+        '   "summary" is a one-line recap ("something light, short, a little offbeat"). '
+        '"context_note" carries soft signals (runtime/energy/company) for ranking.\n'
+    )
+
+
+def _finalize(state: WizardState, profile: str, llm) -> dict:
+    """Force a recommend turn. Used on cap hit or early-exit."""
+    raw = llm.generate(_prompt(state, profile, force_finish=True),
+                        role="reason", max_tokens=config.TOKENS_INTENT,
+                        timeout=config.TIMEOUT_REASON)
+    data = _parse_json_response(raw)
+    return {
+        "action": "recommend",
+        "summary": data.get("summary", "based on what you told me"),
+        "intent": _safe_query_intent(data.get("intent", {})),
+        "context_note": data.get("context_note", ""),
+    }
+
+
+def next_turn(state: WizardState, ctx, force_finish: bool = False) -> dict:
+    """Produce the next wizard turn: a question, or a finish signal with intent."""
+    profile = ctx.taste_profile or ""
+    cap_hit = state.turn_count >= config.WIZARD_MAX_QUESTIONS
+    if force_finish or cap_hit:
+        return _finalize(state, profile, ctx.llm)
+
+    raw = ctx.llm.generate(_prompt(state, profile, force_finish=False),
+                           role="reason", max_tokens=config.TOKENS_INTENT,
+                           timeout=config.TIMEOUT_REASON)
+    try:
+        data = _parse_json_response(raw)
+    except (json.JSONDecodeError, ValueError, TypeError) as exc:
+        log.warning("Malformed wizard turn, finalizing instead: %s", exc)
+        return _finalize(state, profile, ctx.llm)
+
+    if data.get("action") == "recommend":
+        return {
+            "action": "recommend",
+            "summary": data.get("summary", "based on what you told me"),
+            "intent": _safe_query_intent(data.get("intent", {})),
+            "context_note": data.get("context_note", ""),
+        }
+
+    return {
+        "action": "ask",
+        "prompt": data.get("prompt", "What are you in the mood for?"),
+        "subtext": data.get("subtext", ""),
+        "chips": [c for c in data.get("chips", []) if c.get("value")],
+        "multi": bool(data.get("multi", False)),
+        "allow_free_text": bool(data.get("allow_free_text", True)),
+    }
+```
+
+- [ ] **Step 5: Run the test to verify it passes**
+
+Run: `python3 -m pytest tests/test_wizard.py::test_next_turn_returns_ask_question -v`
+Expected: PASS.
+
+- [ ] **Step 6: Write failing tests for finalize-on-cap, malformed-JSON fallback, and recommend mapping**
+
+Append to `tests/test_wizard.py`:
+
+```python
+def test_cap_forces_finalize(monkeypatch):
+    monkeypatch.setattr("config.WIZARD_MAX_QUESTIONS", 2)
+    recommend_json = json.dumps({
+        "action": "recommend", "summary": "light and short",
+        "intent": {"content_type": "movie", "top_n": 5},
+        "context_note": "30 minutes, low energy",
+    })
+    llm = FakeLLM([recommend_json])
+    state = WizardState(turns=[{}, {}], turn_count=2)  # already at cap
+    out = wizard.next_turn(state, _ctx(llm))
+    assert out["action"] == "recommend"
+    assert isinstance(out["intent"], QueryIntent)
+    assert out["intent"].content_type == "movie"
+    assert out["context_note"] == "30 minutes, low energy"
+
+
+def test_malformed_turn_falls_back_to_finalize():
+    recommend_json = json.dumps({
+        "action": "recommend", "summary": "x",
+        "intent": {"content_type": "both"}, "context_note": "",
+    })
+    llm = FakeLLM(["this is not json", recommend_json])
+    out = wizard.next_turn(WizardState(turns=[], turn_count=1), _ctx(llm))
+    assert out["action"] == "recommend"
+    assert len(llm.calls) == 2   # bad turn, then forced finalize
+
+
+def test_state_from_json_resets_on_garbage():
+    assert wizard.WizardState.from_json("{bad json").turns == []
+    s = wizard.WizardState(turns=[{"prompt": "q", "selected": ["a"], "free_text": ""}], turn_count=1)
+    assert wizard.WizardState.from_json(s.to_json()).turn_count == 1
+```
+
+- [ ] **Step 7: Run the new tests to verify they fail, then pass**
+
+Run: `python3 -m pytest tests/test_wizard.py -v`
+Expected: all PASS (the implementation from Step 4 already covers these). If `test_cap_forces_finalize` fails because `config.WIZARD_MAX_QUESTIONS` is read at module import, confirm `wizard.next_turn` reads `config.WIZARD_MAX_QUESTIONS` at call time (it does) so the monkeypatch takes effect.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add config.py config.yaml recommender/wizard.py tests/test_wizard.py
+git commit -m "feat(wizard): adaptive question-loop engine with capped finalize"
+```
+
+---
+
+### Task 3: Web routes + functional templates
+
+Wires the engine into Flask with HTMX partial swaps. State carried in a hidden field; the slow final recommendation runs through the existing background-job registry like `/recommend`.
+
+**Files:**
+- Modify: `recommender/web.py` (add routes + a wizard job runner; near `_run_recommend_job` line 114 and the `/recommend` routes line 510)
+- Create: `recommender/templates/wizard.html`, `recommender/templates/_wizard_step.html`, `recommender/templates/_wizard_results.html`
+- Modify: `recommender/templates/base.html` (nav link), `recommender/templates/recommend.html` (entry card)
+- Test: `tests/test_web_wizard.py`
+
+**Interfaces:**
+- Consumes: `wizard.WizardState`, `wizard.next_turn`; `query_engine.ask(intent_override=, context_note=)`; `_get_job_context`, `_build_result_items`, `job_registry`, `query_history` (all in `web.py`).
+- Produces routes: `GET /wizard`, `POST /wizard/next`, `GET /wizard/jobs/<job_id>/poll`, `POST /wizard/refine`.
+
+- [ ] **Step 1: Write failing route tests**
+
+Create `tests/test_web_wizard.py` (follow the app/client fixture pattern already used in the web tests — open an existing web test to copy how `app.test_client()` and CSRF are set up):
+
+```python
+import json
+from unittest.mock import patch
+from recommender import web
+from recommender.query_engine import QueryIntent
+
+
+def _client():
+    web.app.config["TESTING"] = True
+    return web.app.test_client()
+
+
+def test_get_wizard_renders_shell():
+    resp = _client().get("/wizard")
+    assert resp.status_code == 200
+    assert b"wizard-stage" in resp.data
+
+
+def test_post_next_ask_branch_renders_question():
+    fake_turn = {"action": "ask", "prompt": "Vibe tonight?", "subtext": "",
+                 "chips": [{"label": "Light", "value": "light"}],
+                 "multi": True, "allow_free_text": True}
+    with patch.object(web.wizard, "next_turn", return_value=fake_turn), \
+         patch.object(web, "_get_job_context"):
+        resp = _client().post("/wizard/next", data={
+            "state": json.dumps({"turns": [], "turn_count": 0}),
+        }, headers={"HX-Request": "true"})
+    assert resp.status_code == 200
+    assert b"Vibe tonight?" in resp.data
+    assert b"light" in resp.data
+
+
+def test_post_next_recommend_branch_starts_job():
+    intent = QueryIntent(
+        genres=[], origin_countries=[], languages=[], mood_descriptors=[],
+        similar_to=[], max_runtime_minutes=None, year_from=None, year_to=None,
+        unwatched_only=True, special_intent=None, content_type="both",
+        top_n=5, platforms=[])
+    fake_turn = {"action": "recommend", "summary": "light and short",
+                 "intent": intent, "context_note": "low energy"}
+    with patch.object(web.wizard, "next_turn", return_value=fake_turn), \
+         patch.object(web.job_registry, "submit", return_value="job-123") as sub:
+        resp = _client().post("/wizard/next", data={
+            "state": json.dumps({"turns": [], "turn_count": 1}),
+            "prompt": "Vibe tonight?", "selected": ["light"], "free_text": "",
+        }, headers={"HX-Request": "true"})
+    assert resp.status_code == 200
+    assert b"job-123" in resp.data   # polling partial carries the job id
+    sub.assert_called_once()
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `python3 -m pytest tests/test_web_wizard.py -v`
+Expected: FAIL — 404s / `AttributeError: module 'recommender.web' has no attribute 'wizard'`.
+
+- [ ] **Step 3: Add the wizard import, job runner, and routes to `web.py`**
+
+Add to the imports near the top of `recommender/web.py` (where `query_engine`/`ask` are imported):
+
+```python
+from recommender import wizard
+```
+
+Add a job runner next to `_run_recommend_job` (after line 122):
+
+```python
+def _run_wizard_recommend_job(intent_dict: dict, context_note: str, summary: str) -> dict:
+    from recommender.query_engine import QueryIntent
+    ctx = _get_job_context()
+    intent = QueryIntent(**intent_dict)
+    results = ask("", ctx, intent_override=intent, context_note=context_note)
+    items = _build_result_items(results, ctx)
+    label = f"concierge: {summary}"
+    try:
+        query_history.record(label, items, ctx.llm.provider, ctx.llm.usage.summary())
+    except OSError as exc:
+        log.warning("Failed to persist wizard history: %s", exc)
+    return {"items": items, "query": summary, "summary": summary}
+```
+
+Add the routes near the `/recommend` routes (after line 559):
+
+```python
+@app.route("/wizard")
+def wizard_page() -> str:
+    return render_template("wizard.html")
+
+
+def _collect_answers(form) -> tuple[wizard.WizardState, dict | None]:
+    """Load state from the form and append the just-answered question, if any."""
+    state = wizard.WizardState.from_json(form.get("state", ""))
+    prompt = (form.get("prompt") or "").strip()
+    if prompt:
+        state.turns.append({
+            "prompt": prompt,
+            "selected": form.getlist("selected"),
+            "free_text": (form.get("free_text") or "").strip(),
+        })
+        state.turn_count += 1
+    return state, None
+
+
+@app.route("/wizard/next", methods=["POST"])
+def wizard_next() -> str:
+    state, _ = _collect_answers(request.form)
+    force_finish = request.form.get("finish") == "1"
+    ctx = _get_job_context()
+    try:
+        turn = wizard.next_turn(state, ctx, force_finish=force_finish)
+    except Exception as exc:   # network / provider failure
+        log.exception("Wizard turn failed")
+        return render_template("_wizard_step.html", error=str(exc),
+                               state_json=state.to_json())
+
+    if turn["action"] == "recommend":
+        from dataclasses import asdict
+        intent_dict = asdict(turn["intent"])
+        job_id = job_registry.submit(
+            _run_wizard_recommend_job, intent_dict, turn["context_note"],
+            turn["summary"], label="wizard")
+        return render_template("_polling.html", job_id=job_id,
+                               poll_url=f"/wizard/jobs/{job_id}/poll")
+
+    return render_template("_wizard_step.html", turn=turn,
+                           state_json=state.to_json(),
+                           question_number=state.turn_count + 1,
+                           max_questions=config.WIZARD_MAX_QUESTIONS)
+
+
+@app.route("/wizard/jobs/<job_id>/poll")
+def wizard_poll(job_id: str) -> str:
+    job = job_registry.get(job_id)
+    if job is None:
+        return render_template("_wizard_results.html", results=None,
+                               error="Session expired. Start again.")
+    if job.status in ("pending", "running"):
+        return render_template("_polling.html", job_id=job_id,
+                               poll_url=f"/wizard/jobs/{job_id}/poll",
+                               elapsed=job.elapsed_seconds)
+    if job.status == "error":
+        return render_template("_wizard_results.html", results=None, error=job.error)
+    result = job.result
+    return render_template("_wizard_results.html", results=result["items"],
+                           summary=result["summary"], error=None)
+
+
+@app.route("/wizard/refine", methods=["POST"])
+def wizard_refine() -> str:
+    from dataclasses import asdict
+    from recommender.query_engine import QueryIntent
+    intent_dict = json.loads(request.form.get("intent", "{}"))
+    base_note = request.form.get("context_note", "")
+    directive = request.form.get("directive", "")     # e.g. "make it lighter"
+    shown = request.form.get("shown", "")             # comma-joined titles
+    note = base_note
+    if directive:
+        note = f"{note}\nRefinement: {directive}."
+    if shown:
+        note = f"{note}\nAlready shown, avoid repeating: {shown}."
+    summary = request.form.get("summary", "your picks")
+    job_id = job_registry.submit(
+        _run_wizard_recommend_job, intent_dict, note, summary, label="wizard")
+    return render_template("_polling.html", job_id=job_id,
+                           poll_url=f"/wizard/jobs/{job_id}/poll")
+```
+
+Note: `_polling.html` currently hardcodes its poll URL. Open `recommender/templates/_polling.html` and make the poll target use an optional `poll_url` with the existing default, e.g. change the polling element's `hx-get` to `{{ poll_url or '/jobs/' ~ job_id ~ '/poll' }}` so both the recommend and wizard flows can share it.
+
+- [ ] **Step 4: Create the functional templates**
+
+`recommender/templates/wizard.html`:
+
+```html
+{% extends "base.html" %}
+{% block title %}Streamline — Concierge{% endblock %}
+{% block content %}
+<div style="margin-bottom:1.5rem;">
+  <span class="mono" style="font-size:0.62rem; letter-spacing:0.12em; text-transform:uppercase; color:var(--accent);">Guided Pick</span>
+  <h1 style="font-size:clamp(2rem,4.5vw,3rem); margin-top:0.2rem;">Concierge</h1>
+  <p style="color:var(--body);">A few quick questions and I'll find something for tonight.</p>
+</div>
+
+<div id="wizard-stage"
+     hx-post="/wizard/next" hx-trigger="load" hx-target="#wizard-stage" hx-swap="innerHTML">
+  <input type="hidden" name="state" value="">
+  <div class="mono" style="font-size:0.65rem; color:var(--muted);">reading the room...</div>
+</div>
+{% endblock %}
+```
+
+`recommender/templates/_wizard_step.html`:
+
+```html
+{% if error %}
+<div style="padding:1rem 1.25rem; background:rgba(232,93,74,0.08); border:1px solid rgba(232,93,74,0.2); border-radius:6px; color:#e88;">
+  {{ error }}
+  <form hx-post="/wizard/next" hx-target="#wizard-stage" hx-swap="innerHTML" style="margin-top:0.75rem;">
+    <input type="hidden" name="state" value="{{ state_json }}">
+    <button type="submit" class="btn-ghost" style="padding:6px 12px;">Try again</button>
+  </form>
+  <a href="/recommend" class="mono result-link">use classic search instead</a>
+</div>
+{% else %}
+<form hx-post="/wizard/next" hx-target="#wizard-stage" hx-swap="innerHTML">
+  <input type="hidden" name="state" value="{{ state_json }}">
+  <input type="hidden" name="prompt" value="{{ turn.prompt }}">
+
+  <div class="mono" style="font-size:0.6rem; letter-spacing:0.1em; text-transform:uppercase; color:var(--muted); margin-bottom:0.4rem;">
+    Question {{ question_number }}{% if max_questions %} of up to {{ max_questions }}{% endif %}
+  </div>
+  <h2 style="font-size:1.5rem; margin-bottom:0.3rem;">{{ turn.prompt }}</h2>
+  {% if turn.subtext %}<p style="color:var(--body); margin-bottom:1rem;">{{ turn.subtext }}</p>{% endif %}
+
+  <div class="wiz-chips" style="display:flex; flex-wrap:wrap; gap:0.5rem; margin-bottom:1rem;">
+    {% for chip in turn.chips %}
+    <label class="wiz-chip">
+      <input type="{{ 'checkbox' if turn.multi else 'radio' }}" name="selected" value="{{ chip.value }}" hidden>
+      <span>{{ chip.label }}</span>
+    </label>
+    {% endfor %}
+  </div>
+
+  {% if turn.allow_free_text %}
+  <input type="text" name="free_text" class="input-field" placeholder="or tell me in your own words..."
+         style="padding:0.7rem 1rem; width:100%; margin-bottom:1rem;">
+  {% endif %}
+
+  <div style="display:flex; align-items:center; gap:1rem;">
+    <button type="submit" class="btn-primary" style="padding:0.7rem 1.4rem;">Continue</button>
+    <button type="submit" name="finish" value="1" class="btn-ghost" style="padding:0.7rem 1.2rem;">Show me something now</button>
+  </div>
+</form>
+{% endif %}
+```
+
+`recommender/templates/_wizard_results.html`:
+
+```html
+{% if error %}
+<div style="padding:1rem 1.25rem; background:rgba(232,93,74,0.08); border:1px solid rgba(232,93,74,0.2); border-radius:6px; color:#e88;">
+  {{ error }}
+</div>
+{% elif results %}
+<p style="font-family:'DM Serif Display',serif; font-size:1.3rem; color:var(--text); margin-bottom:1rem;">
+  Because you wanted {{ summary }} —
+</p>
+{% include "_results.html" with context %}
+<div style="display:flex; flex-wrap:wrap; gap:0.5rem; margin-top:1.25rem;">
+  <span class="mono" style="font-size:0.6rem; color:var(--muted); align-self:center;">Not quite?</span>
+  {% for d in ["lighter", "shorter", "more obscure", "surprise me"] %}
+  <button class="btn-ghost" style="padding:4px 10px;"
+          hx-post="/wizard/refine" hx-target="#wizard-stage" hx-swap="innerHTML"
+          hx-vals='{"directive": "{{ d }}", "summary": "{{ summary }}"}'>{{ d }}</button>
+  {% endfor %}
+  <a href="/wizard" class="mono result-link" style="align-self:center;">start over</a>
+</div>
+{% else %}
+<div style="padding:2rem; text-align:center;">
+  <p class="mono" style="font-size:0.7rem; text-transform:uppercase; color:var(--muted);">Nothing matched on your platforms.</p>
+  <a href="/wizard" class="btn-ghost" style="display:inline-block; margin-top:0.75rem; padding:6px 14px;">Try again</a>
+</div>
+{% endif %}
+```
+
+Note: `_results.html` reads `csrf_token` and `query`; both are provided by the existing `_inject_csrf` context processor and (for `query`) the `summary` passed here is unrelated — `_results.html` uses `query` only in its header/empty branches, which the wizard wrapper supersedes. Passing `results` is sufficient; if a template error surfaces about `query`, pass `query=summary` to the `_wizard_results.html` render calls in `web.py`.
+
+- [ ] **Step 5: Add entry points**
+
+In `recommender/templates/base.html`, add a nav link inside the main `.nav-group` (after the `Home` link, line ~377):
+
+```html
+      <a href="/wizard" class="nav-link {% if request.path == '/wizard' %}active{% endif %}">Concierge</a>
+```
+
+In `recommender/templates/recommend.html`, add an entry card just below the search form block (after line 31, before the `{% if error %}`):
+
+```html
+  <a href="/wizard" style="display:block; margin-top:1rem; padding:0.85rem 1.1rem; background:var(--surface); border:1px solid var(--border); border-radius:6px; text-decoration:none; transition:border-color 0.2s;"
+     onmouseover="this.style.borderColor='var(--accent)'" onmouseout="this.style.borderColor='var(--border)'">
+    <span style="color:var(--body);">Not sure what to watch?</span>
+    <span style="color:var(--accent); font-family:'JetBrains Mono',monospace; font-size:0.72rem; text-transform:uppercase; letter-spacing:0.06em;"> Let me ask a few quick questions -></span>
+  </a>
+```
+
+- [ ] **Step 6: Run the route tests, then the full suite**
+
+Run: `python3 -m pytest tests/test_web_wizard.py -v`
+Expected: PASS.
+Then: `python3 -m pytest`
+Expected: PASS (no regressions). If `_polling.html` changes broke a recommend test, fix the template so the default `poll_url` still resolves to `/jobs/<id>/poll`.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add recommender/web.py recommender/templates/ tests/test_web_wizard.py
+git commit -m "feat(web): concierge wizard routes, templates, and entry points"
+```
+
+---
+
+### Task 4: Client-side visual design (frontend-design)
+
+Polishes the functional templates into the dark-editorial concierge experience: selectable chips, a progress bar, staggered reveals, and a composing state. CSS lives in `base.html` so it is shared.
+
+**Files:**
+- Modify: `recommender/templates/base.html` (add wizard CSS to the `<style>` block)
+- Modify: `recommender/templates/_wizard_step.html` (progress bar, chip-select JS), `recommender/templates/wizard.html` (composing state)
+- Test: `tests/test_web_wizard.py` (assert visual markers render)
+
+**Interfaces:**
+- Consumes: question fields from Task 3 (`turn`, `question_number`, `max_questions`).
+- Produces: no new Python interfaces; CSS classes `.wiz-chip`, `.wiz-chip.selected`, `.wiz-progress`.
+
+- [ ] **Step 1: Write a failing test for the progress bar markup**
+
+Add to `tests/test_web_wizard.py`:
+
+```python
+def test_question_renders_progress_segments():
+    from unittest.mock import patch
+    import json
+    fake_turn = {"action": "ask", "prompt": "Q?", "subtext": "",
+                 "chips": [{"label": "A", "value": "a"}], "multi": False,
+                 "allow_free_text": False}
+    with patch.object(web.wizard, "next_turn", return_value=fake_turn), \
+         patch.object(web, "_get_job_context"):
+        resp = _client().post("/wizard/next", data={
+            "state": json.dumps({"turns": [], "turn_count": 0})},
+            headers={"HX-Request": "true"})
+    assert b"wiz-progress" in resp.data
+```
+
+- [ ] **Step 2: Run it to verify it fails**
+
+Run: `python3 -m pytest tests/test_web_wizard.py::test_question_renders_progress_segments -v`
+Expected: FAIL — `wiz-progress` not in output.
+
+- [ ] **Step 3: Add wizard CSS to `base.html`**
+
+Inside the `<style>` block in `recommender/templates/base.html` (before the closing `</style>` at line 366), add:
+
+```css
+    /* Concierge wizard */
+    .wiz-progress { display:flex; gap:5px; margin-bottom:1rem; }
+    .wiz-progress span { height:3px; flex:1; border-radius:2px; background:var(--border); }
+    .wiz-progress span.filled { background:var(--accent); }
+
+    .wiz-chip {
+      display:inline-flex; align-items:center; gap:0.4rem; cursor:pointer;
+      padding:0.5rem 0.95rem; border:1px solid var(--border); border-radius:999px;
+      color:var(--body); font-size:0.9rem; user-select:none;
+      transition:border-color 0.15s, background 0.15s, transform 0.1s;
+      animation: slideUp 0.3s ease both;
+    }
+    .wiz-chip:hover { border-color:var(--muted); }
+    .wiz-chip.selected {
+      border-color:var(--accent); background:rgba(232,93,74,0.12); color:var(--text);
+      transform:translateY(-1px);
+    }
+    .wiz-chip.selected::before { content:"\2713"; color:var(--accent); font-size:0.8rem; }
+    .wiz-chips .wiz-chip:nth-child(1){animation-delay:.02s}
+    .wiz-chips .wiz-chip:nth-child(2){animation-delay:.06s}
+    .wiz-chips .wiz-chip:nth-child(3){animation-delay:.10s}
+    .wiz-chips .wiz-chip:nth-child(4){animation-delay:.14s}
+    .wiz-chips .wiz-chip:nth-child(5){animation-delay:.18s}
+```
+
+- [ ] **Step 4: Add the progress bar and chip-select JS to `_wizard_step.html`**
+
+In `recommender/templates/_wizard_step.html`, immediately after the opening `<form ...>` of the non-error branch, add the progress bar:
+
+```html
+  <div class="wiz-progress" aria-hidden="true">
+    {% for i in range(max_questions or 4) %}
+    <span class="{{ 'filled' if i < question_number else '' }}"></span>
+    {% endfor %}
+  </div>
+```
+
+At the end of the file (after the closing `</form>`), add the toggle script (the hidden inputs drive the form; clicking toggles the `selected` class and the input's `checked`):
+
+```html
+<script>
+(function(){
+  document.querySelectorAll('#wizard-stage .wiz-chip').forEach(function(chip){
+    var input = chip.querySelector('input');
+    function sync(){
+      if (input.type === 'radio') {
+        document.querySelectorAll('#wizard-stage .wiz-chip').forEach(function(c){
+          c.classList.toggle('selected', c.querySelector('input').checked);
+        });
+      } else {
+        chip.classList.toggle('selected', input.checked);
+      }
+      chip.setAttribute('aria-pressed', input.checked);
+    }
+    chip.addEventListener('click', function(e){
+      if (e.target.tagName !== 'INPUT'){ input.checked = !input.checked; }
+      sync();
+    });
+  });
+})();
+</script>
+```
+
+- [ ] **Step 5: Improve the composing state in `wizard.html`**
+
+Replace the placeholder `reading the room...` div in `recommender/templates/wizard.html` with a spinner matching `recommend.html`:
+
+```html
+  <div style="display:flex; align-items:center; gap:0.6rem;">
+    <div style="width:14px; height:14px; border:2px solid var(--border); border-top-color:var(--accent); border-radius:50%; animation:spin 0.6s linear infinite;"></div>
+    <span class="mono" style="font-size:0.65rem; letter-spacing:0.1em; text-transform:uppercase; color:var(--muted);">reading the room...</span>
+  </div>
+```
+
+- [ ] **Step 6: Run the visual-marker test and full suite**
+
+Run: `python3 -m pytest tests/test_web_wizard.py -v && python3 -m pytest`
+Expected: PASS.
+
+- [ ] **Step 7: Manual verification**
+
+Start the app and click through the wizard end to end:
+
+```bash
+./recommend-web restart
+```
+
+Open http://localhost:5051/wizard. Confirm: first question loads, chips toggle (single vs multi), progress fills, "Show me something now" finishes early, results render with the recap and refine bar, and a refine chip re-runs in place. Stop when satisfied: `./recommend-web stop`.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add recommender/templates/ tests/test_web_wizard.py
+git commit -m "feat(web): concierge wizard visual design — chips, progress, motion"
+```
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+- Web-only adaptive wizard, taste profile as prior, cap 3-4 with early exit, multi-select chips + free text — Tasks 2 (engine prompt, cap, `finish`), 3 (routes, `finish=1`), 4 (chips UI). Covered.
+- Refine in place — Task 3 `/wizard/refine` + Task 4 refine bar. Covered. (Implemented via `intent_override` + `context_note` carrying the directive and "avoid shown" list, rather than `ConversationContext`; this stays within the Task 1 surface and still excludes shown titles. Deviation from the spec's suggested mechanism, noted intentionally.)
+- Soft signals as ranking nudge, no new `QueryIntent` fields — Task 1 `context_note`. Covered.
+- Stateless server, client-carried JSON state — Task 2 `WizardState.from_json/to_json`, Task 3 hidden `state` field. Covered.
+- Error handling (malformed JSON, LLM failure, empty results, tampered state, server-side cap) — Task 2 (`from_json` reset, malformed-turn finalize, cap), Task 3 (route try/except, empty-results branch). Covered.
+- Reuse `ask()` pipeline + background job for the slow step — Tasks 1 and 3. Covered.
+- Config `wizard.max_questions` — Task 2. Covered.
+- Tests for engine, `ask` override, routes — Tasks 1-4. Covered.
+
+**Placeholder scan:** No TBD/TODO; every code step shows full code. The two "if a template error surfaces, pass `query=summary`" notes are conditional hardening instructions with the exact fix given, not placeholders.
+
+**Type consistency:** `WizardState(turns, turn_count)`, `next_turn(state, ctx, force_finish=False)`, the `ask`/`recommend` dict shapes, `rank_candidates(..., context_note=...)`, and `ask(..., intent_override=, context_note=)` are used identically across tasks. `_run_wizard_recommend_job(intent_dict, context_note, summary)` matches its `job_registry.submit` call sites in `/wizard/next` and `/wizard/refine`.

--- a/docs/superpowers/specs/2026-06-27-concierge-wizard-design.md
+++ b/docs/superpowers/specs/2026-06-27-concierge-wizard-design.md
@@ -1,0 +1,172 @@
+# Concierge Wizard — Guided Recommendation Mode
+
+**Date:** 2026-06-27
+**Status:** Design approved, pending spec review
+
+## Problem
+
+Streamline today answers "recommend something *like X*" queries well. But there is no path for the
+moment when the user cannot think of anything to watch and wants a *general* recommendation. They do
+not have a seed title or a query in mind — they want the system to ask a few probing questions and
+suggest based on the answers.
+
+This adds a **concierge wizard**: a guided, adaptive Q&A in the web UI that gathers today's viewing
+context, synthesizes a structured intent, and hands off to the existing recommendation pipeline.
+
+## Decisions (captured during brainstorming)
+
+- **Surface:** Web UI only. Matches the "browsing on the couch" moment.
+- **Question style:** Adaptive LLM probing — the next question depends on previous answers.
+- **Taste profile role:** Used as a **prior**. The LLM sees the profile up front and probes only the
+  gaps (today's mood/energy/time/company/novelty), skipping what the profile already implies.
+- **Stopping rule:** Hard cap of 3-4 questions (config-driven), with a "show me something now" early
+  exit after any answer.
+- **Answer input:** LLM-generated **multi-select choice chips** per question, plus an optional
+  free-text box.
+- **Post-results:** **Refine in place** — re-rank/regenerate without restarting the wizard, reusing
+  the existing `ConversationContext` refinement.
+- **Soft signals (runtime/energy/company):** **Ranking nudge only** via a `context_note` injected
+  into the rank step. No new `QueryIntent` fields (YAGNI).
+
+## Architecture
+
+The wizard is a thin new front-end over the existing online pipeline. It produces a structured
+`QueryIntent` plus a human-readable recap, then calls a lightly-refactored `ask()` that skips
+`parse_intent` and reuses everything downstream: TMDB Discover, LLM semantic suggestions,
+content-type-aware watch filter, streaming-availability annotation, and ranking.
+
+**Server stays stateless.** The in-progress Q&A is carried client-side in a hidden form field as
+JSON (HTMX), so it survives page refresh and adds no server-side session memory or lifecycle
+concerns. This fits the single-user homelab product philosophy.
+
+### Data flow
+
+```
+GET  /wizard         -> wizard.html shell; hx-trigger="load" fires the first turn
+POST /wizard/next    -> append current answers to state -> wizard.next_turn(state, ctx)  [1 reason call]
+       |- action "ask"        -> render _wizard_step.html   (next question + chips)
+       |- action "recommend"  -> ask(ctx, intent_override=..., context_note=...) -> _wizard_results.html
+POST /wizard/refine  -> adjust context_note / excludes -> re-run ask() -> swap results
+```
+
+## Components
+
+### 1. Wizard engine — `recommender/wizard.py` (new)
+
+- `WizardState` — JSON-serializable dataclass:
+  - `turns: list[{prompt: str, selected: list[str], free_text: str}]`
+  - `turn_count: int`
+- `next_turn(state: WizardState, ctx: RecommendContext) -> dict` — one `role=reason` LLM call.
+  - **Prompt input:** the taste-profile summary as a prior (reuses
+    `query_engine._profile_for_prompt`), the Q&A so far, `turn_count`, and the cap. Instruction:
+    probe today's context (mood, energy, time available, alone/with others, novelty appetite); skip
+    what the profile already implies; keep chips short and tappable.
+  - **Output:** strict JSON, exactly one of:
+    - `{"action": "ask", "prompt": str, "subtext": str, "chips": [{"label": str, "value": str}], "multi": bool, "allow_free_text": bool}`
+    - `{"action": "recommend", "summary": str, "intent": {<QueryIntent fields>}, "context_note": str}`
+- **Cap enforcement (server-side):** once `turn_count` reaches the cap (default 4, from config), the
+  next call forces finalize regardless of the LLM's chosen action. The "show me now" button posts
+  `finish=1`, triggering immediate finalize. This bounds loops and LLM cost.
+- **Intent mapping:** hard signals (genre, content_type, language, mood) map to existing
+  `QueryIntent` fields. Soft signals with no field today (runtime, energy, company) ride in
+  `context_note`.
+
+### 2. `ask()` integration — `recommender/query_engine.py` (small refactor)
+
+New signature:
+
+```python
+def ask(query, ctx, top_n_override=None, conv_ctx=None,
+        intent_override=None, context_note=None) -> list[Recommendation]:
+```
+
+- If `intent_override` is provided, skip `parse_intent` (currently line 539) and use it directly.
+- If `context_note` is provided, append it to the **rank** prompt so soft signals steer ordering.
+- No behavior change for existing callers (both new params default to `None`).
+
+### 3. Web layer — `recommender/web.py` + templates
+
+- Routes: `GET /wizard`, `POST /wizard/next`, `POST /wizard/refine`. CSRF via the existing
+  `htmx:configRequest` header injection.
+- State carried in a hidden `state` input (JSON); each step's form posts `state` + the current
+  question's answers (selected chip values + free text). HTMX swaps the `#wizard-stage` innerHTML.
+- Templates (new):
+  - `wizard.html` — extends `base.html`; the stage shell + `hx-trigger="load"` for the first turn.
+  - `_wizard_step.html` — one question card (progress, prompt, subtext, chips, free text, actions).
+  - `_wizard_results.html` — recap line + reuse of the existing `result-card` markup + refine bar.
+
+## Client-side design (frontend-design)
+
+Extends the existing **dark editorial** aesthetic (do not introduce a clashing theme):
+`DM Serif Display` headlines, `DM Sans` body, `JetBrains Mono` uppercase micro-labels, coral accent
+`#e85d4a` with amber/teal/lavender, cards on `#1c1922`, staggered `slideUp` reveals.
+
+- **Tone:** a focused "concierge" — calmer and more spacious than the Discover search box, but
+  unmistakably the same product.
+- **Entry points:** a `Concierge` nav link, plus a card on the Discover page —
+  *"Not sure what to watch? Let me ask a few quick questions ->"* (serif prompt, accent arrow,
+  subtle hover lift).
+- **Stage:** centered single column, generous negative space. Mono kicker
+  `GUIDED PICK - QUESTION 02`, a large `DM Serif Display` question, `--body` subtext.
+- **Progress:** a 4-segment mono bar; filled = `--accent`, pending = `--border`. Honest about the
+  "up to 4, maybe fewer" cap.
+- **Chips (multi-select):** pill buttons evolved from `.btn-ghost`. Unselected = bordered/muted;
+  selected = accent-tinted fill + `--accent` border + a check glyph, with `aria-pressed`. Staggered
+  reveal via existing `slideUp` + `animation-delay`. Selection is a tactile micro-interaction
+  (border snap + 1px lift).
+- **Free text:** slim optional `.input-field` below chips — *"or tell me in your own words..."*.
+- **Actions:** `Continue` (`.btn-primary`), `Show me something now` (`.btn-ghost`, early exit), and
+  a quiet `<- back` link.
+- **Between turns:** a "composing" state reusing the spinner with rotating mono microcopy
+  (*"reading the room..."*).
+- Real buttons, keyboard-navigable, CSS-only motion (no JS framework — fits the HTMX stack).
+
+## Results & refinement
+
+- Reuses the existing `result-card` markup.
+- Prepends a serif recap — *"Because you wanted something light, short, and a little offbeat —"*.
+- **Refine bar** of ghost chips: `lighter` - `shorter` - `more obscure` - `surprise me` -
+  `none of these`. Refinement reuses `ConversationContext` to exclude already-shown titles and
+  re-runs in place (no wizard restart).
+- A `tweak this search ->` link drops the synthesized query into the classic search box for power
+  users.
+
+## Error handling
+
+- **Malformed LLM JSON:** retry once; still bad -> graceful finalize with what we have, or fall back
+  to classic search pre-filled with the partial recap (recoverable, per product philosophy).
+- **LLM / network failure:** inline error card with `try again` + `use classic search instead`.
+- **Empty results after finalize:** recap + *"nothing matched on your platforms — loosen the
+  filter?"* refine action (reuses the existing empty-state pattern).
+- **Tampered / unparseable state JSON:** restart the wizard cleanly from turn 0.
+- **Cap** is enforced server-side regardless of LLM output.
+
+## Testing
+
+Follows existing patterns in `tests/test_query_engine.py` and `tests/test_main.py`.
+
+- Engine (`tests/test_wizard.py`, new): `next_turn` with a stub `LLMClient` — ask vs recommend
+  branching, cap forces finalize, malformed-JSON fallback, intent mapping.
+- `ask(intent_override=...)` skips `parse_intent` (LLM not called for parse); `context_note` reaches
+  the rank prompt.
+- Web routes: `GET /wizard`, `POST /wizard/next` (both branches), `/wizard/refine`,
+  malformed-state restart, CSRF enforcement.
+
+## Cost note
+
+Each turn is one `role=reason` call; bounded at the cap (default 4) plus finalize, then the usual
+candidate-gen + rank. Wizard turns are short prompts. Acceptable for single-user use; the cap keeps
+it bounded.
+
+## Out of scope
+
+- CLI wizard front-end (web only for now).
+- New `QueryIntent` hard-filter fields (runtime/energy stay as ranking nudges).
+- Server-side session storage for wizard state (client-carried JSON instead).
+- Persisting wizard sessions to history (a wizard run can still save its synthesized search via the
+  existing search-history path, but no new wizard-specific persistence).
+
+## Config
+
+- `wizard.max_questions` (default 4) — the hard cap. Lives in `config.yaml` under a new `wizard`
+  section, read via `config.py` with a sensible default.

--- a/recommender/query_engine.py
+++ b/recommender/query_engine.py
@@ -232,6 +232,7 @@ def rank_candidates(
     enrichments: dict[str, str],
     client: LLMClient,
     top_n: int = 1,
+    context_note: str | None = None,
 ) -> list[Recommendation]:
     """Rank candidates against taste profile."""
     log.debug("Ranking %d candidates for query: %r (top_n=%d)", len(candidates), query, top_n)
@@ -248,7 +249,9 @@ def rank_candidates(
         f'a candidate must match what the user asked for. The taste profile is secondary, '
         f'used to break ties between candidates that all fit the query.\n\n'
         f'QUERY: "{query}"\n\n'
-        f'TASTE PROFILE:\n{taste_profile}\n\n'
+        + (f'TONIGHT\'S CONTEXT (use to nudge ordering, not as a hard filter):\n{context_note}\n\n'
+           if context_note else '')
+        + f'TASTE PROFILE:\n{taste_profile}\n\n'
         f'CANDIDATES:\n{cands_str}\n\n'
         f'Return ONLY valid JSON: a list of objects with fields:\n'
         f'- title: string (exact title from candidates)\n'
@@ -512,6 +515,8 @@ def ask(
     ctx: RecommendContext,
     top_n_override: int | None = None,
     conv_ctx: "ConversationContext | None" = None,
+    intent_override: "QueryIntent | None" = None,
+    context_note: str | None = None,
 ) -> list[Recommendation]:
     """Answer a natural language recommendation query end-to-end."""
     why_not_title = _extract_why_not_title(query)
@@ -536,7 +541,10 @@ def ask(
                     log.debug("'More like #%d' → using %r as similar_to", idx + 1, picked)
                     query = f"more like {picked}"
 
-        intent = parse_intent(query, ctx.llm, conv_ctx=conv_ctx)
+        if intent_override is not None:
+            intent = intent_override
+        else:
+            intent = parse_intent(query, ctx.llm, conv_ctx=conv_ctx)
         if top_n_override is not None:
             intent.top_n = top_n_override
 
@@ -635,7 +643,8 @@ def ask(
         # Rank with a larger pool when platform filtering is active, so we have
         # enough candidates after discarding titles not on the requested service.
         rank_size = max(intent.top_n * 3, 15) if requested_platforms else intent.top_n
-        results = rank_candidates(query, profile_for_prompt, candidates, enrichments, ctx.llm, rank_size)
+        results = rank_candidates(query, profile_for_prompt, candidates, enrichments,
+                                  ctx.llm, rank_size, context_note=context_note)
 
         annotated = []
         unfiltered = []
@@ -665,7 +674,8 @@ def ask(
             conv_ctx.last_intent = intent
         return annotated
 
-    results = rank_candidates(query, profile_for_prompt, candidates, enrichments, ctx.llm, intent.top_n)
+    results = rank_candidates(query, profile_for_prompt, candidates, enrichments,
+                              ctx.llm, intent.top_n, context_note=context_note)
     if conv_ctx is not None:
         conv_ctx.last_intent = intent
     return results

--- a/recommender/query_engine.py
+++ b/recommender/query_engine.py
@@ -517,8 +517,13 @@ def ask(
     conv_ctx: "ConversationContext | None" = None,
     intent_override: "QueryIntent | None" = None,
     context_note: str | None = None,
+    exclude_titles: set[str] | None = None,
 ) -> list[Recommendation]:
-    """Answer a natural language recommendation query end-to-end."""
+    """Answer a natural language recommendation query end-to-end.
+
+    ``exclude_titles`` are hard-excluded from the candidate pool (exact title
+    match), e.g. titles already shown that a refinement should not repeat.
+    """
     why_not_title = _extract_why_not_title(query)
     if why_not_title:
         return _handle_why_not(why_not_title, ctx)
@@ -547,6 +552,10 @@ def ask(
             intent = parse_intent(query, ctx.llm, conv_ctx=conv_ctx)
         if top_n_override is not None:
             intent.top_n = top_n_override
+
+    # Hard exclusions (e.g. titles already shown that a refine must not repeat).
+    if exclude_titles:
+        extra_excludes = set(extra_excludes) | set(exclude_titles)
 
     if intent.special_intent == 'abandoned':
         return _handle_abandoned(query, intent, ctx)

--- a/recommender/query_engine.py
+++ b/recommender/query_engine.py
@@ -1,5 +1,6 @@
 import json
 import logging
+import math
 import re
 import sys
 from dataclasses import dataclass, field
@@ -637,6 +638,18 @@ def ask(
     if not candidates:
         log.debug("No candidates after all sources, returning empty")
         return []
+
+    # Bound enrichment/ranking cost: enrichment is one serial LLM call per
+    # uncached title, so a broad query can otherwise enrich 100+ titles. Keep the
+    # strongest candidates by rating weighted by vote volume.
+    if len(candidates) > config.MAX_ENRICH_CANDIDATES:
+        candidates.sort(
+            key=lambda c: (c.vote_average or 0) * math.log10((c.vote_count or 0) + 10),
+            reverse=True,
+        )
+        log.debug("Trimming candidate pool %d -> %d before enrichment",
+                  len(candidates), config.MAX_ENRICH_CANDIDATES)
+        candidates = candidates[:config.MAX_ENRICH_CANDIDATES]
 
     log.debug("Enriching %d candidates", len(candidates))
     meta_dict = {c.title: c for c in candidates}

--- a/recommender/templates/_polling.html
+++ b/recommender/templates/_polling.html
@@ -1,6 +1,6 @@
-<div hx-get="/jobs/{{ job_id }}/poll"
+<div hx-get="{{ poll_url or '/jobs/' ~ job_id ~ '/poll' }}"
      hx-trigger="every 2s"
-     hx-target="#results"
+     hx-target="{{ poll_target or '#results' }}"
      hx-swap="innerHTML"
      style="padding:1.5rem 0; display:flex; align-items:center; gap:0.6rem;">
   <div style="width:14px; height:14px; border:2px solid var(--border); border-top-color:var(--accent); border-radius:50%; animation:spin 0.6s linear infinite; flex-shrink:0;"></div>

--- a/recommender/templates/_wizard_results.html
+++ b/recommender/templates/_wizard_results.html
@@ -13,7 +13,7 @@
   <button class="btn-ghost" style="padding:4px 10px;"
           hx-post="/wizard/refine" hx-target="#wizard-stage" hx-swap="innerHTML"
           hx-headers='{"X-CSRF-Token": "{{ csrf_token }}"}'
-          hx-vals='{"directive": "{{ d }}", "summary": "{{ summary }}"}'>{{ d }}</button>
+          hx-vals='{"directive": {{ d | tojson }}, "summary": {{ summary | tojson }}, "intent": {{ intent_json | tojson }}, "context_note": {{ context_note | tojson }}, "shown": {{ shown | tojson }}}'>{{ d }}</button>
   {% endfor %}
   <a href="/wizard" class="mono result-link" style="align-self:center;">start over</a>
 </div>

--- a/recommender/templates/_wizard_results.html
+++ b/recommender/templates/_wizard_results.html
@@ -1,0 +1,25 @@
+{% if error %}
+<div style="padding:1rem 1.25rem; background:rgba(232,93,74,0.08); border:1px solid rgba(232,93,74,0.2); border-radius:6px; color:#e88;">
+  {{ error }}
+</div>
+{% elif results %}
+<p style="font-family:'DM Serif Display',serif; font-size:1.3rem; color:var(--text); margin-bottom:1rem;">
+  Because you wanted {{ summary }} —
+</p>
+{% include "_results.html" with context %}
+<div style="display:flex; flex-wrap:wrap; gap:0.5rem; margin-top:1.25rem;">
+  <span class="mono" style="font-size:0.6rem; color:var(--muted); align-self:center;">Not quite?</span>
+  {% for d in ["lighter", "shorter", "more obscure", "surprise me"] %}
+  <button class="btn-ghost" style="padding:4px 10px;"
+          hx-post="/wizard/refine" hx-target="#wizard-stage" hx-swap="innerHTML"
+          hx-headers='{"X-CSRF-Token": "{{ csrf_token }}"}'
+          hx-vals='{"directive": "{{ d }}", "summary": "{{ summary }}"}'>{{ d }}</button>
+  {% endfor %}
+  <a href="/wizard" class="mono result-link" style="align-self:center;">start over</a>
+</div>
+{% else %}
+<div style="padding:2rem; text-align:center;">
+  <p class="mono" style="font-size:0.7rem; text-transform:uppercase; color:var(--muted);">Nothing matched on your platforms.</p>
+  <a href="/wizard" class="btn-ghost" style="display:inline-block; margin-top:0.75rem; padding:6px 14px;">Try again</a>
+</div>
+{% endif %}

--- a/recommender/templates/_wizard_step.html
+++ b/recommender/templates/_wizard_step.html
@@ -39,10 +39,15 @@
   <h2 style="font-size:1.5rem; margin-bottom:0.3rem;">{{ turn.prompt }}</h2>
   {% if turn.subtext %}<p style="color:var(--body); margin-bottom:1rem;">{{ turn.subtext }}</p>{% endif %}
 
+  {% if turn.chips %}
+  <div class="mono" style="font-size:0.55rem; letter-spacing:0.08em; text-transform:uppercase; color:var(--muted); margin-bottom:0.5rem;">
+    Pick any that fit — choose more than one if you're open to either
+  </div>
+  {% endif %}
   <div class="wiz-chips" style="display:flex; flex-wrap:wrap; gap:0.5rem; margin-bottom:1rem;">
     {% for chip in turn.chips %}
     <label class="wiz-chip">
-      <input type="{{ 'checkbox' if turn.multi else 'radio' }}" name="selected" value="{{ chip.value }}" hidden>
+      <input type="checkbox" name="selected" value="{{ chip.value }}" hidden>
       <span>{{ chip.label }}</span>
     </label>
     {% endfor %}
@@ -80,11 +85,7 @@
     chip.addEventListener('click', function(e){
       // Cancel the label's native toggle so it does not double-toggle with ours.
       e.preventDefault();
-      if (input.type === 'radio') {
-        stage.querySelectorAll('.wiz-chip input').forEach(function(i){ i.checked = (i === input); });
-      } else {
-        input.checked = !input.checked;
-      }
+      input.checked = !input.checked;
       syncAll();
     });
   });

--- a/recommender/templates/_wizard_step.html
+++ b/recommender/templates/_wizard_step.html
@@ -10,6 +10,11 @@
 </div>
 {% else %}
 <form hx-post="/wizard/next" hx-target="#wizard-stage" hx-swap="innerHTML">
+  <div class="wiz-progress" aria-hidden="true">
+    {% for i in range(max_questions or 4) %}
+    <span class="{{ 'filled' if i < question_number else '' }}"></span>
+    {% endfor %}
+  </div>
   <input type="hidden" name="_csrf_token" value="{{ csrf_token }}">
   <input type="hidden" name="state" value="{{ state_json }}">
   <input type="hidden" name="prompt" value="{{ turn.prompt }}">
@@ -39,4 +44,25 @@
     <button type="submit" name="finish" value="1" class="btn-ghost" style="padding:0.7rem 1.2rem;">Show me something now</button>
   </div>
 </form>
+<script>
+(function(){
+  document.querySelectorAll('#wizard-stage .wiz-chip').forEach(function(chip){
+    var input = chip.querySelector('input');
+    function sync(){
+      if (input.type === 'radio') {
+        document.querySelectorAll('#wizard-stage .wiz-chip').forEach(function(c){
+          c.classList.toggle('selected', c.querySelector('input').checked);
+        });
+      } else {
+        chip.classList.toggle('selected', input.checked);
+      }
+      chip.setAttribute('aria-pressed', input.checked);
+    }
+    chip.addEventListener('click', function(e){
+      if (e.target.tagName !== 'INPUT'){ input.checked = !input.checked; }
+      sync();
+    });
+  });
+})();
+</script>
 {% endif %}

--- a/recommender/templates/_wizard_step.html
+++ b/recommender/templates/_wizard_step.html
@@ -9,7 +9,8 @@
   <a href="/recommend" class="mono result-link">use classic search instead</a>
 </div>
 {% else %}
-<form hx-post="/wizard/next" hx-target="#wizard-stage" hx-swap="innerHTML">
+<form hx-post="/wizard/next" hx-target="#wizard-stage" hx-swap="innerHTML"
+      hx-indicator="#wiz-next-spinner" hx-disabled-elt="find button">
   <div class="wiz-progress" aria-hidden="true">
     {% for i in range(max_questions or 4) %}
     <span class="{{ 'filled' if i < question_number else '' }}"></span>
@@ -55,6 +56,10 @@
   <div style="display:flex; align-items:center; gap:1rem;">
     <button type="submit" class="btn-primary" style="padding:0.7rem 1.4rem;">Continue</button>
     <button type="submit" name="finish" value="1" class="btn-ghost" style="padding:0.7rem 1.2rem;">Show me something now</button>
+    <span id="wiz-next-spinner" class="htmx-indicator" style="align-items:center; gap:0.5rem;">
+      <span style="width:13px; height:13px; border:2px solid var(--border); border-top-color:var(--accent); border-radius:50%; display:inline-block; animation:spin 0.6s linear infinite;"></span>
+      <span class="mono" style="font-size:0.62rem; letter-spacing:0.1em; text-transform:uppercase; color:var(--muted);">thinking...</span>
+    </span>
   </div>
 </form>
 <script>

--- a/recommender/templates/_wizard_step.html
+++ b/recommender/templates/_wizard_step.html
@@ -1,0 +1,42 @@
+{% if error %}
+<div style="padding:1rem 1.25rem; background:rgba(232,93,74,0.08); border:1px solid rgba(232,93,74,0.2); border-radius:6px; color:#e88;">
+  {{ error }}
+  <form hx-post="/wizard/next" hx-target="#wizard-stage" hx-swap="innerHTML" style="margin-top:0.75rem;">
+    <input type="hidden" name="_csrf_token" value="{{ csrf_token }}">
+    <input type="hidden" name="state" value="{{ state_json }}">
+    <button type="submit" class="btn-ghost" style="padding:6px 12px;">Try again</button>
+  </form>
+  <a href="/recommend" class="mono result-link">use classic search instead</a>
+</div>
+{% else %}
+<form hx-post="/wizard/next" hx-target="#wizard-stage" hx-swap="innerHTML">
+  <input type="hidden" name="_csrf_token" value="{{ csrf_token }}">
+  <input type="hidden" name="state" value="{{ state_json }}">
+  <input type="hidden" name="prompt" value="{{ turn.prompt }}">
+
+  <div class="mono" style="font-size:0.6rem; letter-spacing:0.1em; text-transform:uppercase; color:var(--muted); margin-bottom:0.4rem;">
+    Question {{ question_number }}{% if max_questions %} of up to {{ max_questions }}{% endif %}
+  </div>
+  <h2 style="font-size:1.5rem; margin-bottom:0.3rem;">{{ turn.prompt }}</h2>
+  {% if turn.subtext %}<p style="color:var(--body); margin-bottom:1rem;">{{ turn.subtext }}</p>{% endif %}
+
+  <div class="wiz-chips" style="display:flex; flex-wrap:wrap; gap:0.5rem; margin-bottom:1rem;">
+    {% for chip in turn.chips %}
+    <label class="wiz-chip">
+      <input type="{{ 'checkbox' if turn.multi else 'radio' }}" name="selected" value="{{ chip.value }}" hidden>
+      <span>{{ chip.label }}</span>
+    </label>
+    {% endfor %}
+  </div>
+
+  {% if turn.allow_free_text %}
+  <input type="text" name="free_text" class="input-field" placeholder="or tell me in your own words..."
+         style="padding:0.7rem 1rem; width:100%; margin-bottom:1rem;">
+  {% endif %}
+
+  <div style="display:flex; align-items:center; gap:1rem;">
+    <button type="submit" class="btn-primary" style="padding:0.7rem 1.4rem;">Continue</button>
+    <button type="submit" name="finish" value="1" class="btn-ghost" style="padding:0.7rem 1.2rem;">Show me something now</button>
+  </div>
+</form>
+{% endif %}

--- a/recommender/templates/_wizard_step.html
+++ b/recommender/templates/_wizard_step.html
@@ -19,6 +19,19 @@
   <input type="hidden" name="state" value="{{ state_json }}">
   <input type="hidden" name="prompt" value="{{ turn.prompt }}">
 
+  {% if answered %}
+  <div style="margin-bottom:1.25rem; padding:0.75rem 1rem; background:var(--surface); border:1px solid var(--border); border-radius:6px;">
+    <div class="mono" style="font-size:0.55rem; letter-spacing:0.1em; text-transform:uppercase; color:var(--muted); margin-bottom:0.5rem;">Your answers so far</div>
+    {% for t in answered %}
+    {% set ans = t.selected | join(', ') %}{% if t.free_text %}{% set ans = ans ~ ('  ·  ' if ans else '') ~ t.free_text %}{% endif %}
+    <div style="font-size:0.82rem; line-height:1.5; margin-bottom:0.25rem;">
+      <span style="color:var(--muted);">{{ t.prompt }}</span>
+      <span style="color:var(--text);"> — {{ ans or 'skipped' }}</span>
+    </div>
+    {% endfor %}
+  </div>
+  {% endif %}
+
   <div class="mono" style="font-size:0.6rem; letter-spacing:0.1em; text-transform:uppercase; color:var(--muted); margin-bottom:0.4rem;">
     Question {{ question_number }}{% if max_questions %} of up to {{ max_questions }}{% endif %}
   </div>
@@ -46,23 +59,31 @@
 </form>
 <script>
 (function(){
-  document.querySelectorAll('#wizard-stage .wiz-chip').forEach(function(chip){
+  var stage = document.getElementById('wizard-stage');
+  if (!stage) return;
+  function syncAll(){
+    stage.querySelectorAll('.wiz-chip').forEach(function(c){
+      var inp = c.querySelector('input');
+      var on = !!(inp && inp.checked);
+      c.classList.toggle('selected', on);
+      c.setAttribute('aria-pressed', on ? 'true' : 'false');
+    });
+  }
+  stage.querySelectorAll('.wiz-chip').forEach(function(chip){
     var input = chip.querySelector('input');
-    function sync(){
-      if (input.type === 'radio') {
-        document.querySelectorAll('#wizard-stage .wiz-chip').forEach(function(c){
-          c.classList.toggle('selected', c.querySelector('input').checked);
-        });
-      } else {
-        chip.classList.toggle('selected', input.checked);
-      }
-      chip.setAttribute('aria-pressed', input.checked);
-    }
+    if (!input) return;
     chip.addEventListener('click', function(e){
-      if (e.target.tagName !== 'INPUT'){ input.checked = !input.checked; }
-      sync();
+      // Cancel the label's native toggle so it does not double-toggle with ours.
+      e.preventDefault();
+      if (input.type === 'radio') {
+        stage.querySelectorAll('.wiz-chip input').forEach(function(i){ i.checked = (i === input); });
+      } else {
+        input.checked = !input.checked;
+      }
+      syncAll();
     });
   });
+  syncAll();
 })();
 </script>
 {% endif %}

--- a/recommender/templates/base.html
+++ b/recommender/templates/base.html
@@ -294,7 +294,7 @@
        (the nav strips below) opt back in explicitly. */
     html, body { overflow-x: hidden; }
 
-    /* Concierge wizard */
+    /* Mood Match wizard */
     .wiz-progress { display:flex; gap:5px; margin-bottom:1rem; }
     .wiz-progress span { height:3px; flex:1; border-radius:2px; background:var(--border); }
     .wiz-progress span.filled { background:var(--accent); }
@@ -399,7 +399,7 @@
     </a>
     <div class="nav-group" style="margin-left:0.5rem;">
       <a href="/" class="nav-link {% if request.path == '/' %}active{% endif %}">Home</a>
-      <a href="/wizard" class="nav-link {% if request.path == '/wizard' %}active{% endif %}">Concierge</a>
+      <a href="/wizard" class="nav-link {% if request.path == '/wizard' %}active{% endif %}">Mood Match</a>
       <a href="/searches" class="nav-link {% if request.path == '/searches' %}active{% endif %}">Searches</a>
       <a href="/watchlist" class="nav-link {% if request.path == '/watchlist' %}active{% endif %}" style="display:flex; align-items:center; gap:0.3rem;">
         Watchlist

--- a/recommender/templates/base.html
+++ b/recommender/templates/base.html
@@ -294,6 +294,30 @@
        (the nav strips below) opt back in explicitly. */
     html, body { overflow-x: hidden; }
 
+    /* Concierge wizard */
+    .wiz-progress { display:flex; gap:5px; margin-bottom:1rem; }
+    .wiz-progress span { height:3px; flex:1; border-radius:2px; background:var(--border); }
+    .wiz-progress span.filled { background:var(--accent); }
+
+    .wiz-chip {
+      display:inline-flex; align-items:center; gap:0.4rem; cursor:pointer;
+      padding:0.5rem 0.95rem; border:1px solid var(--border); border-radius:999px;
+      color:var(--body); font-size:0.9rem; user-select:none;
+      transition:border-color 0.15s, background 0.15s, transform 0.1s;
+      animation: slideUp 0.3s ease both;
+    }
+    .wiz-chip:hover { border-color:var(--muted); }
+    .wiz-chip.selected {
+      border-color:var(--accent); background:rgba(232,93,74,0.12); color:var(--text);
+      transform:translateY(-1px);
+    }
+    .wiz-chip.selected::before { content:"\2713"; color:var(--accent); font-size:0.8rem; }
+    .wiz-chips .wiz-chip:nth-child(1){animation-delay:.02s}
+    .wiz-chips .wiz-chip:nth-child(2){animation-delay:.06s}
+    .wiz-chips .wiz-chip:nth-child(3){animation-delay:.10s}
+    .wiz-chips .wiz-chip:nth-child(4){animation-delay:.14s}
+    .wiz-chips .wiz-chip:nth-child(5){animation-delay:.18s}
+
     /* Mobile masthead: three deliberate rows.
        Row 1: brand alone.
        Row 2: primary nav, horizontally scrollable if needed.

--- a/recommender/templates/base.html
+++ b/recommender/templates/base.html
@@ -375,6 +375,7 @@
     </a>
     <div class="nav-group" style="margin-left:0.5rem;">
       <a href="/" class="nav-link {% if request.path == '/' %}active{% endif %}">Home</a>
+      <a href="/wizard" class="nav-link {% if request.path == '/wizard' %}active{% endif %}">Concierge</a>
       <a href="/searches" class="nav-link {% if request.path == '/searches' %}active{% endif %}">Searches</a>
       <a href="/watchlist" class="nav-link {% if request.path == '/watchlist' %}active{% endif %}" style="display:flex; align-items:center; gap:0.3rem;">
         Watchlist

--- a/recommender/templates/recommend.html
+++ b/recommender/templates/recommend.html
@@ -28,6 +28,12 @@
     <div style="width:14px; height:14px; border:2px solid var(--border); border-top-color:var(--accent); border-radius:50%; animation:spin 0.6s linear infinite;"></div>
     <span class="mono" style="font-size:0.65rem; letter-spacing:0.1em; text-transform:uppercase; color:var(--muted);">Finding matches...</span>
   </div>
+
+  <a href="/wizard" style="display:block; margin-top:1rem; padding:0.85rem 1.1rem; background:var(--surface); border:1px solid var(--border); border-radius:6px; text-decoration:none; transition:border-color 0.2s;"
+     onmouseover="this.style.borderColor='var(--accent)'" onmouseout="this.style.borderColor='var(--border)'">
+    <span style="color:var(--body);">Not sure what to watch?</span>
+    <span style="color:var(--accent); font-family:'JetBrains Mono',monospace; font-size:0.72rem; text-transform:uppercase; letter-spacing:0.06em;"> Let me ask a few quick questions -></span>
+  </a>
 </div>
 
 {% if error %}

--- a/recommender/templates/wizard.html
+++ b/recommender/templates/wizard.html
@@ -10,6 +10,9 @@
 <div id="wizard-stage"
      hx-post="/wizard/next" hx-trigger="load" hx-target="#wizard-stage" hx-swap="innerHTML"
      hx-headers='{"X-CSRF-Token": "{{ csrf_token }}"}'>
-  <div class="mono" style="font-size:0.65rem; color:var(--muted);">reading the room...</div>
+  <div style="display:flex; align-items:center; gap:0.6rem;">
+    <div style="width:14px; height:14px; border:2px solid var(--border); border-top-color:var(--accent); border-radius:50%; animation:spin 0.6s linear infinite;"></div>
+    <span class="mono" style="font-size:0.65rem; letter-spacing:0.1em; text-transform:uppercase; color:var(--muted);">reading the room...</span>
+  </div>
 </div>
 {% endblock %}

--- a/recommender/templates/wizard.html
+++ b/recommender/templates/wizard.html
@@ -1,18 +1,34 @@
 {% extends "base.html" %}
-{% block title %}Streamline — Concierge{% endblock %}
+{% block title %}Streamline — Mood Match{% endblock %}
 {% block content %}
 <div style="margin-bottom:1.5rem;">
   <span class="mono" style="font-size:0.62rem; letter-spacing:0.12em; text-transform:uppercase; color:var(--accent);">Guided Pick</span>
-  <h1 style="font-size:clamp(2rem,4.5vw,3rem); margin-top:0.2rem;">Concierge</h1>
-  <p style="color:var(--body);">A few quick questions and I'll find something for tonight.</p>
+  <h1 style="font-size:clamp(2rem,4.5vw,3rem); margin-top:0.2rem;">Mood Match</h1>
 </div>
 
-<div id="wizard-stage"
-     hx-post="/wizard/next" hx-trigger="load" hx-target="#wizard-stage" hx-swap="innerHTML"
-     hx-headers='{"X-CSRF-Token": "{{ csrf_token }}"}'>
-  <div style="display:flex; align-items:center; gap:0.6rem;">
-    <div style="width:14px; height:14px; border:2px solid var(--border); border-top-color:var(--accent); border-radius:50%; animation:spin 0.6s linear infinite;"></div>
-    <span class="mono" style="font-size:0.65rem; letter-spacing:0.1em; text-transform:uppercase; color:var(--muted);">reading the room...</span>
+<div id="wizard-stage">
+  <div style="padding:1.5rem 1.6rem; background:var(--surface); border:1px solid var(--border); border-radius:8px;">
+    <p style="color:var(--body); margin-bottom:0.75rem;">
+      Can't decide what to watch? Mood Match asks a few quick questions about your
+      mood, energy, and how much time you have tonight, then suggests titles from
+      your streaming services. It uses your taste profile as a starting point, so
+      it already knows the kind of thing you tend to enjoy.
+    </p>
+    <p style="color:var(--muted); font-size:0.85rem; margin-bottom:1.5rem;">
+      Up to {{ max_questions }} short questions. You can stop and see picks at any point.
+    </p>
+    <div style="display:flex; align-items:center; gap:0.8rem;">
+      <button class="btn-primary" style="padding:0.75rem 1.6rem;"
+              hx-post="/wizard/next" hx-target="#wizard-stage" hx-swap="innerHTML"
+              hx-headers='{"X-CSRF-Token": "{{ csrf_token }}"}'
+              hx-indicator="#wiz-start-spinner" hx-disabled-elt="this">
+        Start
+      </button>
+      <span id="wiz-start-spinner" class="htmx-indicator" style="align-items:center; gap:0.5rem;">
+        <span style="width:13px; height:13px; border:2px solid var(--border); border-top-color:var(--accent); border-radius:50%; display:inline-block; animation:spin 0.6s linear infinite;"></span>
+        <span class="mono" style="font-size:0.62rem; letter-spacing:0.1em; text-transform:uppercase; color:var(--muted);">reading the room...</span>
+      </span>
+    </div>
   </div>
 </div>
 {% endblock %}

--- a/recommender/templates/wizard.html
+++ b/recommender/templates/wizard.html
@@ -1,0 +1,15 @@
+{% extends "base.html" %}
+{% block title %}Streamline — Concierge{% endblock %}
+{% block content %}
+<div style="margin-bottom:1.5rem;">
+  <span class="mono" style="font-size:0.62rem; letter-spacing:0.12em; text-transform:uppercase; color:var(--accent);">Guided Pick</span>
+  <h1 style="font-size:clamp(2rem,4.5vw,3rem); margin-top:0.2rem;">Concierge</h1>
+  <p style="color:var(--body);">A few quick questions and I'll find something for tonight.</p>
+</div>
+
+<div id="wizard-stage"
+     hx-post="/wizard/next" hx-trigger="load" hx-target="#wizard-stage" hx-swap="innerHTML"
+     hx-headers='{"X-CSRF-Token": "{{ csrf_token }}"}'>
+  <div class="mono" style="font-size:0.65rem; color:var(--muted);">reading the room...</div>
+</div>
+{% endblock %}

--- a/recommender/web.py
+++ b/recommender/web.py
@@ -134,7 +134,8 @@ def _run_wizard_recommend_job(intent_dict: dict, context_note: str, summary: str
         query_history.record(label, items, ctx.llm.provider, ctx.llm.usage.summary())
     except OSError as exc:
         log.warning("Failed to persist wizard history: %s", exc)
-    return {"items": items, "query": summary, "summary": summary}
+    return {"items": items, "query": summary, "summary": summary,
+            "intent_dict": intent_dict, "context_note": context_note}
 
 
 def _build_result_items(results: list, ctx: RecommendContext) -> list[dict]:
@@ -636,12 +637,14 @@ def wizard_poll(job_id: str) -> str:
     result = job.result
     return render_template("_wizard_results.html", results=result["items"],
                            summary=result["summary"], error=None,
-                           query=result["summary"])
+                           query=result["summary"],
+                           intent_json=json.dumps(result["intent_dict"]),
+                           context_note=result["context_note"],
+                           shown=", ".join(i["title"] for i in result["items"]))
 
 
 @app.route("/wizard/refine", methods=["POST"])
 def wizard_refine() -> str:
-    from dataclasses import asdict
     from recommender.query_engine import QueryIntent
     intent_dict = json.loads(request.form.get("intent", "{}"))
     base_note = request.form.get("context_note", "")

--- a/recommender/web.py
+++ b/recommender/web.py
@@ -29,6 +29,7 @@ from recommender.llm import create_client
 from recommender.log import setup_logging
 from recommender.enricher import enrichment_key_from_parts
 from recommender.query_engine import RecommendContext, ask
+from recommender import wizard
 from recommender.structured_profile import load_structured_profile
 from recommender.tmdb_client import TmdbClient
 
@@ -120,6 +121,20 @@ def _run_recommend_job(query: str) -> dict:
     except OSError as exc:
         log.warning("Failed to persist query history for %r: %s", query, exc)
     return {"items": items, "query": query}
+
+
+def _run_wizard_recommend_job(intent_dict: dict, context_note: str, summary: str) -> dict:
+    from recommender.query_engine import QueryIntent
+    ctx = _get_job_context()
+    intent = QueryIntent(**intent_dict)
+    results = ask("", ctx, intent_override=intent, context_note=context_note)
+    items = _build_result_items(results, ctx)
+    label = f"concierge: {summary}"
+    try:
+        query_history.record(label, items, ctx.llm.provider, ctx.llm.usage.summary())
+    except OSError as exc:
+        log.warning("Failed to persist wizard history: %s", exc)
+    return {"items": items, "query": summary, "summary": summary}
 
 
 def _build_result_items(results: list, ctx: RecommendContext) -> list[dict]:
@@ -556,6 +571,93 @@ def poll_job(job_id: str) -> str:
 
     result = job.result
     return render_template("_results.html", results=result["items"], query=result["query"], error=None)
+
+
+@app.route("/wizard")
+def wizard_page() -> str:
+    return render_template("wizard.html")
+
+
+def _collect_answers(form) -> tuple[wizard.WizardState, dict | None]:
+    """Load state from the form and append the just-answered question, if any."""
+    state = wizard.WizardState.from_json(form.get("state", ""))
+    prompt = (form.get("prompt") or "").strip()
+    if prompt:
+        state.turns.append({
+            "prompt": prompt,
+            "selected": form.getlist("selected"),
+            "free_text": (form.get("free_text") or "").strip(),
+        })
+        state.turn_count += 1
+    return state, None
+
+
+@app.route("/wizard/next", methods=["POST"])
+def wizard_next() -> str:
+    state, _ = _collect_answers(request.form)
+    force_finish = request.form.get("finish") == "1"
+    ctx = _get_job_context()
+    try:
+        turn = wizard.next_turn(state, ctx, force_finish=force_finish)
+    except Exception as exc:   # network / provider failure
+        log.exception("Wizard turn failed")
+        return render_template("_wizard_step.html", error=str(exc),
+                               state_json=state.to_json())
+
+    if turn["action"] == "recommend":
+        from dataclasses import asdict
+        intent_dict = asdict(turn["intent"])
+        job_id = job_registry.submit(
+            _run_wizard_recommend_job, intent_dict, turn["context_note"],
+            turn["summary"], label="wizard")
+        return render_template("_polling.html", job_id=job_id,
+                               poll_url=f"/wizard/jobs/{job_id}/poll",
+                               poll_target="#wizard-stage")
+
+    return render_template("_wizard_step.html", turn=turn,
+                           state_json=state.to_json(),
+                           question_number=state.turn_count + 1,
+                           max_questions=config.WIZARD_MAX_QUESTIONS)
+
+
+@app.route("/wizard/jobs/<job_id>/poll")
+def wizard_poll(job_id: str) -> str:
+    job = job_registry.get(job_id)
+    if job is None:
+        return render_template("_wizard_results.html", results=None,
+                               error="Session expired. Start again.", query="")
+    if job.status in ("pending", "running"):
+        return render_template("_polling.html", job_id=job_id,
+                               poll_url=f"/wizard/jobs/{job_id}/poll",
+                               poll_target="#wizard-stage",
+                               elapsed=job.elapsed_seconds)
+    if job.status == "error":
+        return render_template("_wizard_results.html", results=None, error=job.error, query="")
+    result = job.result
+    return render_template("_wizard_results.html", results=result["items"],
+                           summary=result["summary"], error=None,
+                           query=result["summary"])
+
+
+@app.route("/wizard/refine", methods=["POST"])
+def wizard_refine() -> str:
+    from dataclasses import asdict
+    from recommender.query_engine import QueryIntent
+    intent_dict = json.loads(request.form.get("intent", "{}"))
+    base_note = request.form.get("context_note", "")
+    directive = request.form.get("directive", "")     # e.g. "make it lighter"
+    shown = request.form.get("shown", "")             # comma-joined titles
+    note = base_note
+    if directive:
+        note = f"{note}\nRefinement: {directive}."
+    if shown:
+        note = f"{note}\nAlready shown, avoid repeating: {shown}."
+    summary = request.form.get("summary", "your picks")
+    job_id = job_registry.submit(
+        _run_wizard_recommend_job, intent_dict, note, summary, label="wizard")
+    return render_template("_polling.html", job_id=job_id,
+                           poll_url=f"/wizard/jobs/{job_id}/poll",
+                           poll_target="#wizard-stage")
 
 
 @app.route("/title/<int:tmdb_id>")

--- a/recommender/web.py
+++ b/recommender/web.py
@@ -123,13 +123,17 @@ def _run_recommend_job(query: str) -> dict:
     return {"items": items, "query": query}
 
 
-def _run_wizard_recommend_job(intent_dict: dict, context_note: str, summary: str) -> dict:
+def _run_wizard_recommend_job(intent_dict: dict, context_note: str, summary: str,
+                              exclude: list[str] | None = None) -> dict:
     from recommender.query_engine import QueryIntent
     ctx = _get_job_context()
     intent = QueryIntent(**intent_dict)
-    results = ask("", ctx, intent_override=intent, context_note=context_note)
+    # Use the human-readable recap as the query so semantic suggestions and the
+    # ranker stay tied to the wizard answers rather than an empty string.
+    results = ask(summary, ctx, intent_override=intent, context_note=context_note,
+                  exclude_titles=set(exclude) if exclude else None)
     items = _build_result_items(results, ctx)
-    label = f"concierge: {summary}"
+    label = f"mood match: {summary}"
     try:
         query_history.record(label, items, ctx.llm.provider, ctx.llm.usage.summary())
     except OSError as exc:
@@ -576,7 +580,7 @@ def poll_job(job_id: str) -> str:
 
 @app.route("/wizard")
 def wizard_page() -> str:
-    return render_template("wizard.html")
+    return render_template("wizard.html", max_questions=config.WIZARD_MAX_QUESTIONS)
 
 
 def _collect_answers(form) -> tuple[wizard.WizardState, dict | None]:
@@ -617,6 +621,7 @@ def wizard_next() -> str:
 
     return render_template("_wizard_step.html", turn=turn,
                            state_json=state.to_json(),
+                           answered=state.turns,
                            question_number=state.turn_count + 1,
                            max_questions=config.WIZARD_MAX_QUESTIONS)
 
@@ -645,7 +650,6 @@ def wizard_poll(job_id: str) -> str:
 
 @app.route("/wizard/refine", methods=["POST"])
 def wizard_refine() -> str:
-    from recommender.query_engine import QueryIntent
     intent_dict = json.loads(request.form.get("intent", "{}"))
     base_note = request.form.get("context_note", "")
     directive = request.form.get("directive", "")     # e.g. "make it lighter"
@@ -653,11 +657,11 @@ def wizard_refine() -> str:
     note = base_note
     if directive:
         note = f"{note}\nRefinement: {directive}."
-    if shown:
-        note = f"{note}\nAlready shown, avoid repeating: {shown}."
+    # Hard-exclude the titles already shown so a refine never repeats them.
+    exclude = [t.strip() for t in shown.split(",") if t.strip()]
     summary = request.form.get("summary", "your picks")
     job_id = job_registry.submit(
-        _run_wizard_recommend_job, intent_dict, note, summary, label="wizard")
+        _run_wizard_recommend_job, intent_dict, note, summary, exclude, label="wizard")
     return render_template("_polling.html", job_id=job_id,
                            poll_url=f"/wizard/jobs/{job_id}/poll",
                            poll_target="#wizard-stage")

--- a/recommender/wizard.py
+++ b/recommender/wizard.py
@@ -60,7 +60,7 @@ def _prompt(state: WizardState, profile: str, force_finish: bool) -> str:
         "Ask another only if it would materially change the recommendation; otherwise finish.\n"
     )
     return (
-        "You are a film/TV concierge helping someone who cannot decide what to watch. "
+        "You are a film and TV guide helping someone who cannot decide what to watch. "
         "Use their taste profile as a PRIOR: do not ask what it already implies; probe only "
         "tonight's context (mood, energy, time available, alone or with others, novelty vs comfort).\n\n"
         f"TASTE PROFILE:\n{profile}\n\n"
@@ -69,7 +69,9 @@ def _prompt(state: WizardState, profile: str, force_finish: bool) -> str:
         "Return ONLY valid JSON, exactly one of:\n"
         '1) {"action":"ask","prompt":str,"subtext":str,'
         '"chips":[{"label":str,"value":str}],"multi":bool,"allow_free_text":bool}\n'
-        "   3-5 short, tappable chips. Set multi=true when several answers can co-apply.\n"
+        "   3-5 tappable chips. Chip labels MUST be short, plain, everyday words "
+        "(1-3 words, no jargon or fancy phrasing) — e.g. \"Funny\", \"Tense\", \"Easy watch\", "
+        "\"Under an hour\". Set multi=true when several answers can co-apply.\n"
         '2) {"action":"recommend","summary":str,'
         '"intent":{"genres":[],"origin_countries":[],"languages":[],"mood_descriptors":[],'
         '"similar_to":[],"max_runtime_minutes":null,"year_from":null,"year_to":null,'
@@ -83,7 +85,7 @@ def _prompt(state: WizardState, profile: str, force_finish: bool) -> str:
 def _finalize(state: WizardState, profile: str, llm) -> dict:
     """Force a recommend turn. Used on cap hit or early-exit."""
     raw = llm.generate(_prompt(state, profile, force_finish=True),
-                        role="reason", max_tokens=config.TOKENS_INTENT,
+                        role="reason", max_tokens=config.WIZARD_MAX_TOKENS,
                         timeout=config.TIMEOUT_REASON)
     try:
         data = _parse_json_response(raw)
@@ -108,7 +110,7 @@ def next_turn(state: WizardState, ctx, force_finish: bool = False) -> dict:
         return _finalize(state, profile, ctx.llm)
 
     raw = ctx.llm.generate(_prompt(state, profile, force_finish=False),
-                           role="reason", max_tokens=config.TOKENS_INTENT,
+                           role="reason", max_tokens=config.WIZARD_MAX_TOKENS,
                            timeout=config.TIMEOUT_REASON)
     try:
         data = _parse_json_response(raw)

--- a/recommender/wizard.py
+++ b/recommender/wizard.py
@@ -1,0 +1,128 @@
+"""Concierge wizard: adaptive guided-recommendation question loop.
+
+One role=reason LLM call per turn. The model sees the taste profile as a prior
+and the answers so far, and returns either the next question or a finish signal
+carrying a synthesized QueryIntent plus a free-text ranking note. The question
+cap is enforced here, independent of what the model returns.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from dataclasses import dataclass, field
+
+import config
+from recommender.query_engine import _parse_json_response, _safe_query_intent
+
+log = logging.getLogger(__name__)
+
+
+@dataclass
+class WizardState:
+    turns: list[dict] = field(default_factory=list)
+    turn_count: int = 0
+
+    @classmethod
+    def from_json(cls, raw: str) -> "WizardState":
+        try:
+            data = json.loads(raw) if raw else {}
+            turns = data.get("turns", [])
+            if not isinstance(turns, list):
+                raise ValueError("turns must be a list")
+            return cls(turns=turns, turn_count=int(data.get("turn_count", len(turns))))
+        except (json.JSONDecodeError, ValueError, TypeError) as exc:
+            log.warning("Resetting wizard state, could not parse: %s", exc)
+            return cls(turns=[], turn_count=0)
+
+    def to_json(self) -> str:
+        return json.dumps({"turns": self.turns, "turn_count": self.turn_count})
+
+
+def _qa_so_far(state: WizardState) -> str:
+    if not state.turns:
+        return "(no answers yet)"
+    lines = []
+    for t in state.turns:
+        picks = ", ".join(t.get("selected", []))
+        free = (t.get("free_text") or "").strip()
+        answer = " / ".join(p for p in (picks, free) if p) or "(skipped)"
+        lines.append(f'Q: {t.get("prompt", "")}\nA: {answer}')
+    return "\n".join(lines)
+
+
+def _prompt(state: WizardState, profile: str, force_finish: bool) -> str:
+    cap = config.WIZARD_MAX_QUESTIONS
+    finish_clause = (
+        "You MUST finish now: return the recommend action. Do not ask another question.\n"
+        if force_finish else
+        f"You may ask at most {cap} questions total ({state.turn_count} asked so far). "
+        "Ask another only if it would materially change the recommendation; otherwise finish.\n"
+    )
+    return (
+        "You are a film/TV concierge helping someone who cannot decide what to watch. "
+        "Use their taste profile as a PRIOR: do not ask what it already implies; probe only "
+        "tonight's context (mood, energy, time available, alone or with others, novelty vs comfort).\n\n"
+        f"TASTE PROFILE:\n{profile}\n\n"
+        f"ANSWERS SO FAR:\n{_qa_so_far(state)}\n\n"
+        f"{finish_clause}"
+        "Return ONLY valid JSON, exactly one of:\n"
+        '1) {"action":"ask","prompt":str,"subtext":str,'
+        '"chips":[{"label":str,"value":str}],"multi":bool,"allow_free_text":bool}\n'
+        "   3-5 short, tappable chips. Set multi=true when several answers can co-apply.\n"
+        '2) {"action":"recommend","summary":str,'
+        '"intent":{"genres":[],"origin_countries":[],"languages":[],"mood_descriptors":[],'
+        '"similar_to":[],"max_runtime_minutes":null,"year_from":null,"year_to":null,'
+        '"unwatched_only":true,"special_intent":null,"content_type":"both","top_n":5,'
+        '"platforms":[]},"context_note":str}\n'
+        '   "summary" is a one-line recap ("something light, short, a little offbeat"). '
+        '"context_note" carries soft signals (runtime/energy/company) for ranking.\n'
+    )
+
+
+def _finalize(state: WizardState, profile: str, llm) -> dict:
+    """Force a recommend turn. Used on cap hit or early-exit."""
+    raw = llm.generate(_prompt(state, profile, force_finish=True),
+                        role="reason", max_tokens=config.TOKENS_INTENT,
+                        timeout=config.TIMEOUT_REASON)
+    data = _parse_json_response(raw)
+    return {
+        "action": "recommend",
+        "summary": data.get("summary", "based on what you told me"),
+        "intent": _safe_query_intent(data.get("intent", {})),
+        "context_note": data.get("context_note", ""),
+    }
+
+
+def next_turn(state: WizardState, ctx, force_finish: bool = False) -> dict:
+    """Produce the next wizard turn: a question, or a finish signal with intent."""
+    profile = ctx.taste_profile or ""
+    cap_hit = state.turn_count >= config.WIZARD_MAX_QUESTIONS
+    if force_finish or cap_hit:
+        return _finalize(state, profile, ctx.llm)
+
+    raw = ctx.llm.generate(_prompt(state, profile, force_finish=False),
+                           role="reason", max_tokens=config.TOKENS_INTENT,
+                           timeout=config.TIMEOUT_REASON)
+    try:
+        data = _parse_json_response(raw)
+    except (json.JSONDecodeError, ValueError, TypeError) as exc:
+        log.warning("Malformed wizard turn, finalizing instead: %s", exc)
+        return _finalize(state, profile, ctx.llm)
+
+    if data.get("action") == "recommend":
+        return {
+            "action": "recommend",
+            "summary": data.get("summary", "based on what you told me"),
+            "intent": _safe_query_intent(data.get("intent", {})),
+            "context_note": data.get("context_note", ""),
+        }
+
+    return {
+        "action": "ask",
+        "prompt": data.get("prompt", "What are you in the mood for?"),
+        "subtext": data.get("subtext", ""),
+        "chips": [c for c in data.get("chips", []) if c.get("value")],
+        "multi": bool(data.get("multi", False)),
+        "allow_free_text": bool(data.get("allow_free_text", True)),
+    }

--- a/recommender/wizard.py
+++ b/recommender/wizard.py
@@ -71,7 +71,9 @@ def _prompt(state: WizardState, profile: str, force_finish: bool) -> str:
         '"chips":[{"label":str,"value":str}],"multi":bool,"allow_free_text":bool}\n'
         "   3-5 tappable chips. Chip labels MUST be short, plain, everyday words "
         "(1-3 words, no jargon or fancy phrasing) — e.g. \"Funny\", \"Tense\", \"Easy watch\", "
-        "\"Under an hour\". Set multi=true when several answers can co-apply.\n"
+        "\"Under an hour\". The user can ALWAYS select more than one chip (every question "
+        "is multi-select), so phrase the question and chips so that picking several is "
+        "natural (it means they are open to any of them). Keep multi=true.\n"
         '2) {"action":"recommend","summary":str,'
         '"intent":{"genres":[],"origin_countries":[],"languages":[],"mood_descriptors":[],'
         '"similar_to":[],"max_runtime_minutes":null,"year_from":null,"year_to":null,'

--- a/recommender/wizard.py
+++ b/recommender/wizard.py
@@ -85,7 +85,13 @@ def _finalize(state: WizardState, profile: str, llm) -> dict:
     raw = llm.generate(_prompt(state, profile, force_finish=True),
                         role="reason", max_tokens=config.TOKENS_INTENT,
                         timeout=config.TIMEOUT_REASON)
-    data = _parse_json_response(raw)
+    try:
+        data = _parse_json_response(raw)
+        if not isinstance(data, dict):
+            data = {}
+    except (json.JSONDecodeError, ValueError, TypeError, AttributeError) as exc:
+        log.warning("Malformed finalize response, using defaults: %s", exc)
+        data = {}
     return {
         "action": "recommend",
         "summary": data.get("summary", "based on what you told me"),
@@ -108,6 +114,10 @@ def next_turn(state: WizardState, ctx, force_finish: bool = False) -> dict:
         data = _parse_json_response(raw)
     except (json.JSONDecodeError, ValueError, TypeError) as exc:
         log.warning("Malformed wizard turn, finalizing instead: %s", exc)
+        return _finalize(state, profile, ctx.llm)
+
+    if not isinstance(data, dict):
+        log.warning("Wizard turn returned non-object JSON, finalizing instead")
         return _finalize(state, profile, ctx.llm)
 
     if data.get("action") == "recommend":

--- a/tests/test_query_engine.py
+++ b/tests/test_query_engine.py
@@ -588,3 +588,53 @@ def test_rank_path_falls_back_to_prose_profile_without_structured_profile():
         ask("crime", ctx)
     prompts = [call.args[0] for call in ctx.llm.generate.call_args_list]
     assert any("FULL PROSE PROFILE" in prompt for prompt in prompts)
+
+
+def test_rank_candidates_includes_context_note_in_prompt():
+    from recommender import query_engine
+
+    captured = {}
+
+    class FakeLLM:
+        provider = "fake"
+        def generate(self, prompt, role="reason", max_tokens=1000, timeout=30.0):
+            captured["prompt"] = prompt
+            return "[]"
+
+    cand = make_meta("Example", tmdb_id=1, content_type="movie")
+    query_engine.rank_candidates(
+        "something", "PROFILE", [cand], {}, FakeLLM(), top_n=1,
+        context_note="Wants something short and low-energy tonight.",
+    )
+    assert "short and low-energy" in captured["prompt"]
+
+
+def test_ask_with_intent_override_skips_parse_intent(monkeypatch):
+    from recommender import query_engine
+    from recommender.query_engine import QueryIntent, RecommendContext
+
+    def boom(*a, **k):
+        raise AssertionError("parse_intent must not be called when intent_override is given")
+    monkeypatch.setattr(query_engine, "parse_intent", boom)
+
+    class FakeTmdb:
+        def search_by_filters(self, **k):
+            return []
+    class FakeLLM:
+        provider = "fake"
+        def generate(self, prompt, role="reason", max_tokens=1000, timeout=30.0):
+            return "[]"   # no LLM suggestions
+
+    ctx = RecommendContext(
+        taste_profile="PROFILE", watch_index=None, tmdb_client=FakeTmdb(),
+        llm=FakeLLM(), cache_dir="", events=[],
+    )
+    intent = QueryIntent(
+        genres=[], origin_countries=[], languages=[], mood_descriptors=[],
+        similar_to=[], max_runtime_minutes=None, year_from=None, year_to=None,
+        unwatched_only=True, special_intent=None, content_type="movie",
+        top_n=3, platforms=[],
+    )
+    results = query_engine.ask("ignored", ctx, intent_override=intent,
+                               context_note="low energy")
+    assert results == []   # no candidates -> empty, but parse_intent never ran

--- a/tests/test_query_engine.py
+++ b/tests/test_query_engine.py
@@ -90,6 +90,47 @@ def make_meta(title, tmdb_id=1, content_type="tv", genres=None, vote_avg=8.0):
     )
 
 
+def test_ask_hard_excludes_titles(monkeypatch):
+    """exclude_titles must drop matching candidates from the pool."""
+    import recommender.query_engine as qe
+
+    def _no_parse(*a, **k):
+        raise AssertionError("parse_intent must not run with intent_override")
+    monkeypatch.setattr(qe, "parse_intent", _no_parse)
+
+    cand = make_meta("Excluded Movie", tmdb_id=1, content_type="movie")
+
+    class FakeIndex:
+        def is_watched(self, c):
+            return False
+
+    class FakeTmdb:
+        def search_by_filters(self, **k):
+            return [cand]
+        def get_metadata(self, title, ct):
+            return None
+
+    class FakeLLM:
+        provider = "fake"
+        def generate(self, *a, **k):
+            return "[]"  # no LLM suggestions
+
+    ctx = qe.RecommendContext(
+        taste_profile="P", watch_index=FakeIndex(), tmdb_client=FakeTmdb(),
+        llm=FakeLLM(), cache_dir="", events=[],
+    )
+    intent = qe.QueryIntent(
+        genres=["drama"], origin_countries=[], languages=[], mood_descriptors=[],
+        similar_to=[], max_runtime_minutes=None, year_from=None, year_to=None,
+        unwatched_only=True, special_intent=None, content_type="movie",
+        top_n=5, platforms=[],
+    )
+    # Excluding the only candidate empties the pool -> early empty return.
+    results = qe.ask("q", ctx, intent_override=intent,
+                     exclude_titles={"Excluded Movie"})
+    assert results == []
+
+
 def test_rank_candidates_returns_recommendations():
     candidates = [make_meta("Broadchurch", tmdb_id=1), make_meta("Hinterland", tmdb_id=2)]
     enrichments = {"tv/1": "Dark coastal crime.", "tv/2": "Welsh noir."}

--- a/tests/test_query_engine.py
+++ b/tests/test_query_engine.py
@@ -131,6 +131,56 @@ def test_ask_hard_excludes_titles(monkeypatch):
     assert results == []
 
 
+def test_ask_caps_candidate_pool_before_enrichment(monkeypatch):
+    """A broad query must not enrich more than MAX_ENRICH_CANDIDATES titles."""
+    import recommender.query_engine as qe
+
+    monkeypatch.setattr(qe.config, "MAX_ENRICH_CANDIDATES", 5)
+
+    def _no_parse(*a, **k):
+        raise AssertionError("parse_intent must not run with intent_override")
+    monkeypatch.setattr(qe, "parse_intent", _no_parse)
+
+    cands = [make_meta(f"M{i}", tmdb_id=i, content_type="movie", vote_avg=8.0)
+             for i in range(1, 21)]
+
+    captured = {}
+
+    def fake_enrich(meta_dict, cache_dir, client):
+        captured["n"] = len(meta_dict)
+        return {}
+    monkeypatch.setattr(qe, "enrich_batch", fake_enrich)
+    monkeypatch.setattr(qe, "rank_candidates", lambda *a, **k: [])
+
+    class FakeIndex:
+        def is_watched(self, c):
+            return False
+
+    class FakeTmdb:
+        def search_by_filters(self, **k):
+            return list(cands)
+        def get_metadata(self, title, ct):
+            return None
+
+    class FakeLLM:
+        provider = "fake"
+        def generate(self, *a, **k):
+            return "[]"
+
+    ctx = qe.RecommendContext(
+        taste_profile="P", watch_index=FakeIndex(), tmdb_client=FakeTmdb(),
+        llm=FakeLLM(), cache_dir="", events=[],
+    )
+    intent = qe.QueryIntent(
+        genres=["drama"], origin_countries=[], languages=[], mood_descriptors=[],
+        similar_to=[], max_runtime_minutes=None, year_from=None, year_to=None,
+        unwatched_only=True, special_intent=None, content_type="movie",
+        top_n=5, platforms=[],
+    )
+    qe.ask("q", ctx, intent_override=intent)
+    assert captured["n"] == 5
+
+
 def test_rank_candidates_returns_recommendations():
     candidates = [make_meta("Broadchurch", tmdb_id=1), make_meta("Hinterland", tmdb_id=2)]
     enrichments = {"tv/1": "Dark coastal crime.", "tv/2": "Welsh noir."}

--- a/tests/test_web_wizard.py
+++ b/tests/test_web_wizard.py
@@ -64,6 +64,20 @@ def test_post_next_recommend_branch_starts_job(client):
     sub.assert_called_once()
 
 
+def test_question_renders_progress_segments(client):
+    from unittest.mock import patch
+    import json
+    fake_turn = {"action": "ask", "prompt": "Q?", "subtext": "",
+                 "chips": [{"label": "A", "value": "a"}], "multi": False,
+                 "allow_free_text": False}
+    with patch.object(web.wizard, "next_turn", return_value=fake_turn), \
+         patch.object(web, "_get_job_context"):
+        resp = client.post("/wizard/next", data=_csrf_form(
+            state=json.dumps({"turns": [], "turn_count": 0})),
+            headers={"HX-Request": "true"})
+    assert b"wiz-progress" in resp.data
+
+
 def test_post_refine_starts_job(client):
     intent_json = json.dumps({
         "genres": [], "origin_countries": [], "languages": [], "mood_descriptors": [],

--- a/tests/test_web_wizard.py
+++ b/tests/test_web_wizard.py
@@ -1,0 +1,64 @@
+"""Tests for the concierge wizard routes."""
+
+import json
+from unittest.mock import patch
+
+import pytest
+
+from recommender import web
+from recommender.query_engine import QueryIntent
+from recommender.web import app
+
+
+@pytest.fixture
+def client():
+    app.config["TESTING"] = True
+    app.config["SECRET_KEY"] = "test-secret"
+    with app.test_client() as c:
+        with c.session_transaction() as sess:
+            sess["csrf_token"] = "test-csrf-token"
+        yield c
+
+
+def _csrf_form(**kwargs):
+    return {"_csrf_token": "test-csrf-token", **kwargs}
+
+
+def test_get_wizard_renders_shell(client):
+    resp = client.get("/wizard")
+    assert resp.status_code == 200
+    assert b"wizard-stage" in resp.data
+
+
+def test_post_next_ask_branch_renders_question(client):
+    fake_turn = {"action": "ask", "prompt": "Vibe tonight?", "subtext": "",
+                 "chips": [{"label": "Light", "value": "light"}],
+                 "multi": True, "allow_free_text": True}
+    with patch.object(web.wizard, "next_turn", return_value=fake_turn), \
+         patch.object(web, "_get_job_context"):
+        resp = client.post("/wizard/next", data=_csrf_form(
+            state=json.dumps({"turns": [], "turn_count": 0}),
+        ), headers={"HX-Request": "true"})
+    assert resp.status_code == 200
+    assert b"Vibe tonight?" in resp.data
+    assert b"light" in resp.data
+
+
+def test_post_next_recommend_branch_starts_job(client):
+    intent = QueryIntent(
+        genres=[], origin_countries=[], languages=[], mood_descriptors=[],
+        similar_to=[], max_runtime_minutes=None, year_from=None, year_to=None,
+        unwatched_only=True, special_intent=None, content_type="both",
+        top_n=5, platforms=[])
+    fake_turn = {"action": "recommend", "summary": "light and short",
+                 "intent": intent, "context_note": "low energy"}
+    with patch.object(web.wizard, "next_turn", return_value=fake_turn), \
+         patch.object(web, "_get_job_context"), \
+         patch.object(web.job_registry, "submit", return_value="job-123") as sub:
+        resp = client.post("/wizard/next", data=_csrf_form(
+            state=json.dumps({"turns": [], "turn_count": 1}),
+            prompt="Vibe tonight?", selected=["light"], free_text="",
+        ), headers={"HX-Request": "true"})
+    assert resp.status_code == 200
+    assert b"job-123" in resp.data   # polling partial carries the job id
+    sub.assert_called_once()

--- a/tests/test_web_wizard.py
+++ b/tests/test_web_wizard.py
@@ -28,6 +28,10 @@ def test_get_wizard_renders_shell(client):
     resp = client.get("/wizard")
     assert resp.status_code == 200
     assert b"wizard-stage" in resp.data
+    # Landing describes the feature and waits for an explicit Start (no auto-fire).
+    assert b"Mood Match" in resp.data
+    assert b"Start" in resp.data
+    assert b'hx-trigger="load"' not in resp.data
 
 
 def test_post_next_ask_branch_renders_question(client):

--- a/tests/test_web_wizard.py
+++ b/tests/test_web_wizard.py
@@ -62,3 +62,23 @@ def test_post_next_recommend_branch_starts_job(client):
     assert resp.status_code == 200
     assert b"job-123" in resp.data   # polling partial carries the job id
     sub.assert_called_once()
+
+
+def test_post_refine_starts_job(client):
+    intent_json = json.dumps({
+        "genres": [], "origin_countries": [], "languages": [], "mood_descriptors": [],
+        "similar_to": [], "max_runtime_minutes": None, "year_from": None, "year_to": None,
+        "unwatched_only": True, "special_intent": None, "content_type": "both",
+        "top_n": 5, "platforms": [],
+    })
+    with patch.object(web.job_registry, "submit", return_value="job-xyz") as sub:
+        resp = client.post("/wizard/refine", data=_csrf_form(
+            intent=intent_json,
+            context_note="low energy",
+            directive="lighter",
+            shown="A, B",
+            summary="light picks",
+        ), headers={"HX-Request": "true"})
+    assert resp.status_code == 200
+    assert b"job-xyz" in resp.data
+    sub.assert_called_once()

--- a/tests/test_wizard.py
+++ b/tests/test_wizard.py
@@ -66,3 +66,21 @@ def test_state_from_json_resets_on_garbage():
     assert wizard.WizardState.from_json("{bad json").turns == []
     s = wizard.WizardState(turns=[{"prompt": "q", "selected": ["a"], "free_text": ""}], turn_count=1)
     assert wizard.WizardState.from_json(s.to_json()).turn_count == 1
+
+
+def test_finalize_handles_array_response():
+    llm = FakeLLM(["[]"])
+    out = wizard.next_turn(WizardState(turns=[], turn_count=0), _ctx(llm), force_finish=True)
+    assert out["action"] == "recommend"
+    assert isinstance(out["intent"], QueryIntent)
+
+
+def test_next_turn_array_response_falls_back_to_finalize():
+    llm = FakeLLM([
+        "[]",
+        json.dumps({"action": "recommend", "summary": "x",
+                    "intent": {"content_type": "both"}, "context_note": ""}),
+    ])
+    out = wizard.next_turn(WizardState(turns=[], turn_count=1), _ctx(llm))
+    assert out["action"] == "recommend"
+    assert len(llm.calls) == 2

--- a/tests/test_wizard.py
+++ b/tests/test_wizard.py
@@ -1,0 +1,68 @@
+import json
+from recommender import wizard
+from recommender.wizard import WizardState
+from recommender.query_engine import RecommendContext, QueryIntent
+
+
+class FakeLLM:
+    def __init__(self, responses):
+        self._responses = list(responses)
+        self.calls = []
+    def generate(self, prompt, role="reason", max_tokens=1000, timeout=30.0):
+        self.calls.append(prompt)
+        return self._responses.pop(0)
+
+
+def _ctx(llm):
+    return RecommendContext(
+        taste_profile="Loves slow-burn British crime drama.",
+        watch_index=None, tmdb_client=None, llm=llm, cache_dir="", events=[],
+    )
+
+
+def test_next_turn_returns_ask_question():
+    llm = FakeLLM([json.dumps({
+        "action": "ask",
+        "prompt": "What's the vibe tonight?",
+        "subtext": "Pick any that fit.",
+        "chips": [{"label": "Light", "value": "light"}, {"label": "Tense", "value": "tense"}],
+        "multi": True,
+        "allow_free_text": True,
+    })])
+    out = wizard.next_turn(WizardState(turns=[], turn_count=0), _ctx(llm))
+    assert out["action"] == "ask"
+    assert out["chips"][0]["value"] == "light"
+    assert out["multi"] is True
+
+
+def test_cap_forces_finalize(monkeypatch):
+    monkeypatch.setattr("config.WIZARD_MAX_QUESTIONS", 2)
+    recommend_json = json.dumps({
+        "action": "recommend", "summary": "light and short",
+        "intent": {"content_type": "movie", "top_n": 5},
+        "context_note": "30 minutes, low energy",
+    })
+    llm = FakeLLM([recommend_json])
+    state = WizardState(turns=[{}, {}], turn_count=2)  # already at cap
+    out = wizard.next_turn(state, _ctx(llm))
+    assert out["action"] == "recommend"
+    assert isinstance(out["intent"], QueryIntent)
+    assert out["intent"].content_type == "movie"
+    assert out["context_note"] == "30 minutes, low energy"
+
+
+def test_malformed_turn_falls_back_to_finalize():
+    recommend_json = json.dumps({
+        "action": "recommend", "summary": "x",
+        "intent": {"content_type": "both"}, "context_note": "",
+    })
+    llm = FakeLLM(["this is not json", recommend_json])
+    out = wizard.next_turn(WizardState(turns=[], turn_count=1), _ctx(llm))
+    assert out["action"] == "recommend"
+    assert len(llm.calls) == 2   # bad turn, then forced finalize
+
+
+def test_state_from_json_resets_on_garbage():
+    assert wizard.WizardState.from_json("{bad json").turns == []
+    s = wizard.WizardState(turns=[{"prompt": "q", "selected": ["a"], "free_text": ""}], turn_count=1)
+    assert wizard.WizardState.from_json(s.to_json()).turn_count == 1


### PR DESCRIPTION
## Summary

Adds a guided **concierge wizard** recommendation mode to the web UI for the "I can't think of anything to watch" moment — no seed title or typed query required. The wizard asks adaptive, LLM-driven questions (using the existing taste profile as a prior to probe only tonight's context: mood, energy, time, company, novelty), then synthesizes a structured `QueryIntent` plus a free-text ranking note and runs the existing recommendation pipeline.

Design spec: `docs/superpowers/specs/2026-06-27-concierge-wizard-design.md`
Implementation plan: `docs/superpowers/plans/2026-06-28-concierge-wizard.md`

## What's included

- **Query pipeline** (`query_engine.ask`/`rank_candidates`): new optional `intent_override` (skip `parse_intent`) and `context_note` (ranking nudge) params; no behavior change for existing callers.
- **Wizard engine** (`recommender/wizard.py`): one `reason` LLM call per turn returning either the next question (multi-select chips + optional free text) or a finish signal carrying a synthesized intent. Question cap enforced server-side (`config.WIZARD_MAX_QUESTIONS`, set to 10). Degrades gracefully on malformed/non-object LLM JSON.
- **Web layer** (`recommender/web.py` + templates): `GET /wizard`, `POST /wizard/next`, `GET /wizard/jobs/<id>/poll`, `POST /wizard/refine`. Stateless server — Q&A state carried client-side as JSON. Slow final recommendation runs through the existing background-job registry. Refine-in-place bar (lighter / shorter / more obscure / surprise me). Entry points: nav link + Discover-page card.
- **Visual design**: selectable chips, progress bar, staggered reveals, composing state — all within the existing dark-editorial aesthetic.

## Key design choices

- Soft signals (runtime/energy/company) are ranking nudges via `context_note`, not new `QueryIntent` fields.
- Server stays stateless (client-carried JSON state); reuses the existing job registry and `_polling.html` (backward-compatible).
- LLM-derived strings reaching the browser are autoescaped; `hx-vals` hardened with `| tojson`; CSRF covered.

## Testing

- New: `tests/test_wizard.py` (engine, cap enforcement, malformed-JSON fallback), `tests/test_web_wizard.py` (routes, refine, progress bar), plus `ask(intent_override=)` coverage in `tests/test_query_engine.py`.
- Full suite: 408 passed. The single failure (`tests/test_signals.py::test_full_completion_scores_high`) is pre-existing on `master` and unrelated to this branch.

## Review

Built via subagent-driven development with a per-task review gate and a final whole-branch review (caught and fixed the refine wiring, an `hx-vals` injection, and a finalize-path malformed-JSON guard).

🤖 Generated with [Claude Code](https://claude.com/claude-code)