### PR TITLE
feat(llm): prompt caching via cacheable system prefix

### DIFF
--- a/recommender/llm.py
+++ b/recommender/llm.py
@@ -38,6 +38,12 @@ def _int_model_setting(models: dict[str, object], key: str, default: int) -> int
     return int(raw)
 
 
+# Prompt-cache pricing multipliers relative to base input price (Anthropic).
+# Cache writes cost 1.25x the base input rate; cache reads cost 0.1x.
+_CACHE_WRITE_MULTIPLIER = 1.25
+_CACHE_READ_MULTIPLIER = 0.10
+
+
 @dataclass
 class UsageStats:
     """Accumulated token usage across multiple LLM calls."""
@@ -45,33 +51,44 @@ class UsageStats:
     input_tokens: int = 0
     output_tokens: int = 0
     thinking_tokens: int = 0
+    cache_read_tokens: int = 0
+    cache_write_tokens: int = 0
     cost_usd: float = 0.0
     total_latency_ms: float = 0.0
     _by_model: dict = field(default_factory=dict)
 
     def record(self, model: str, input_t: int, output_t: int, thinking_t: int = 0,
-               latency_ms: float = 0.0) -> None:
+               latency_ms: float = 0.0, cache_read_t: int = 0,
+               cache_write_t: int = 0) -> None:
         self.calls += 1
         self.input_tokens += input_t
         self.output_tokens += output_t
         self.thinking_tokens += thinking_t
+        self.cache_read_tokens += cache_read_t
+        self.cache_write_tokens += cache_write_t
         self.total_latency_ms += latency_ms
 
         pricing = _PRICING.get(model, {"input": 0, "output": 0, "thinking": 0})
+        input_price = pricing.get("input", 0)
         cost = (
-            input_t * pricing.get("input", 0) / 1_000_000
+            input_t * input_price / 1_000_000
             + output_t * pricing.get("output", 0) / 1_000_000
             + thinking_t * pricing.get("thinking", 0) / 1_000_000
+            + cache_read_t * input_price * _CACHE_READ_MULTIPLIER / 1_000_000
+            + cache_write_t * input_price * _CACHE_WRITE_MULTIPLIER / 1_000_000
         )
         self.cost_usd += cost
 
         if model not in self._by_model:
             self._by_model[model] = {"calls": 0, "input": 0, "output": 0, "thinking": 0,
+                                     "cache_read": 0, "cache_write": 0,
                                      "cost": 0.0, "latency_ms": 0.0}
         self._by_model[model]["calls"] += 1
         self._by_model[model]["input"] += input_t
         self._by_model[model]["output"] += output_t
         self._by_model[model]["thinking"] += thinking_t
+        self._by_model[model]["cache_read"] += cache_read_t
+        self._by_model[model]["cache_write"] += cache_write_t
         self._by_model[model]["cost"] += cost
         self._by_model[model]["latency_ms"] += latency_ms
 
@@ -84,6 +101,9 @@ class UsageStats:
         parts.append(f"{self.input_tokens:,} in / {self.output_tokens:,} out")
         if self.thinking_tokens:
             parts.append(f"{self.thinking_tokens:,} thinking")
+        if self.cache_read_tokens or self.cache_write_tokens:
+            parts.append(f"{self.cache_read_tokens:,} cache read / "
+                         f"{self.cache_write_tokens:,} cache write")
         if self.total_latency_ms:
             parts.append(f"{self.avg_latency_ms():.0f}ms avg latency")
         parts.append(f"~${self.cost_usd:.4f}")
@@ -94,7 +114,10 @@ class UsageStats:
         self.input_tokens = 0
         self.output_tokens = 0
         self.thinking_tokens = 0
+        self.cache_read_tokens = 0
+        self.cache_write_tokens = 0
         self.cost_usd = 0.0
+        self.total_latency_ms = 0.0
         self._by_model.clear()
 
 
@@ -113,11 +136,16 @@ class LLMClient(ABC):
         role: str = "reason",
         max_tokens: int = 1000,
         timeout: float = 30.0,
+        system: str | None = None,
     ) -> str:
         """Send a prompt and return the response text.
 
         Args:
             role: "fast" (enrichment, simple tasks) or "reason" (intent, ranking, profile)
+            system: Stable instruction/context prefix. Pass content that repeats
+                across calls (e.g. the taste profile) here rather than in `prompt`
+                so providers can serve it from a prompt cache. Anthropic caches it
+                explicitly; Gemini and OpenAI cache long prefixes automatically.
         """
 
 
@@ -134,20 +162,33 @@ class AnthropicClient(LLMClient):
         log.debug("Using Anthropic provider (fast=%s, reason=%s)", models.get("fast"), models.get("reason"))
 
     def generate(self, prompt: str, role: str = "reason",
-                 max_tokens: int = 1000, timeout: float = 30.0) -> str:
+                 max_tokens: int = 1000, timeout: float = 30.0,
+                 system: str | None = None) -> str:
         model = self.models.get(role, self.models.get("reason", "claude-sonnet-4-6"))
+        kwargs: dict = {
+            "model": model,
+            "max_tokens": max_tokens,
+            "timeout": timeout,
+            "messages": [{"role": "user", "content": prompt}],
+        }
+        if system:
+            # Mark the stable prefix as cacheable. The prefix must be byte-identical
+            # across calls to hit the cache; below the model's minimum cacheable size
+            # the API silently skips caching (no write premium charged).
+            kwargs["system"] = [{
+                "type": "text",
+                "text": system,
+                "cache_control": {"type": "ephemeral"},
+            }]
         t0 = time.monotonic()
-        message = self._client.messages.create(
-            model=model,
-            max_tokens=max_tokens,
-            timeout=timeout,
-            messages=[{"role": "user", "content": prompt}],
-        )
+        message = self._client.messages.create(**kwargs)
         latency_ms = (time.monotonic() - t0) * 1000
         self.usage.record(
             model=model,
             input_t=message.usage.input_tokens,
             output_t=message.usage.output_tokens,
+            cache_read_t=getattr(message.usage, "cache_read_input_tokens", 0) or 0,
+            cache_write_t=getattr(message.usage, "cache_creation_input_tokens", 0) or 0,
             latency_ms=latency_ms,
         )
         self.was_truncated = message.stop_reason == "max_tokens"
@@ -173,7 +214,8 @@ class GeminiClient(LLMClient):
                  models.get("fast"), models.get("reason"))
 
     def generate(self, prompt: str, role: str = "reason",
-                 max_tokens: int = 1000, timeout: float = 30.0) -> str:
+                 max_tokens: int = 1000, timeout: float = 30.0,
+                 system: str | None = None) -> str:
         from google.genai import types
 
         model = self.models.get(role, self.models.get("reason", "gemini-2.5-flash"))
@@ -182,6 +224,10 @@ class GeminiClient(LLMClient):
         adjusted_tokens = max(max_tokens * 3, 4000)
 
         config_params: dict = {"max_output_tokens": adjusted_tokens}
+        # A stable system instruction lets Gemini serve repeated prefixes from its
+        # implicit context cache.
+        if system:
+            config_params["system_instruction"] = system
         # Enable JSON mode when prompt asks for structured JSON output
         prompt_lower = prompt.lower()
         if any(phrase in prompt_lower for phrase in [
@@ -268,8 +314,16 @@ class OpenAIClient(LLMClient):
         )
 
     def generate(self, prompt: str, role: str = "reason",
-                 max_tokens: int = 1000, timeout: float = 30.0) -> str:
+                 max_tokens: int = 1000, timeout: float = 30.0,
+                 system: str | None = None) -> str:
         model = self.models.get(role, self.models.get("reason", "gpt-4.1-mini"))
+
+        # A stable system message lets OpenAI serve long repeated prefixes from its
+        # automatic prompt cache.
+        messages: list[dict] = []
+        if system:
+            messages.append({"role": "system", "content": system})
+        messages.append({"role": "user", "content": prompt})
 
         # Some OpenAI-compatible thinking models spend output budget on reasoning
         # before the final answer. Scale/floor are configurable because providers
@@ -287,7 +341,7 @@ class OpenAIClient(LLMClient):
                     model=model,
                     max_tokens=adjusted_tokens,
                     timeout=scaled_timeout,
-                    messages=[{"role": "user", "content": prompt}],
+                    messages=messages,
                 )
                 break
             except Exception as exc:

--- a/recommender/query_engine.py
+++ b/recommender/query_engine.py
@@ -245,15 +245,21 @@ def rank_candidates(
     )
     log.debug("Candidate list sent to ranker:\n%s", cands_str)
 
+    # Stable across queries within a session (instructions + taste profile), so it
+    # goes in the cacheable system block. The taste profile can be large; caching it
+    # avoids re-sending it on every query.
+    system = (
+        'You rank streaming candidates for one user. IMPORTANT: the query is the '
+        'primary filter — a candidate must match what the user asked for. The taste '
+        'profile below is secondary, used only to break ties between candidates that '
+        'all fit the query.\n\n'
+        f'TASTE PROFILE:\n{taste_profile}'
+    )
     prompt = (
-        f'Rank these candidates for a user. IMPORTANT: the query is the primary filter — '
-        f'a candidate must match what the user asked for. The taste profile is secondary, '
-        f'used to break ties between candidates that all fit the query.\n\n'
         f'QUERY: "{query}"\n\n'
         + (f'TONIGHT\'S CONTEXT (use to nudge ordering, not as a hard filter):\n{context_note}\n\n'
            if context_note else '')
-        + f'TASTE PROFILE:\n{taste_profile}\n\n'
-        f'CANDIDATES:\n{cands_str}\n\n'
+        + f'CANDIDATES:\n{cands_str}\n\n'
         f'Return ONLY valid JSON: a list of objects with fields:\n'
         f'- title: string (exact title from candidates)\n'
         f'- explanation: string (1-2 sentences why this fits the query and this user)\n'
@@ -265,7 +271,7 @@ def rank_candidates(
     # Scale output tokens based on result count
     rank_tokens = max(config.TOKENS_RANKING, top_n * 200 + 200)
     response_text = client.generate(prompt, role="reason", max_tokens=rank_tokens,
-                                     timeout=config.TIMEOUT_REASON)
+                                     timeout=config.TIMEOUT_REASON, system=system)
 
     log.debug("Raw ranking response: %s", response_text[:500])
     try:

--- a/recommender/wizard.py
+++ b/recommender/wizard.py
@@ -51,21 +51,17 @@ def _qa_so_far(state: WizardState) -> str:
     return "\n".join(lines)
 
 
-def _prompt(state: WizardState, profile: str, force_finish: bool) -> str:
-    cap = config.WIZARD_MAX_QUESTIONS
-    finish_clause = (
-        "You MUST finish now: return the recommend action. Do not ask another question.\n"
-        if force_finish else
-        f"You may ask at most {cap} questions total ({state.turn_count} asked so far). "
-        "Ask another only if it would materially change the recommendation; otherwise finish.\n"
-    )
+def _system(profile: str) -> str:
+    """Stable per-session prefix: role, taste profile, and output contract.
+
+    Identical across every turn of a session, so it is passed as the cacheable
+    `system` block — the taste profile is re-read from cache instead of re-sent.
+    """
     return (
         "You are a film and TV guide helping someone who cannot decide what to watch. "
         "Use their taste profile as a PRIOR: do not ask what it already implies; probe only "
         "tonight's context (mood, energy, time available, alone or with others, novelty vs comfort).\n\n"
         f"TASTE PROFILE:\n{profile}\n\n"
-        f"ANSWERS SO FAR:\n{_qa_so_far(state)}\n\n"
-        f"{finish_clause}"
         "Return ONLY valid JSON, exactly one of:\n"
         '1) {"action":"ask","prompt":str,"subtext":str,'
         '"chips":[{"label":str,"value":str}],"multi":bool,"allow_free_text":bool}\n'
@@ -84,11 +80,27 @@ def _prompt(state: WizardState, profile: str, force_finish: bool) -> str:
     )
 
 
+def _user(state: WizardState, force_finish: bool) -> str:
+    """Volatile per-turn content: answers so far and the finish directive."""
+    cap = config.WIZARD_MAX_QUESTIONS
+    finish_clause = (
+        "You MUST finish now: return the recommend action. Do not ask another question.\n"
+        if force_finish else
+        f"You may ask at most {cap} questions total ({state.turn_count} asked so far). "
+        "Ask another only if it would materially change the recommendation; otherwise finish.\n"
+    )
+    return (
+        f"ANSWERS SO FAR:\n{_qa_so_far(state)}\n\n"
+        f"{finish_clause}"
+        "Decide the next turn."
+    )
+
+
 def _finalize(state: WizardState, profile: str, llm) -> dict:
     """Force a recommend turn. Used on cap hit or early-exit."""
-    raw = llm.generate(_prompt(state, profile, force_finish=True),
+    raw = llm.generate(_user(state, force_finish=True),
                         role="reason", max_tokens=config.WIZARD_MAX_TOKENS,
-                        timeout=config.TIMEOUT_REASON)
+                        timeout=config.TIMEOUT_REASON, system=_system(profile))
     try:
         data = _parse_json_response(raw)
         if not isinstance(data, dict):
@@ -111,9 +123,9 @@ def next_turn(state: WizardState, ctx, force_finish: bool = False) -> dict:
     if force_finish or cap_hit:
         return _finalize(state, profile, ctx.llm)
 
-    raw = ctx.llm.generate(_prompt(state, profile, force_finish=False),
+    raw = ctx.llm.generate(_user(state, force_finish=False),
                            role="reason", max_tokens=config.WIZARD_MAX_TOKENS,
-                           timeout=config.TIMEOUT_REASON)
+                           timeout=config.TIMEOUT_REASON, system=_system(profile))
     try:
         data = _parse_json_response(raw)
     except (json.JSONDecodeError, ValueError, TypeError) as exc:

--- a/tests/test_query_engine.py
+++ b/tests/test_query_engine.py
@@ -639,8 +639,10 @@ def test_rank_path_uses_structured_profile_slice_when_available():
     )
     with patch("recommender.query_engine.enrich_batch", return_value={"tv/77": "British coastal crime."}):
         ask("serious British crime", ctx)
-    prompts = [call.args[0] for call in ctx.llm.generate.call_args_list]
-    combined = "\n\n".join(prompts)
+    calls = ctx.llm.generate.call_args_list
+    texts = ([call.args[0] for call in calls]
+             + [call.kwargs.get("system") or "" for call in calls])
+    combined = "\n\n".join(texts)
     assert "Relevant taste profile slice:" in combined
     assert "British crime" in combined
     assert "Family animation" not in combined
@@ -677,8 +679,10 @@ def test_rank_path_falls_back_to_prose_profile_without_structured_profile():
     )
     with patch("recommender.query_engine.enrich_batch", return_value={"tv/77": "British coastal crime."}):
         ask("crime", ctx)
-    prompts = [call.args[0] for call in ctx.llm.generate.call_args_list]
-    assert any("FULL PROSE PROFILE" in prompt for prompt in prompts)
+    calls = ctx.llm.generate.call_args_list
+    texts = ([call.args[0] for call in calls]
+             + [call.kwargs.get("system") or "" for call in calls])
+    assert any("FULL PROSE PROFILE" in t for t in texts)
 
 
 def test_rank_candidates_includes_context_note_in_prompt():
@@ -688,7 +692,7 @@ def test_rank_candidates_includes_context_note_in_prompt():
 
     class FakeLLM:
         provider = "fake"
-        def generate(self, prompt, role="reason", max_tokens=1000, timeout=30.0):
+        def generate(self, prompt, role="reason", max_tokens=1000, timeout=30.0, system=None):
             captured["prompt"] = prompt
             return "[]"
 
@@ -713,7 +717,7 @@ def test_ask_with_intent_override_skips_parse_intent(monkeypatch):
             return []
     class FakeLLM:
         provider = "fake"
-        def generate(self, prompt, role="reason", max_tokens=1000, timeout=30.0):
+        def generate(self, prompt, role="reason", max_tokens=1000, timeout=30.0, system=None):
             return "[]"   # no LLM suggestions
 
     ctx = RecommendContext(

--- a/tests/test_wizard.py
+++ b/tests/test_wizard.py
@@ -8,7 +8,7 @@ class FakeLLM:
     def __init__(self, responses):
         self._responses = list(responses)
         self.calls = []
-    def generate(self, prompt, role="reason", max_tokens=1000, timeout=30.0):
+    def generate(self, prompt, role="reason", max_tokens=1000, timeout=30.0, system=None):
         self.calls.append(prompt)
         return self._responses.pop(0)
 


### PR DESCRIPTION
## Summary

- Adds an optional `system` parameter to `LLMClient.generate()` across the ABC and all three provider implementations (Anthropic, Gemini, OpenAI).
- Stable, high-reuse content (taste profile, ranking instructions) is passed as `system` so providers can serve it from a prompt cache: Anthropic uses `cache_control: ephemeral`, Gemini maps to `system_instruction`, OpenAI to a leading system message.
- `UsageStats` gains `cache_read_tokens` / `cache_write_tokens` fields with correct Anthropic pricing (write 1.25×, read 0.10× base input rate).
- Applied at the two highest-reuse call sites: `wizard.py` splits per-turn prompt into a cached `_system(profile)` + volatile `_user(state)`; `query_engine.rank_candidates` moves instructions + taste profile into `system` so they cache across queries in a session.

## Context

Found mid-stream on local-only branch `feature/prompt-caching` (1 commit `134de38`, branched from master HEAD `a59a772`). No prior PR existed. Pushed and opened as part of stale-branch reconciliation.

## Test plan

- [ ] Run `python3 -m pytest tests/test_query_engine.py tests/test_wizard.py -v` — both test files updated in this commit
- [ ] Run `./recommend "spy thriller"` and confirm `cache_read_tokens` shows up in debug stats after the second query in a session
- [ ] Confirm Gemini and OpenAI paths still work (no cache_control field leaked to those providers)