### PR TITLE
feat(watchlist): rich cards with cached poster, rating, genres, availability

### DIFF
--- a/recommender/templates/watchlist.html
+++ b/recommender/templates/watchlist.html
@@ -27,7 +27,7 @@
 </div>
 
 {% if items %}
-<div id="wl-list" style="display:flex; flex-direction:column; gap:6px;">
+<div id="wl-list" style="display:flex; flex-direction:column; gap:10px;">
   {% for item in items %}
   <div id="wl-item-{{ loop.index }}"
     class="wl-item"
@@ -35,33 +35,76 @@
     data-title="{{ item.title | lower }}"
     data-saved="{{ item.saved_at or '' }}"
     data-rating="{{ item.vote_average }}"
-    style="display:flex; align-items:center; justify-content:space-between; gap:1rem; padding:0.75rem 1rem; border-radius:6px; background:var(--surface); border:1px solid var(--border);">
-    <div style="display:flex; align-items:baseline; gap:0.5rem; min-width:0;">
-      <span style="font-family:'DM Serif Display',serif; font-size:1.05rem; color:var(--text); white-space:nowrap; overflow:hidden; text-overflow:ellipsis;">{{ item.title }}</span>
-      <span class="badge {{ 'badge-tv' if item.content_type == 'tv' else 'badge-movie' }}" style="flex-shrink:0;">{{ item.content_type }}</span>
+    style="display:flex; gap:1rem; padding:1.25rem; border-radius:6px; background:var(--surface); border:1px solid var(--border); transition:border-color 0.2s;"
+    onmouseover="this.style.borderColor='var(--accent)'"
+    onmouseout="this.style.borderColor='var(--border)'">
+
+    {% if item.poster %}
+    <div style="width:68px; flex-shrink:0; aspect-ratio:2/3; overflow:hidden; border-radius:4px;">
+      <img src="{{ item.poster }}" alt="{{ item.title }}" style="width:100%; height:100%; object-fit:cover;">
     </div>
-    <div style="display:flex; align-items:center; gap:0.4rem; flex-shrink:0;">
-      <form hx-post="/watchlist/watched" hx-target="#wl-item-{{ loop.index }}" hx-swap="outerHTML" style="margin:0; display:inline;">
-        <input type="hidden" name="_csrf_token" value="{{ csrf_token }}">
-        <input type="hidden" name="title" value="{{ item.title }}">
-        <input type="hidden" name="content_type" value="{{ item.content_type }}">
-        {% if item.tmdb_id %}<input type="hidden" name="tmdb_id" value="{{ item.tmdb_id }}">{% endif %}
-        <button type="submit" class="wl-btn wl-btn--watched">Mark as watched</button>
-      </form>
-      <form hx-post="/watchlist/dismiss" hx-target="#wl-item-{{ loop.index }}" hx-swap="outerHTML" style="margin:0; display:inline;">
-        <input type="hidden" name="_csrf_token" value="{{ csrf_token }}">
-        <input type="hidden" name="title" value="{{ item.title }}">
-        <input type="hidden" name="content_type" value="{{ item.content_type }}">
-        {% if item.tmdb_id %}<input type="hidden" name="tmdb_id" value="{{ item.tmdb_id }}">{% endif %}
-        <button type="submit" class="wl-btn wl-btn--dismiss">Won't watch</button>
-      </form>
-      <form hx-post="/watchlist/remove" hx-target="#wl-item-{{ loop.index }}" hx-swap="outerHTML" style="margin:0; display:inline;">
-        <input type="hidden" name="_csrf_token" value="{{ csrf_token }}">
-        <input type="hidden" name="title" value="{{ item.title }}">
-        <input type="hidden" name="content_type" value="{{ item.content_type }}">
-        {% if item.tmdb_id %}<input type="hidden" name="tmdb_id" value="{{ item.tmdb_id }}">{% endif %}
-        <button type="submit" class="wl-btn wl-btn--remove" title="Remove">&times;</button>
-      </form>
+    {% else %}
+    <div style="width:68px; flex-shrink:0; aspect-ratio:2/3; background:var(--surface2); border-radius:4px; display:flex; align-items:center; justify-content:center;">
+      <span style="font-family:'DM Serif Display',serif; font-size:1.5rem; color:var(--border);">{{ item.title[:1] }}</span>
+    </div>
+    {% endif %}
+
+    <div style="flex:1; min-width:0;">
+      <div style="display:flex; align-items:flex-start; justify-content:space-between; gap:0.5rem; margin-bottom:0.35rem;">
+        {% if item.tmdb_url %}
+        <a href="{{ item.tmdb_url }}" target="_blank" rel="noopener" style="text-decoration:none;">
+          <h3 style="font-family:'DM Serif Display',serif; font-size:1.2rem; color:var(--text); line-height:1.25; margin:0; transition:color 0.15s;"
+            onmouseover="this.style.color='var(--accent)'" onmouseout="this.style.color='var(--text)'">{{ item.title }}</h3>
+        </a>
+        {% else %}
+        <h3 style="font-family:'DM Serif Display',serif; font-size:1.2rem; color:var(--text); line-height:1.25; margin:0;">{{ item.title }}</h3>
+        {% endif %}
+        <span class="badge {{ 'badge-tv' if item.content_type == 'tv' else 'badge-movie' }}" style="flex-shrink:0;">{{ item.content_type }}</span>
+      </div>
+
+      <div style="display:flex; align-items:center; gap:0.5rem; margin-bottom:0.5rem;">
+        {% if item.vote_average %}
+        <span class="mono" style="font-size:0.65rem; color:var(--accent2);">★ {{ "%.1f"|format(item.vote_average) }}</span>
+        {% endif %}
+        {% if item.genres %}
+        {% if item.vote_average %}<span style="color:var(--border);">·</span>{% endif %}
+        <span class="mono" style="font-size:0.62rem; color:var(--muted);">{{ item.genres | join("  ·  ") }}</span>
+        {% endif %}
+      </div>
+
+      <div style="display:flex; align-items:center; gap:0.8rem; flex-wrap:wrap; margin-bottom:0.75rem;">
+        {% if item.streaming_providers %}
+        <span class="mono" style="font-size:0.58rem; color:var(--muted);">{{ item.streaming_providers | join("  ·  ") }}</span>
+        {% else %}
+        <span class="mono" style="font-size:0.58rem; color:var(--muted); opacity:0.6;">Not on your services</span>
+        {% endif %}
+        {% if item.tmdb_url %}<a href="{{ item.tmdb_url }}" target="_blank" rel="noopener" class="mono result-link">TMDB</a>{% endif %}
+        {% if item.imdb_url %}<a href="{{ item.imdb_url }}" target="_blank" rel="noopener" class="mono result-link">IMDB</a>{% endif %}
+      </div>
+
+      <div style="display:flex; align-items:center; gap:0.4rem; flex-wrap:wrap;">
+        <form hx-post="/watchlist/watched" hx-target="#wl-item-{{ loop.index }}" hx-swap="outerHTML" style="margin:0; display:inline;">
+          <input type="hidden" name="_csrf_token" value="{{ csrf_token }}">
+          <input type="hidden" name="title" value="{{ item.title }}">
+          <input type="hidden" name="content_type" value="{{ item.content_type }}">
+          {% if item.tmdb_id %}<input type="hidden" name="tmdb_id" value="{{ item.tmdb_id }}">{% endif %}
+          <button type="submit" class="wl-btn wl-btn--watched">Mark as watched</button>
+        </form>
+        <form hx-post="/watchlist/dismiss" hx-target="#wl-item-{{ loop.index }}" hx-swap="outerHTML" style="margin:0; display:inline;">
+          <input type="hidden" name="_csrf_token" value="{{ csrf_token }}">
+          <input type="hidden" name="title" value="{{ item.title }}">
+          <input type="hidden" name="content_type" value="{{ item.content_type }}">
+          {% if item.tmdb_id %}<input type="hidden" name="tmdb_id" value="{{ item.tmdb_id }}">{% endif %}
+          <button type="submit" class="wl-btn wl-btn--dismiss">Won't watch</button>
+        </form>
+        <form hx-post="/watchlist/remove" hx-target="#wl-item-{{ loop.index }}" hx-swap="outerHTML" style="margin:0; display:inline;">
+          <input type="hidden" name="_csrf_token" value="{{ csrf_token }}">
+          <input type="hidden" name="title" value="{{ item.title }}">
+          <input type="hidden" name="content_type" value="{{ item.content_type }}">
+          {% if item.tmdb_id %}<input type="hidden" name="tmdb_id" value="{{ item.tmdb_id }}">{% endif %}
+          <button type="submit" class="wl-btn wl-btn--remove" title="Remove">&times;</button>
+        </form>
+      </div>
     </div>
   </div>
   {% endfor %}

--- a/recommender/web.py
+++ b/recommender/web.py
@@ -987,25 +987,65 @@ def _watchlist_save_fragment(title: str, ct: str, tmdb_id: int | None, target_id
 
 # ── Watchlist routes ──────────────────────────────────────────────────────────
 
+def _decorate_saved_item(item: dict, ctx) -> None:
+    """Attach cached poster, rating, genres, providers, and links to a saved title.
+
+    Cache-first so the page stays instant. A title saved on another machine may
+    have no cached metadata yet; when it has a tmdb_id we fetch and cache its
+    detail JSON once so the card fills in. All network work is best-effort and
+    never breaks the page render.
+    """
+    item.setdefault("vote_average", 0.0)
+    item.setdefault("genres", [])
+    item.setdefault("streaming_providers", [])
+    item.setdefault("poster", None)
+    item.setdefault("tmdb_url", "")
+    item.setdefault("imdb_url", "")
+    tmdb_id = item.get("tmdb_id")
+    ct = item.get("content_type")
+    if not (ctx and tmdb_id and ct):
+        return
+    tmdb = ctx.tmdb_client
+    meta = tmdb.get_cached_by_id(tmdb_id, ct)
+    if meta is None and config.TMDB_API_KEY:
+        # One-time backfill for titles saved elsewhere with no cached metadata.
+        try:
+            data = tmdb._fetch_details(tmdb_id, ct)
+            tmdb._save_cache(ct, tmdb_id, data)
+            meta = tmdb.get_cached_by_id(tmdb_id, ct)
+        except Exception:
+            meta = None
+    if meta is None:
+        return
+    item["vote_average"] = meta.vote_average or 0.0
+    item["genres"] = meta.genres[:3]
+    item["poster"] = _get_poster_url(tmdb_id, ct)
+    tmdb_type = "tv" if ct == "tv" else "movie"
+    item["tmdb_url"] = f"https://www.themoviedb.org/{tmdb_type}/{tmdb_id}"
+    raw = tmdb._load_cache(ct, tmdb_id) or {}
+    imdb_id = raw.get("imdb_id")
+    if imdb_id:
+        item["imdb_url"] = f"https://www.imdb.com/title/{imdb_id}/"
+    else:
+        from urllib.parse import quote
+        item["imdb_url"] = f"https://www.imdb.com/find/?q={quote(item['title'])}"
+    try:
+        item["streaming_providers"] = tmdb.get_watch_providers(
+            tmdb_id, ct, config.WATCH_REGION, config.PROVIDERS_CACHE_DIR)[:4]
+    except Exception:
+        item["streaming_providers"] = []
+
+
 @app.route("/watchlist")
 def watchlist_page() -> str:
     _ensure_user_store_once()
     items = user_store.list_saved_titles(config.EVENT_DB_PATH, status="watchlist")
     try:
         ctx = _get_context()
-        for item in items:
-            vote_average = 0.0
-            if item.get("tmdb_id"):
-                try:
-                    meta = ctx.tmdb_client.get_cached_by_id(item["tmdb_id"], item["content_type"])
-                    if meta:
-                        vote_average = meta.vote_average or 0.0
-                except Exception:
-                    pass
-            item["vote_average"] = vote_average
     except Exception:
-        for item in items:
-            item.setdefault("vote_average", 0.0)
+        ctx = None
+    for item in items:
+        _decorate_saved_item(item, ctx)
     return render_template("watchlist.html", items=items)
 
 

--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -795,6 +795,40 @@ class TestRenderedState:
         assert b"Mark as watched" in resp.data  # action button present
         assert b"Won&#39;t watch" in resp.data or b"Won't watch" in resp.data
 
+    def test_watchlist_page_renders_cached_metadata(self, client, tmp_path, monkeypatch):
+        """A saved title with cached TMDB metadata shows its poster, rating, genres,
+        and streaming availability rather than a bare text row."""
+        from recommender import web
+        from recommender.user_store import init_db, save_title
+        from recommender.tmdb_client import TmdbMetadata
+        from unittest.mock import MagicMock
+
+        db = str(tmp_path / "test.db")
+        init_db(db)
+        save_title(db, "Calibre", "movie", tmdb_id=474051)
+        monkeypatch.setattr("config.EVENT_DB_PATH", db)
+        monkeypatch.setattr("config.FEEDBACK_PATH", str(tmp_path / "feedback.json"))
+        monkeypatch.setattr("config.TMDB_API_KEY", "tmdb")
+
+        meta = TmdbMetadata(tmdb_id=474051, content_type="movie", title="Calibre",
+                            genres=["Thriller", "Drama"], vote_average=6.9)
+        tmdb_client = MagicMock()
+        tmdb_client.get_cached_by_id.return_value = meta
+        tmdb_client._load_cache.return_value = {"imdb_id": "tt6230738"}
+        tmdb_client.get_watch_providers.return_value = ["Netflix"]
+        monkeypatch.setattr(web, "_get_context", lambda: MagicMock(tmdb_client=tmdb_client))
+        monkeypatch.setattr(web, "_get_poster_url",
+                            lambda tid, ct, size="w300": "https://image.tmdb.org/t/p/w300/x.jpg")
+
+        resp = client.get("/watchlist")
+        html = resp.data.decode()
+        assert resp.status_code == 200
+        assert "image.tmdb.org" in html              # poster rendered
+        assert "6.9" in html                          # rating shown
+        assert "Thriller" in html                     # genres shown
+        assert "Netflix" in html                      # streaming availability shown
+        assert "tt6230738" in html                    # direct IMDB link from cached id
+
     def test_archive_rate_shows_thumbs_state(self, client, tmp_path, monkeypatch):
         from recommender.user_store import init_db, rate_title
 


### PR DESCRIPTION
## What

The watchlist page rendered a bare text list even though poster, genre, and streaming-provider data already sat in the TMDB cache for most saved titles. This surfaces that data so the watchlist matches the search-results / archive card language.

## Changes

- `_decorate_saved_item()` attaches **poster, rating (★), genres, streaming availability**, and TMDB/IMDB links to each saved title from cache — no LLM calls.
- One-time `_fetch_details` + cache backfill for titles saved on another machine with no cached metadata (e.g. items synced from the server). Fully guarded: a missing API key, context, or network error degrades to the old plain row instead of erroring.
- `watchlist.html`: flat row → horizontal card (poster, title/badge, rating + genres, providers + links, actions). Keeps the `data-*` attributes so the existing filter/sort JS keeps working; adds a poster placeholder and a "Not on your services" fallback.
- New test `test_watchlist_page_renders_cached_metadata`.

## Validation

- `pytest tests/` → 474 passed (the lone `test_signals` failure is a pre-existing, unrelated time-of-day flake).
- Verified live locally: 15/15 saved titles render posters (2 server-synced titles backfilled and persisted to cache on first load), with ratings, genres, and provider availability shown.