### PR TITLE
feat(archive,search): source filter, recent sort, rating filter, provider consolidation (#37, #36)

### DIFF
--- a/recommender/templates/history.html
+++ b/recommender/templates/history.html
@@ -19,12 +19,27 @@
       <option value="tv" {% if ct_filter == 'tv' %}selected{% endif %}>TV</option>
       <option value="movie" {% if ct_filter == 'movie' %}selected{% endif %}>Film</option>
     </select>
+    {% if providers %}
+    <select name="platform" class="input-field mono" style="padding:0.6rem 0.75rem; font-size:0.72rem;">
+      <option value="" {% if not platform_filter %}selected{% endif %}>All sources</option>
+      {% for p in providers %}
+      <option value="{{ p }}" {% if platform_filter == p %}selected{% endif %}>{{ platform_labels.get(p, p | replace('_', ' ') | title) }}</option>
+      {% endfor %}
+    </select>
+    {% endif %}
+    <select name="rating" class="input-field mono" style="padding:0.6rem 0.75rem; font-size:0.72rem;">
+      <option value="" {% if not rating_filter %}selected{% endif %}>Any rating</option>
+      <option value="liked" {% if rating_filter == 'liked' %}selected{% endif %}>Liked</option>
+      <option value="disliked" {% if rating_filter == 'disliked' %}selected{% endif %}>Disliked</option>
+      <option value="unrated" {% if rating_filter == 'unrated' %}selected{% endif %}>Unrated</option>
+    </select>
     <select name="sort" class="input-field mono" style="padding:0.6rem 0.75rem; font-size:0.72rem;">
       <option value="az" {% if sort == 'az' %}selected{% endif %}>A → Z</option>
       <option value="za" {% if sort == 'za' %}selected{% endif %}>Z → A</option>
+      <option value="recent" {% if sort == 'recent' %}selected{% endif %}>Recently watched</option>
     </select>
     <button type="submit" class="btn-primary" style="padding:0.6rem 1.1rem;">Filter</button>
-    {% if q or ct_filter %}
+    {% if q or ct_filter or platform_filter or rating_filter or sort != 'az' %}
     <a href="/history" class="btn-ghost" style="padding:0.6rem 0.9rem;">Clear</a>
     {% endif %}
     <!-- Add watched toggle — inline at end of filter row -->
@@ -115,6 +130,13 @@
       {% if item.description %}
       <p style="font-size:0.78rem; color:var(--muted); line-height:1.45; overflow:hidden; display:-webkit-box; -webkit-line-clamp:1; -webkit-box-orient:vertical; margin-top:0.1rem;">{{ item.description }}</p>
       {% endif %}
+      {% if item.platforms or item.last_watched %}
+      <div class="mono" style="font-size:0.55rem; color:var(--muted); margin-top:0.15rem; letter-spacing:0.04em;">
+        {% if item.platforms %}{% for p in item.platforms %}{{ platform_labels.get(p, p | replace('_', ' ') | title) }}{% if not loop.last %} · {% endif %}{% endfor %}{% endif %}
+        {% if item.platforms and item.last_watched %}<span style="color:var(--border);"> · </span>{% endif %}
+        {% if item.last_watched %}{{ item.last_watched[:10] }}{% endif %}
+      </div>
+      {% endif %}
       {% set uid = "hist-" ~ loop.index %}
       {% with title=item.title, content_type=item.content_type, tmdb_id=item.tmdb_id, current_rating=item.rating, uid=uid %}
       {% include "_rating_state.html" %}
@@ -191,19 +213,19 @@
 {% if total_pages > 1 %}
 <div class="archive-pager">
   {% if page > 1 %}
-  <a href="{{ url_for('history', page=page - 1, sort=sort, per_page=per_page, q=q or None, type=ct_filter or None) }}" class="btn-ghost pager-btn">Prev</a>
+  <a href="{{ url_for('history', page=page - 1, sort=sort, per_page=per_page, q=q or None, type=ct_filter or None, platform=platform_filter or None, rating=rating_filter or None) }}" class="btn-ghost pager-btn">Prev</a>
   {% endif %}
   {% for p in range(1, total_pages + 1) %}
     {% if p == page %}
     <span class="mono pager-current">{{ p }}</span>
     {% elif p == 1 or p == total_pages or (p >= page - 2 and p <= page + 2) %}
-    <a href="{{ url_for('history', page=p, sort=sort, per_page=per_page, q=q or None, type=ct_filter or None) }}" class="btn-ghost pager-btn">{{ p }}</a>
+    <a href="{{ url_for('history', page=p, sort=sort, per_page=per_page, q=q or None, type=ct_filter or None, platform=platform_filter or None, rating=rating_filter or None) }}" class="btn-ghost pager-btn">{{ p }}</a>
     {% elif p == page - 3 or p == page + 3 %}
     <span class="mono pager-ellipsis">...</span>
     {% endif %}
   {% endfor %}
   {% if page < total_pages %}
-  <a href="{{ url_for('history', page=page + 1, sort=sort, per_page=per_page, q=q or None, type=ct_filter or None) }}" class="btn-ghost pager-btn">Next</a>
+  <a href="{{ url_for('history', page=page + 1, sort=sort, per_page=per_page, q=q or None, type=ct_filter or None, platform=platform_filter or None, rating=rating_filter or None) }}" class="btn-ghost pager-btn">Next</a>
   {% endif %}
 </div>
 {% endif %}

--- a/recommender/templates/searches.html
+++ b/recommender/templates/searches.html
@@ -232,8 +232,38 @@ function setMinRating(val) {
   _shApply();
 }
 
+// Collapse granular TMDB provider names into one entry per brand: strip
+// ad-supported tiers and channel-reseller suffixes, then group known aliases.
+function canonicalProvider(raw) {
+  let low = (raw || '').trim().toLowerCase();
+  if (!low) return null;
+  low = low
+    .replace(/\s+with ads$/, '')
+    .replace(/\s+amazon channel$/, '')
+    .replace(/\s+apple tv channel$/, '')
+    .replace(/\s+roku premium channel$/, '')
+    .trim();
+  const brands = [
+    ['netflix', 'Netflix'],
+    ['amazon prime', 'Amazon Prime Video'],
+    ['prime video', 'Amazon Prime Video'],
+    ['disney', 'Disney+'],
+    ['paramount', 'Paramount+'],
+    ['britbox', 'BritBox'],
+    ['acorn', 'Acorn TV'],
+    ['apple tv', 'Apple TV+'],
+    ['hulu', 'Hulu'],
+    ['peacock', 'Peacock'],
+  ];
+  for (const [kw, label] of brands) {
+    if (low.includes(kw)) return { key: label.toLowerCase(), label };
+  }
+  const label = low.replace(/\b\w/g, c => c.toUpperCase());
+  return { key: low, label };
+}
+
 function setProvider(val) {
-  _shProvider = val.toLowerCase();
+  _shProvider = (val || '').toLowerCase();
   _shApply();
 }
 
@@ -245,7 +275,10 @@ function _shApply() {
     rows.forEach(row => {
       const typeOk = _shType === 'all' || row.dataset.type === _shType;
       const ratingOk = parseFloat(row.dataset.rating || 0) >= _shMinRating;
-      const providerOk = !_shProvider || (row.dataset.providers || '').includes(_shProvider);
+      const providerOk = !_shProvider || (row.dataset.providers || '').split(',').some(p => {
+        const c = canonicalProvider(p);
+        return c && c.key === _shProvider;
+      });
       const show = typeOk && ratingOk && providerOk;
       row.style.display = show ? '' : 'none';
       if (show) visibleRows++;
@@ -263,21 +296,21 @@ function _shApply() {
   }
 }
 
-// Populate provider dropdown from rendered data
+// Populate provider dropdown from rendered data, consolidated by brand.
 (function buildProviderDropdown() {
-  const providers = new Set();
+  const groups = new Map();   // canonical key -> display label
   document.querySelectorAll('.sh-result').forEach(row => {
     (row.dataset.providers || '').split(',').forEach(p => {
-      const t = p.trim();
-      if (t) providers.add(t);
+      const c = canonicalProvider(p);
+      if (c) groups.set(c.key, c.label);
     });
   });
-  if (providers.size === 0) return;
+  if (groups.size === 0) return;
   const sel = document.getElementById('sh-provider');
-  [...providers].sort().forEach(p => {
+  [...groups.entries()].sort((a, b) => a[1].localeCompare(b[1])).forEach(([key, label]) => {
     const opt = document.createElement('option');
-    opt.value = p;
-    opt.textContent = p.charAt(0).toUpperCase() + p.slice(1);
+    opt.value = key;
+    opt.textContent = label;
     sel.appendChild(opt);
   });
   sel.style.display = '';

--- a/recommender/user_state.py
+++ b/recommender/user_state.py
@@ -29,8 +29,9 @@ class UserStateIndex:
     _watchlist_tmdb_ids: set[int] = field(default_factory=set)
     _watchlist_titles: set[tuple[str, str]] = field(default_factory=set)
 
-    # ratings: keyed by tmdb_id or (normalized_title, content_type)
-    _ratings_by_tmdb: dict[int, str] = field(default_factory=dict)
+    # ratings: keyed by (content_type, tmdb_id) or (normalized_title, content_type).
+    # The TMDB key is typed so a movie and TV show sharing a numeric id don't collide.
+    _ratings_by_typed: dict[tuple[str, int], str] = field(default_factory=dict)
     _ratings_by_title: dict[tuple[str, str], str] = field(default_factory=dict)
 
     @classmethod
@@ -74,7 +75,7 @@ class UserStateIndex:
             ).fetchall():
                 tmdb_id, norm, ct, rating = row
                 if tmdb_id is not None:
-                    idx._ratings_by_tmdb[tmdb_id] = rating
+                    idx._ratings_by_typed[(ct, tmdb_id)] = rating
                 idx._ratings_by_title[(norm, ct)] = rating
 
         finally:
@@ -101,6 +102,6 @@ class UserStateIndex:
 
     def get_rating(self, meta) -> str | None:
         if meta.tmdb_id is not None:
-            return self._ratings_by_tmdb.get(meta.tmdb_id)
+            return self._ratings_by_typed.get((meta.content_type, meta.tmdb_id))
         key = (_normalize(meta.title), meta.content_type)
         return self._ratings_by_title.get(key)

--- a/recommender/watch_index.py
+++ b/recommender/watch_index.py
@@ -32,18 +32,37 @@ class WatchIndex:
         return (_normalize(candidate.title), candidate.content_type) in self.normalized_titles
 
 
+def _merge_provenance(dst: dict, src: dict) -> None:
+    """Union platform provenance and keep the most recent watch timestamp.
+
+    Used when two entries are merged during deduplication so neither the
+    source-provider set nor the latest-watched timestamp is lost.
+    """
+    merged = set(dst.get("platforms") or []) | set(src.get("platforms") or [])
+    dst["platforms"] = sorted(merged)
+    if (src.get("last_watched") or "") > (dst.get("last_watched") or ""):
+        dst["last_watched"] = src.get("last_watched") or ""
+
+
 def build(events: list[WatchEvent], metadata: dict) -> WatchIndex:
     """Build exclusion index from watch events. metadata provides TMDB IDs.
 
     metadata may be keyed by title string or by (title, content_type) tuple.
     Typed keys are checked first to support dual-existence titles (e.g. "Breathe"
     existing as both TV and movie).
+
+    Each entry also carries provenance aggregated across every event for the
+    title (not just the first): ``platforms`` (sorted source-provider list) and
+    ``last_watched`` (latest event timestamp, ISO string).
     """
     tmdb_ids: set[int] = set()
     tmdb_keys: set[tuple[str, int]] = set()
     normalized_titles: set[tuple[str, str]] = set()
     entries: list[dict] = []
     seen_keys: set[tuple[str, str]] = set()
+    entry_by_key: dict[tuple[str, str], dict] = {}
+    platforms_by_key: dict[tuple[str, str], set[str]] = {}
+    latest_by_key: dict[tuple[str, str], str] = {}
 
     for e in events:
         key = e.series_name if e.content_type == 'tv' else e.title
@@ -59,11 +78,25 @@ def build(events: list[WatchEvent], metadata: dict) -> WatchIndex:
             if tmdb_id:
                 tmdb_ids.add(tmdb_id)
                 tmdb_keys.add((ct, tmdb_id))
-            entries.append({
+            entry = {
                 "tmdb_id": tmdb_id,
                 "title": key,
                 "content_type": ct,
-            })
+            }
+            entries.append(entry)
+            entry_by_key[dedup_key] = entry
+            platforms_by_key[dedup_key] = set()
+            latest_by_key[dedup_key] = ""
+        # Aggregate provenance across every event for this title.
+        if e.platform:
+            platforms_by_key[dedup_key].add(e.platform)
+        ts = e.timestamp.isoformat() if e.timestamp else ""
+        if ts > latest_by_key[dedup_key]:
+            latest_by_key[dedup_key] = ts
+
+    for dk, entry in entry_by_key.items():
+        entry["platforms"] = sorted(platforms_by_key[dk])
+        entry["last_watched"] = latest_by_key[dk]
 
     index = WatchIndex(tmdb_ids=tmdb_ids, tmdb_keys=tmdb_keys,
                        normalized_titles=normalized_titles, entries=entries)
@@ -87,8 +120,10 @@ def deduplicate(index: WatchIndex) -> WatchIndex:
         if tmdb_id:
             typed_key = (ct, tmdb_id)
             if typed_key in seen_keys:
+                kept = deduped[seen_keys[typed_key]]
                 log.debug("Dedup by typed TMDB ID: %r merged with %r (%s/%d)",
-                           e["title"], deduped[seen_keys[typed_key]]["title"], ct, tmdb_id)
+                           e["title"], kept["title"], ct, tmdb_id)
+                _merge_provenance(kept, e)
                 continue
             seen_keys[typed_key] = len(deduped)
         deduped.append(e)
@@ -105,6 +140,7 @@ def deduplicate(index: WatchIndex) -> WatchIndex:
                     and fuzz.ratio(e["title"].lower(), existing["title"].lower()) >= 90):
                 log.debug("Dedup by fuzzy match: %r ~ %r (score >= 90)",
                            e["title"], existing["title"])
+                _merge_provenance(existing, e)
                 is_dup = True
                 break
         if not is_dup:

--- a/recommender/web.py
+++ b/recommender/web.py
@@ -210,7 +210,7 @@ def _build_result_items(results: list, ctx: RecommendContext) -> list[dict]:
             "vote_average": r.vote_average,
             "genres": r.genres[:3],
             "explanation": r.explanation,
-            "streaming_providers": r.streaming_providers[:4],
+            "streaming_providers": _consolidate_providers(r.streaming_providers)[:4],
             "poster": poster,
             "tmdb_url": tmdb_url,
             "imdb_url": imdb_url,
@@ -438,6 +438,8 @@ def history() -> str:
     q = request.args.get("q", "").lower()
     ct_filter = request.args.get("type", "")
     sort = request.args.get("sort", "az")
+    platform_filter = request.args.get("platform", "")
+    rating_filter = request.args.get("rating", "")
 
     entries = list(ctx.watch_index.entries)
 
@@ -457,14 +459,26 @@ def history() -> str:
                 "content_type": m["content_type"],
                 "tmdb_id": m.get("tmdb_id"),
                 "source": m["source"],
+                # Manual additions are their own provider category (issue #37).
+                "platforms": ["manual"],
+                "last_watched": m.get("watched_at", ""),
             })
+
+    # Source-provider options for the filter dropdown, computed over the full
+    # set before filtering so every provider stays selectable.
+    providers = sorted({p for e in entries for p in (e.get("platforms") or [])})
 
     if q:
         entries = [e for e in entries if q in e["title"].lower()]
     if ct_filter in ("tv", "movie"):
         entries = [e for e in entries if e.get("content_type") == ct_filter]
+    if platform_filter:
+        entries = [e for e in entries if platform_filter in (e.get("platforms") or [])]
 
-    if sort == "za":
+    if sort == "recent":
+        # Most recently watched first; titles with no timestamp sort last.
+        entries.sort(key=lambda e: e.get("last_watched") or "", reverse=True)
+    elif sort == "za":
         entries.sort(key=lambda e: e["title"].lower(), reverse=True)
     else:
         entries.sort(key=lambda e: e["title"].lower())
@@ -495,7 +509,17 @@ def history() -> str:
             "poster": _get_poster_url(e.get("tmdb_id", 0), e.get("content_type", "movie"), "w185")
                       if e.get("tmdb_id") else None,
             "rating": us.get_rating(m),
+            "platforms": e.get("platforms") or [],
+            "last_watched": e.get("last_watched") or "",
         })
+
+    if rating_filter == "liked":
+        items = [it for it in items if it["rating"] == "liked"]
+    elif rating_filter == "disliked":
+        items = [it for it in items if it["rating"] == "disliked"]
+    elif rating_filter == "unrated":
+        items = [it for it in items if not it["rating"]]
+
     total = len(items)
     ALLOWED_PAGE_SIZES = (30, 60, 120)
     try:
@@ -518,6 +542,10 @@ def history() -> str:
         q=q,
         ct_filter=ct_filter,
         sort=sort,
+        platform_filter=platform_filter,
+        rating_filter=rating_filter,
+        providers=providers,
+        platform_labels=PLATFORM_LABELS,
         total=total,
         page=page,
         total_pages=total_pages,
@@ -987,6 +1015,60 @@ def _watchlist_save_fragment(title: str, ct: str, tmdb_id: int | None, target_id
 
 # ── Watchlist routes ──────────────────────────────────────────────────────────
 
+# Display names for internal ingestion source codes (archive "source" filter).
+# Plain title-casing mangles these (Hbo, Apple Tv), so map them explicitly.
+PLATFORM_LABELS = {
+    "netflix": "Netflix",
+    "prime": "Prime Video",
+    "apple_tv": "Apple TV",
+    "disney": "Disney+",
+    "hbo": "HBO Max",
+    "manual": "Manual",
+}
+
+
+# Brand grouping for granular TMDB streaming-provider names (consolidates
+# ad-supported tiers, channel resells, and aliases). Mirrors the client-side
+# canonicalProvider() on the Searches page.
+_PROVIDER_SUFFIXES = (" with ads", " amazon channel", " apple tv channel",
+                      " roku premium channel")
+_PROVIDER_BRANDS = (
+    ("netflix", "Netflix"),
+    ("amazon prime", "Amazon Prime Video"),
+    ("prime video", "Amazon Prime Video"),
+    ("disney", "Disney+"),
+    ("paramount", "Paramount+"),
+    ("britbox", "BritBox"),
+    ("acorn", "Acorn TV"),
+    ("apple tv", "Apple TV+"),
+    ("hulu", "Hulu"),
+    ("peacock", "Peacock"),
+)
+
+
+def _canonical_provider(raw: str) -> str:
+    low = (raw or "").strip().lower()
+    for suffix in _PROVIDER_SUFFIXES:
+        if low.endswith(suffix):
+            low = low[: -len(suffix)].strip()
+    for keyword, label in _PROVIDER_BRANDS:
+        if keyword in low:
+            return label
+    return low.title()
+
+
+def _consolidate_providers(names: list[str]) -> list[str]:
+    """Collapse TMDB provider variants to one entry per brand, preserving order."""
+    out: list[str] = []
+    seen: set[str] = set()
+    for name in names or []:
+        label = _canonical_provider(name)
+        if label and label not in seen:
+            seen.add(label)
+            out.append(label)
+    return out
+
+
 def _decorate_saved_item(item: dict, ctx) -> None:
     """Attach cached poster, rating, genres, providers, and links to a saved title.
 
@@ -1030,8 +1112,9 @@ def _decorate_saved_item(item: dict, ctx) -> None:
         from urllib.parse import quote
         item["imdb_url"] = f"https://www.imdb.com/find/?q={quote(item['title'])}"
     try:
-        item["streaming_providers"] = tmdb.get_watch_providers(
-            tmdb_id, ct, config.WATCH_REGION, config.PROVIDERS_CACHE_DIR)[:4]
+        item["streaming_providers"] = _consolidate_providers(
+            tmdb.get_watch_providers(
+                tmdb_id, ct, config.WATCH_REGION, config.PROVIDERS_CACHE_DIR))[:4]
     except Exception:
         item["streaming_providers"] = []
 

--- a/recommender/web.py
+++ b/recommender/web.py
@@ -447,13 +447,15 @@ def history() -> str:
     _ensure_user_store_once()
     manual = user_store.list_manual_archive(config.EVENT_DB_PATH)
 
-    existing_norm = {
-        (_norm_title(e.get("title", "")), e.get("content_type", "tv"))
-        for e in entries
-    }
+    existing_idx = {}
+    for i, e in enumerate(entries):
+        existing_idx.setdefault(
+            (_norm_title(e.get("title", "")), e.get("content_type", "tv")), i)
+
     for m in manual:
         key = (_norm_title(m["title"]), m["content_type"])
-        if key not in existing_norm:
+        watched_at = m.get("watched_at", "")
+        if key not in existing_idx:
             entries.append({
                 "title": m["title"],
                 "content_type": m["content_type"],
@@ -461,8 +463,20 @@ def history() -> str:
                 "source": m["source"],
                 # Manual additions are their own provider category (issue #37).
                 "platforms": ["manual"],
-                "last_watched": m.get("watched_at", ""),
+                "last_watched": watched_at,
             })
+            existing_idx[key] = len(entries) - 1
+        else:
+            # The title is already in the watch index: fold the manual watch in
+            # rather than dropping it, so the 'manual' source filter and recency
+            # sort both see it. Copy first — the entry dict is shared with the
+            # cached watch index and must not be mutated in place.
+            i = existing_idx[key]
+            merged = dict(entries[i])
+            merged["platforms"] = sorted(set(merged.get("platforms") or []) | {"manual"})
+            if watched_at > (merged.get("last_watched") or ""):
+                merged["last_watched"] = watched_at
+            entries[i] = merged
 
     # Source-provider options for the filter dropdown, computed over the full
     # set before filtering so every provider stays selectable.

--- a/recommender/web.py
+++ b/recommender/web.py
@@ -447,36 +447,57 @@ def history() -> str:
     _ensure_user_store_once()
     manual = user_store.list_manual_archive(config.EVENT_DB_PATH)
 
-    existing_idx = {}
+    # Match a manual row to an existing entry by typed TMDB identity when it has
+    # one (the schema's unique key), so same-title remakes/editions with distinct
+    # ids stay distinct; fall back to (title, type) only for rows without an id.
+    by_tmdb: dict[tuple[str, int], int] = {}
+    by_title: dict[tuple[str, str], int] = {}
     for i, e in enumerate(entries):
-        existing_idx.setdefault(
-            (_norm_title(e.get("title", "")), e.get("content_type", "tv")), i)
+        ct = e.get("content_type", "tv")
+        tid = e.get("tmdb_id")
+        if tid:
+            by_tmdb.setdefault((ct, tid), i)
+        by_title.setdefault((_norm_title(e.get("title", "")), ct), i)
 
     for m in manual:
-        key = (_norm_title(m["title"]), m["content_type"])
+        ct = m["content_type"]
+        tid = m.get("tmdb_id")
+        title_key = (_norm_title(m["title"]), ct)
         watched_at = m.get("watched_at", "")
-        if key not in existing_idx:
+
+        if tid and (ct, tid) in by_tmdb:
+            target = by_tmdb[(ct, tid)]
+        elif tid:
+            target = None              # distinct id not present yet → new row
+        elif title_key in by_title:
+            target = by_title[title_key]
+        else:
+            target = None
+
+        if target is None:
             entries.append({
                 "title": m["title"],
-                "content_type": m["content_type"],
-                "tmdb_id": m.get("tmdb_id"),
+                "content_type": ct,
+                "tmdb_id": tid,
                 "source": m["source"],
                 # Manual additions are their own provider category (issue #37).
                 "platforms": ["manual"],
                 "last_watched": watched_at,
             })
-            existing_idx[key] = len(entries) - 1
+            new_i = len(entries) - 1
+            if tid:
+                by_tmdb.setdefault((ct, tid), new_i)
+            by_title.setdefault(title_key, new_i)
         else:
-            # The title is already in the watch index: fold the manual watch in
-            # rather than dropping it, so the 'manual' source filter and recency
-            # sort both see it. Copy first — the entry dict is shared with the
-            # cached watch index and must not be mutated in place.
-            i = existing_idx[key]
-            merged = dict(entries[i])
+            # Fold the manual watch into the existing row rather than dropping it,
+            # so the 'manual' source filter and recency sort both see it. Copy
+            # first — the entry dict is shared with the cached watch index and
+            # must not be mutated in place.
+            merged = dict(entries[target])
             merged["platforms"] = sorted(set(merged.get("platforms") or []) | {"manual"})
             if watched_at > (merged.get("last_watched") or ""):
                 merged["last_watched"] = watched_at
-            entries[i] = merged
+            entries[target] = merged
 
     # Source-provider options for the filter dropdown, computed over the full
     # set before filtering so every provider stays selectable.

--- a/tests/test_user_state.py
+++ b/tests/test_user_state.py
@@ -107,6 +107,21 @@ def test_get_rating_does_not_fallthrough_on_wrong_tmdb_id(tmp_path):
     assert idx.get_rating(FakeMeta("Breaking Bad", "tv", tmdb_id=9999)) is None
 
 
+def test_get_rating_is_content_type_aware_for_shared_tmdb_id(tmp_path):
+    """A movie and a TV show that share a numeric TMDB id must not collide."""
+    db = str(tmp_path / "test.db")
+    init_db(db)
+    rate_title(db, "Breathe", "movie", "liked", tmdb_id=407445)
+
+    from recommender.user_state import UserStateIndex
+    idx = UserStateIndex.load(db)
+
+    # The movie is liked; the TV show with the same id is still unrated.
+    assert idx.get_rating(FakeMeta("Breathe", "movie", tmdb_id=407445)) == "liked"
+    assert idx.get_rating(FakeMeta("Breathe", "tv", tmdb_id=407445)) is None
+    assert not idx.has_rating(FakeMeta("Breathe", "tv", tmdb_id=407445))
+
+
 def test_is_in_watchlist(tmp_path):
     db = str(tmp_path / "test.db")
     init_db(db)

--- a/tests/test_watch_index.py
+++ b/tests/test_watch_index.py
@@ -179,3 +179,41 @@ def test_save_and_load_roundtrip(tmp_path):
     assert 67452 in loaded.tmdb_ids
     assert ("tv", 67452) in loaded.tmdb_keys
     assert ("fleabag", "tv") in loaded.normalized_titles
+
+
+def _event(title, platform, ts, content_type="movie", series_name=None):
+    return WatchEvent(
+        platform=platform, title=title, content_type=content_type,
+        series_name=series_name or title,
+        watched_duration=timedelta(hours=1), total_duration=None,
+        timestamp=ts, profile="ADULT",
+    )
+
+
+def test_build_aggregates_platforms_and_latest_timestamp():
+    t1 = datetime(2026, 1, 1, 12, 0, 0)
+    t2 = datetime(2026, 3, 5, 9, 0, 0)
+    events = [
+        _event("The Bear", "netflix", t1, "tv", "The Bear"),
+        _event("The Bear", "prime", t2, "tv", "The Bear"),
+    ]
+    index = wi.build(events, {})
+    entry = [e for e in index.entries if e["title"] == "The Bear"][0]
+    assert entry["platforms"] == ["netflix", "prime"]   # union across episodes
+    assert entry["last_watched"] == t2.isoformat()       # most recent kept
+
+
+def test_deduplicate_merges_provenance_across_typed_identity():
+    entries = [
+        {"tmdb_id": 5, "title": "A", "content_type": "movie",
+         "platforms": ["netflix"], "last_watched": "2026-01-01T00:00:00"},
+        {"tmdb_id": 5, "title": "A (4K)", "content_type": "movie",
+         "platforms": ["prime"], "last_watched": "2026-02-01T00:00:00"},
+    ]
+    index = WatchIndex(tmdb_ids={5}, tmdb_keys={("movie", 5)},
+                       normalized_titles=set(), entries=entries)
+    deduped = wi.deduplicate(index)
+    assert len(deduped.entries) == 1
+    merged = deduped.entries[0]
+    assert merged["platforms"] == ["netflix", "prime"]
+    assert merged["last_watched"] == "2026-02-01T00:00:00"

--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -927,6 +927,33 @@ def test_history_provider_filter_and_recent_sort(client, tmp_path, monkeypatch):
         assert html.index("Prime Pick") < html.index("Netflix Pick")
 
 
+def test_history_merges_manual_provenance_into_existing_entry(client, tmp_path, monkeypatch):
+    """Issue #37 review: a manual watch of an already-indexed title folds its
+    'manual' source into the existing row instead of being dropped."""
+    from unittest.mock import MagicMock, patch
+    from recommender.user_store import init_db, add_to_archive
+
+    db = str(tmp_path / "test.db")
+    init_db(db)
+    add_to_archive(db, "Imported Show", "tv", source="web")
+    monkeypatch.setattr("config.EVENT_DB_PATH", db)
+    monkeypatch.setattr("config.FEEDBACK_PATH", str(tmp_path / "feedback.json"))
+
+    mock_ctx = MagicMock()
+    mock_ctx.watch_index.entries = [
+        {"title": "Imported Show", "content_type": "tv", "tmdb_id": None,
+         "platforms": ["netflix"], "last_watched": "2026-01-01T00:00:00"},
+    ]
+    with patch("recommender.web._get_context", return_value=mock_ctx):
+        # The manual source filter now finds the already-indexed title.
+        assert b"Imported Show" in client.get("/history?platform=manual").data
+        # The original source is still present (no in-place mutation of the cache).
+        resp = client.get("/history?platform=netflix")
+        assert b"Imported Show" in resp.data
+        # Still a single row, not a duplicate.
+        assert resp.data.count(b"hist-2") == 0
+
+
 def test_consolidate_providers_groups_variants():
     """Issue #36: granular TMDB provider names collapse to one entry per brand."""
     from recommender.web import _consolidate_providers

--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -895,6 +895,78 @@ def test_history_includes_manual_archive_entries(client, tmp_path, monkeypatch):
     assert b"Manual Show" in resp.data
 
 
+def test_history_provider_filter_and_recent_sort(client, tmp_path, monkeypatch):
+    """Issue #37: filter the archive by source provider and sort by recency."""
+    from unittest.mock import MagicMock, patch
+    from recommender.user_store import init_db
+
+    db = str(tmp_path / "test.db")
+    init_db(db)
+    monkeypatch.setattr("config.EVENT_DB_PATH", db)
+    monkeypatch.setattr("config.FEEDBACK_PATH", str(tmp_path / "feedback.json"))
+
+    mock_ctx = MagicMock()
+    mock_ctx.watch_index.entries = [
+        {"title": "Netflix Pick", "content_type": "movie", "tmdb_id": None,
+         "platforms": ["netflix"], "last_watched": "2026-01-01T00:00:00"},
+        {"title": "Prime Pick", "content_type": "movie", "tmdb_id": None,
+         "platforms": ["prime"], "last_watched": "2026-05-01T00:00:00"},
+    ]
+    with patch("recommender.web._get_context", return_value=mock_ctx):
+        # Dropdown offers a source filter.
+        resp = client.get("/history")
+        assert b"All sources" in resp.data
+
+        # Filtering by provider keeps only that source.
+        resp = client.get("/history?platform=netflix")
+        assert b"Netflix Pick" in resp.data
+        assert b"Prime Pick" not in resp.data
+
+        # Recent sort puts the most recently watched first.
+        html = client.get("/history?sort=recent").data.decode()
+        assert html.index("Prime Pick") < html.index("Netflix Pick")
+
+
+def test_consolidate_providers_groups_variants():
+    """Issue #36: granular TMDB provider names collapse to one entry per brand."""
+    from recommender.web import _consolidate_providers
+
+    out = _consolidate_providers([
+        "Netflix", "Netflix Standard with Ads",
+        "Amazon Prime Video", "Amazon Prime Video with Ads", "Freevee Amazon Channel",
+        "Paramount+ Amazon Channel", "Apple TV+",
+    ])
+    assert out == ["Netflix", "Amazon Prime Video", "Freevee", "Paramount+", "Apple TV+"]
+
+
+def test_history_rating_filter(client, tmp_path, monkeypatch):
+    """Issue #36: filter the archive by rating status."""
+    from unittest.mock import MagicMock, patch
+    from recommender.user_store import init_db, rate_title
+
+    db = str(tmp_path / "test.db")
+    init_db(db)
+    rate_title(db, "Liked Movie", "movie", "liked")
+    monkeypatch.setattr("config.EVENT_DB_PATH", db)
+    monkeypatch.setattr("config.FEEDBACK_PATH", str(tmp_path / "feedback.json"))
+
+    mock_ctx = MagicMock()
+    mock_ctx.watch_index.entries = [
+        {"title": "Liked Movie", "content_type": "movie", "tmdb_id": None,
+         "platforms": [], "last_watched": ""},
+        {"title": "Unrated Movie", "content_type": "movie", "tmdb_id": None,
+         "platforms": [], "last_watched": ""},
+    ]
+    with patch("recommender.web._get_context", return_value=mock_ctx):
+        resp = client.get("/history?rating=liked")
+        assert b"Liked Movie" in resp.data
+        assert b"Unrated Movie" not in resp.data
+
+        resp = client.get("/history?rating=unrated")
+        assert b"Unrated Movie" in resp.data
+        assert b"Liked Movie" not in resp.data
+
+
 def test_history_pagination_url_encodes_query(client):
     from unittest.mock import MagicMock, patch
 

--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -954,6 +954,29 @@ def test_history_merges_manual_provenance_into_existing_entry(client, tmp_path, 
         assert resp.data.count(b"hist-2") == 0
 
 
+def test_history_keeps_distinct_manual_entries_with_different_tmdb_ids(client, tmp_path, monkeypatch):
+    """Review fix: two manual rows sharing a title/type but with different TMDB
+    ids (e.g. remakes) must stay distinct, not collapse via a title-only key."""
+    from unittest.mock import MagicMock, patch
+    from recommender.user_store import init_db, add_to_archive
+
+    db = str(tmp_path / "test.db")
+    init_db(db)
+    add_to_archive(db, "The Office", "tv", tmdb_id=2316)   # US
+    add_to_archive(db, "The Office", "tv", tmdb_id=2996)   # UK remake
+    monkeypatch.setattr("config.EVENT_DB_PATH", db)
+    monkeypatch.setattr("config.FEEDBACK_PATH", str(tmp_path / "feedback.json"))
+
+    mock_ctx = MagicMock()
+    mock_ctx.watch_index.entries = []
+    with patch("recommender.web._get_context", return_value=mock_ctx):
+        resp = client.get("/history?platform=manual&per_page=120")
+        # Two separate list rows (hist-2 only appears with a second item)...
+        assert b"hist-2" in resp.data
+        # ...and not a spurious third.
+        assert b"hist-3" not in resp.data
+
+
 def test_consolidate_providers_groups_variants():
     """Issue #36: granular TMDB provider names collapse to one entry per brand."""
     from recommender.web import _consolidate_providers


### PR DESCRIPTION
Implements #37 and #36.

## #37 — Archive source-provider filter and recent sort

- `watch_index` entries now carry **`platforms`** (sorted source list) and **`last_watched`** (latest ISO timestamp), aggregated across *all* events in `build()` and merged when entries collapse in `deduplicate()` (new `_merge_provenance`). `save`/`load` unchanged (JSON-serializable).
- `/history`: server-side **provider filter**, **recent sort**, and a provider dropdown built over the full set. Manual additions are their own `manual` source.
- `history.html`: source dropdown, "Recently watched" sort, and a per-item source + date line.

## #36 — Provider consolidation and archive rating filter

- `searches.html`: `canonicalProvider()` collapses ad-supported tiers, channel resells, and aliases (Netflix, Amazon Prime Video, Paramount+, BritBox, Acorn TV, …) for the dropdown and filtering.
- Server-side `_consolidate_providers()` mirrors it for the **watchlist** and **search results**, so brand names are consistent across the app.
- `/history`: **rating filter** (Any/Liked/Disliked/Unrated).

## Provider display

- `PLATFORM_LABELS` maps internal source codes to correct casing (**HBO Max, Apple TV, Prime Video**) instead of mangled `|title` output.

## Notes / deliberate deviations

- **Archive filters are server-side** (provider, rating, recent sort). #36 described the rating filter as client-side pills, but the archive paginates server-side, so a client-side filter would only affect the visible page. Same delivered behavior, correct under pagination.
- **Watch index provenance**: `build()` now populates `platforms`/`last_watched`; existing on-disk indexes lack these until the next `./recommend setup`. The route degrades gracefully (no source shown, sorts last). The local index was augmented in place to avoid an entry-dropping rebuild.

## Validation

- `pytest tests/` → 479 passed (the lone `test_signals` failure is a pre-existing, unrelated time-of-day flake).
- Verified live locally: archive source dropdown (Netflix/Prime Video/Apple TV/Disney+/HBO Max), provider filter, Recently-watched sort, rating filter; watchlist + search results show consolidated brand names.

Closes #37, closes #36.