### PR TITLE
[codex] Fix taste profile cluster cap

### DIFF
--- a/recommender/structured_profile.py
+++ b/recommender/structured_profile.py
@@ -17,6 +17,7 @@ from .llm import LLMClient
 log = logging.getLogger("recommender.structured_profile")
 
 ALLOWED_CO_VIEWING = {"personal", "family", "mixed", "unknown"}
+FAMILY_WEIGHT_MULTIPLIER = 0.75
 FAMILY_TERMS = {
     "animation",
     "animated",
@@ -165,12 +166,29 @@ def validate_structured_profile(data: dict[str, Any]) -> dict[str, Any]:
     return profile
 
 
+def _deprioritize_family_cluster_weights(profile: dict[str, Any]) -> dict[str, Any]:
+    adjusted = {
+        key: value.copy() if isinstance(value, list) else value
+        for key, value in profile.items()
+    }
+    adjusted_clusters: list[dict[str, Any]] = []
+    for cluster in profile["clusters"]:
+        adjusted_cluster = cluster.copy()
+        if adjusted_cluster["co_viewing"] == "family":
+            adjusted_cluster["weight"] = _clamp_weight(
+                adjusted_cluster["weight"] * FAMILY_WEIGHT_MULTIPLIER
+            )
+        adjusted_clusters.append(adjusted_cluster)
+    adjusted["clusters"] = adjusted_clusters
+    return adjusted
+
+
 def parse_structured_profile_response(text: str) -> dict[str, Any]:
     try:
         data = json.loads(_strip_json_fence(text))
     except json.JSONDecodeError as exc:
         raise ValueError(f"invalid structured profile JSON: {exc}") from exc
-    return validate_structured_profile(data)
+    return _deprioritize_family_cluster_weights(validate_structured_profile(data))
 
 
 def build_structured_profile(

--- a/recommender/taste_profile_builder.py
+++ b/recommender/taste_profile_builder.py
@@ -1,6 +1,7 @@
 import hashlib
 import json
 import logging
+import re
 import time
 from pathlib import Path
 
@@ -11,6 +12,22 @@ from .llm import LLMClient
 log = logging.getLogger("recommender.profile")
 
 _BATCH_DIR = Path(config.ENRICHMENT_CACHE_DIR).parent / "profile_batches"
+_MAX_PROFILE_CLUSTERS = 15
+_LIST_ITEM_RE = re.compile(r"^\s*(?:[-*]\s+|\d+[\.)]\s*)(.+?)\s*$")
+_FAMILY_CLUSTER_PATTERNS = (
+    r"\bdisney\b",
+    r"\bpixar\b",
+    r"\bchristmas\b",
+    r"\bholiday\b",
+    r"\bseasonal\b",
+    r"\bkids?\b",
+    r"\bchildren(?:'s)?\b",
+    r"\bchild[- ]friendly\b",
+    r"\bfamily\s+(?:animation|animated|television|tv|sitcom|comfort|viewing|content|"
+    r"movie|movies|film|films|musical|musicals|adventure|adventures|channel)\b",
+    r"\b(?:animation|animated|television|tv|sitcom|comfort|viewing|content|movie|movies|"
+    r"film|films|musical|musicals|adventure|adventures|channel)\s+(?:and\s+)?family\b",
+)
 
 
 def _batch_fingerprint(scored: list[tuple[str, float]]) -> str:
@@ -93,6 +110,81 @@ def _build_batch_profile(
                             timeout=config.TIMEOUT_PROFILE_BATCH).strip()
 
 
+def _is_family_cluster_text(text: str) -> bool:
+    normalized = text.strip().splitlines()[0].casefold() if text.strip() else ""
+    return any(re.search(pattern, normalized) for pattern in _FAMILY_CLUSTER_PATTERNS)
+
+
+def _personal_clusters_first(items: list[str]) -> list[str]:
+    personal: list[str] = []
+    family: list[str] = []
+    for item in items:
+        if _is_family_cluster_text(item):
+            family.append(item)
+        else:
+            personal.append(item)
+    return personal + family
+
+
+def _cap_cluster_list(text: str, max_clusters: int = _MAX_PROFILE_CLUSTERS) -> str:
+    lines = [line.strip() for line in text.splitlines() if line.strip()]
+    list_items = []
+    for line in lines:
+        match = _LIST_ITEM_RE.match(line)
+        if match:
+            list_items.append(match.group(1).strip())
+
+    if list_items:
+        ordered = _personal_clusters_first(list_items)
+        capped = ordered[:max_clusters]
+        if len(list_items) > max_clusters:
+            log.info("Capped extracted clusters to %d (was %d list items)", max_clusters, len(list_items))
+        return "\n".join(f"{index}. {item}" for index, item in enumerate(capped, start=1))
+
+    if len(lines) > max_clusters:
+        log.info("Capped extracted clusters to %d lines (was %d lines)", max_clusters, len(lines))
+    return "\n".join(lines[:max_clusters])
+
+
+def _split_markdown_sections(text: str) -> tuple[str, list[str]]:
+    preamble: list[str] = []
+    sections: list[str] = []
+    current_section: list[str] | None = None
+
+    for line in text.splitlines():
+        if line.startswith("## "):
+            if current_section is not None:
+                sections.append("\n".join(current_section).strip())
+            current_section = [line]
+        elif current_section is None:
+            preamble.append(line)
+        else:
+            current_section.append(line)
+
+    if current_section is not None:
+        sections.append("\n".join(current_section).strip())
+
+    return "\n".join(preamble).strip(), sections
+
+
+def _cap_markdown_sections(text: str, max_sections: int = _MAX_PROFILE_CLUSTERS) -> str:
+    """Keep at most max_sections markdown h2 sections, preserving any preamble."""
+    preamble, sections = _split_markdown_sections(text)
+    if not sections:
+        return text.strip()
+
+    ordered_sections = _personal_clusters_first(sections)
+    kept_sections = ordered_sections[:max_sections]
+    if len(sections) > max_sections:
+        log.info("Capped final profile to %d sections (was %d)", max_sections, len(sections))
+
+    parts = []
+    if preamble:
+        parts.append(preamble)
+    parts.extend(kept_sections)
+    return "\n".join(parts).strip()
+
+
 def _merge_profiles(
     batch_profiles: list[str],
     client: LLMClient,
@@ -111,12 +203,17 @@ def _merge_profiles(
     cluster_prompt = (
         "Below are taste profile analyses from different segments of the same person's "
         "watch history. List ONLY the distinct taste cluster names you see, merging "
-        "overlapping clusters. Return a numbered list of 8-15 cluster names, nothing else.\n\n"
+        "overlapping clusters. Return a numbered list of 8-15 cluster names, nothing else.\n"
+        "Order the clusters by importance to the person's true personal taste, deprioritizing "
+        "high-volume family/co-viewing content.\n\n"
         f"{profiles_str}"
     )
     clusters_text = client.generate(cluster_prompt, role="reason",
                                      max_tokens=500, timeout=config.TIMEOUT_PROFILE_MERGE).strip()
     log.debug("Extracted clusters: %s", clusters_text[:500])
+
+    # Enforce maximum clusters and keep family/co-viewing patterns from occupying the top slots.
+    clusters_text = _cap_cluster_list(clusters_text)
 
     # Step 2: Write the full profile constrained to those clusters
     prompt = (
@@ -126,6 +223,8 @@ def _merge_profiles(
         f"CONSOLIDATED CLUSTERS:\n{clusters_text}\n\n"
         "Write the final merged taste profile. Rules:\n"
         "- Write one section (## heading) per cluster from the list above\n"
+        "- Do not add extra ## sections beyond the consolidated cluster list; merge leftover "
+        "patterns into the nearest retained cluster\n"
         "- Each section: a rich paragraph describing the pattern (tone, pacing, themes, "
         "what draws this person), followed by key titles in bold/italic\n"
         "- Merge overlapping content from different batches into the same cluster\n"
@@ -135,8 +234,9 @@ def _merge_profiles(
         "- IMPORTANT: You MUST complete every section. If running low on space, "
         "make later sections shorter rather than cutting off mid-sentence.\n"
     )
-    return client.generate(prompt, role="reason", max_tokens=config.TOKENS_PROFILE_MERGE,
-                            timeout=config.TIMEOUT_PROFILE_MERGE).strip()
+    profile_text = client.generate(prompt, role="reason", max_tokens=config.TOKENS_PROFILE_MERGE,
+                                   timeout=config.TIMEOUT_PROFILE_MERGE).strip()
+    return _cap_markdown_sections(profile_text)
 
 
 def build(

--- a/recommender/taste_profile_builder.py
+++ b/recommender/taste_profile_builder.py
@@ -14,6 +14,7 @@ log = logging.getLogger("recommender.profile")
 _BATCH_DIR = Path(config.ENRICHMENT_CACHE_DIR).parent / "profile_batches"
 _MAX_PROFILE_CLUSTERS = 15
 _LIST_ITEM_RE = re.compile(r"^\s*(?:[-*]\s+|\d+[\.)]\s*)(.+?)\s*$")
+_MARKDOWN_HEADING_NUMBER_RE = re.compile(r"^(##\s+)(?:\d+[\.)]\s*)?(.+?)\s*$")
 _FAMILY_CLUSTER_PATTERNS = (
     r"\bdisney\b",
     r"\bpixar\b",
@@ -167,6 +168,19 @@ def _split_markdown_sections(text: str) -> tuple[str, list[str]]:
     return "\n".join(preamble).strip(), sections
 
 
+def _renumber_markdown_sections(sections: list[str]) -> list[str]:
+    renumbered: list[str] = []
+    for index, section in enumerate(sections, start=1):
+        lines = section.splitlines()
+        if not lines:
+            continue
+        match = _MARKDOWN_HEADING_NUMBER_RE.match(lines[0])
+        if match:
+            lines[0] = f"{match.group(1)}{index}. {match.group(2)}"
+        renumbered.append("\n".join(lines))
+    return renumbered
+
+
 def _cap_markdown_sections(text: str, max_sections: int = _MAX_PROFILE_CLUSTERS) -> str:
     """Keep at most max_sections markdown h2 sections, preserving any preamble."""
     preamble, sections = _split_markdown_sections(text)
@@ -174,7 +188,7 @@ def _cap_markdown_sections(text: str, max_sections: int = _MAX_PROFILE_CLUSTERS)
         return text.strip()
 
     ordered_sections = _personal_clusters_first(sections)
-    kept_sections = ordered_sections[:max_sections]
+    kept_sections = _renumber_markdown_sections(ordered_sections[:max_sections])
     if len(sections) > max_sections:
         log.info("Capped final profile to %d sections (was %d)", max_sections, len(sections))
 

--- a/tests/test_structured_profile.py
+++ b/tests/test_structured_profile.py
@@ -66,6 +66,42 @@ def test_parse_structured_profile_response_rejects_invalid_json():
         raise AssertionError("invalid JSON did not raise ValueError")
 
 
+def test_parse_structured_profile_response_deprioritizes_family_weight_once():
+    payload = {
+        "clusters": [
+            {
+                "label": "Family animation",
+                "weight": 1.0,
+                "co_viewing": "family",
+            }
+        ]
+    }
+
+    result = parse_structured_profile_response(json.dumps(payload))
+    revalidated = validate_structured_profile(result)
+
+    assert result["clusters"][0]["weight"] == 0.75
+    assert revalidated["clusters"][0]["weight"] == 0.75
+
+
+def test_save_and_load_does_not_reapply_family_weight_penalty(tmp_path):
+    profile = parse_structured_profile_response(json.dumps({
+        "clusters": [
+            {
+                "label": "Family animation",
+                "weight": 1.0,
+                "co_viewing": "family",
+            }
+        ]
+    }))
+    path = tmp_path / "taste_profile_structured.json"
+
+    save_structured_profile(profile, path)
+
+    loaded = load_structured_profile(path)
+    assert loaded["clusters"][0]["weight"] == 0.75
+
+
 def test_validate_structured_profile_drops_empty_clusters_and_fills_lists():
     result = validate_structured_profile({
         "clusters": [

--- a/tests/test_taste_profile_builder.py
+++ b/tests/test_taste_profile_builder.py
@@ -106,10 +106,13 @@ def test_merge_profiles_reorders_family_sections_after_personal_before_capping()
 
     headings = [line for line in result.splitlines() if line.startswith("## ")]
     assert len(headings) == 15
-    assert headings[0] == "## 4. British Crime & Police Drama"
-    assert headings[12] == "## 16. Slow-Burn Prestige Crime & Noir"
-    assert "## 1. Disney/Pixar Animated Canon" in headings[13:]
-    assert "## 3. Christmas & Holiday Content" not in headings
+    assert headings[0] == "## 1. British Crime & Police Drama"
+    assert headings[12] == "## 13. Slow-Burn Prestige Crime & Noir"
+    assert headings[13] == "## 14. Disney/Pixar Animated Canon"
+    assert headings[14] == "## 15. Disney Channel & Family Television"
+    assert "Christmas & Holiday Content" not in result
+    for index, heading in enumerate(headings, start=1):
+        assert heading.startswith(f"## {index}. ")
 
     final_prompt = client.generate.call_args_list[1].args[0]
     cluster_block = final_prompt.split("CONSOLIDATED CLUSTERS:\n", 1)[1]

--- a/tests/test_taste_profile_builder.py
+++ b/tests/test_taste_profile_builder.py
@@ -1,8 +1,8 @@
 from datetime import datetime, timedelta
 
 from recommender.ingestion.base import WatchEvent
-from recommender.taste_profile_builder import build
-from tests.mock_llm import make_mock_llm
+from recommender.taste_profile_builder import _merge_profiles, build
+from tests.mock_llm import make_mock_llm, make_mock_llm_sequence
 
 
 def make_event(title, series_name=None, content_type="movie", seconds=3600):
@@ -52,3 +52,66 @@ def test_build_skips_titles_with_no_enrichment():
     build(events, scores, enrichments, client)
     prompt = client.generate.call_args[0][0]
     assert "Unknown" not in prompt or "Unknown description" not in prompt
+
+
+def test_merge_profiles_caps_final_profile_to_fifteen_sections():
+    cluster_list = "\n".join(f"{i}. Cluster {i}" for i in range(1, 29))
+    final_profile = "\n".join(
+        f"## {i}. Cluster {i}\nYou like pattern {i}."
+        for i in range(1, 18)
+    )
+    client = make_mock_llm_sequence([cluster_list, final_profile])
+
+    result = _merge_profiles(["batch profile"], client)
+
+    headings = [line for line in result.splitlines() if line.startswith("## ")]
+    assert len(headings) == 15
+    assert headings[-1] == "## 15. Cluster 15"
+    assert "## 16. Cluster 16" not in result
+
+
+def test_merge_profiles_reorders_family_sections_after_personal_before_capping():
+    family_clusters = [
+        "Disney/Pixar Animated Canon",
+        "Disney Channel & Family Television",
+        "Christmas & Holiday Content",
+    ]
+    personal_clusters = [
+        "British Crime & Police Drama",
+        "Prestige American Institutional Drama",
+        "Spy & Espionage Thriller",
+        "Romantic Period Drama",
+        "Musical Drama & Biography",
+        "Investigative Documentary & True Story",
+        "Philosophical Science Fiction",
+        "Nordic Noir & Remote Setting Crime",
+        "Political Satire & Current Affairs Media",
+        "Food, Culinary & Travel Documentary",
+        "South Asian Cinema & Indian Content",
+        "Psychological & Puzzle-Box Thriller",
+        "Slow-Burn Prestige Crime & Noir",
+    ]
+    all_clusters = family_clusters + personal_clusters
+    cluster_list = "\n".join(
+        f"{index}. {cluster}"
+        for index, cluster in enumerate(all_clusters, start=1)
+    )
+    final_profile = "\n".join(
+        f"## {index}. {cluster}\nYou like {cluster}."
+        for index, cluster in enumerate(all_clusters, start=1)
+    )
+    client = make_mock_llm_sequence([cluster_list, final_profile])
+
+    result = _merge_profiles(["batch profile"], client)
+
+    headings = [line for line in result.splitlines() if line.startswith("## ")]
+    assert len(headings) == 15
+    assert headings[0] == "## 4. British Crime & Police Drama"
+    assert headings[12] == "## 16. Slow-Burn Prestige Crime & Noir"
+    assert "## 1. Disney/Pixar Animated Canon" in headings[13:]
+    assert "## 3. Christmas & Holiday Content" not in headings
+
+    final_prompt = client.generate.call_args_list[1].args[0]
+    cluster_block = final_prompt.split("CONSOLIDATED CLUSTERS:\n", 1)[1]
+    cluster_block = cluster_block.split("\n\nWrite the final", 1)[0]
+    assert cluster_block.splitlines()[0] == "1. British Crime & Police Drama"


### PR DESCRIPTION
## Summary

- Enforce the taste profile prose cluster cap deterministically after LLM generation.
- Reorder family, Disney, holiday, and kid-oriented prose clusters after personal clusters before applying the cap so the dashboard surface does not preserve family-first drift.
- Apply structured family/co-viewing weight deprioritization once on fresh LLM output while keeping validation, save/load, and query-time normalization idempotent.
- Add regression tests for final prose overflow, family-first prose ordering, and structured weight idempotency.

## Root Cause

The previous profile prompts asked for 8-15 clusters and family/co-viewing deprioritization, but the LLM could still return too many sections or put high-volume family clusters first. The dashboard reads the prose profile's `##` sections directly, so prompt-only ordering was not a reliable fix.

## Validation

- `python3 -m pytest -q tests/test_taste_profile_builder.py tests/test_structured_profile.py` -> `20 passed`
- `python3 -m pytest -q` -> `551 passed, 4 warnings`
- `git diff --check` -> clean

Closes #63.

Follow-up: #64 tracks a fuller raw-vs-adjusted structured weight model for explainability.
