### PR TITLE
Redesign Profile taste clusters as an asymmetric mosaic grid

### DIFF
--- a/recommender/templates/index.html
+++ b/recommender/templates/index.html
@@ -169,7 +169,7 @@
         var extras = document.querySelectorAll('.mosaic-tile--extra');
         var moreTile = document.getElementById('cluster-more-tile');
         var expanded = moreTile.dataset.expanded === '1';
-        extras.forEach(function(t) { t.style.display = expanded ? 'none' : ''; });
+        extras.forEach(function(t) { t.style.display = expanded ? 'none' : 'flex'; });
         moreTile.dataset.expanded = expanded ? '0' : '1';
         var label = document.getElementById('cluster-more-label');
         label.textContent = expanded ? ('+ ' + extras.length + ' more clusters') : 'show fewer ↑';

--- a/recommender/templates/index.html
+++ b/recommender/templates/index.html
@@ -103,29 +103,79 @@
   </div>
 
   {% if clusters %}
-  <div style="display:flex; flex-direction:column; gap:6px;">
-    {% set colors = ['var(--accent)', 'var(--teal)', 'var(--lavender)', 'var(--accent2)'] %}
-    {% for cluster in clusters %}
-    {% set clr = colors[loop.index0 % 4] %}
-    <details class="cluster-details" style="background:var(--surface); border-radius:6px; overflow:hidden;">
-      <summary style="
-        display:flex; align-items:center; gap:0.75rem;
-        padding:1rem 1.25rem;
-        cursor:pointer; list-style:none; user-select:none;
-        border-left:3px solid {{ clr }};
-        transition:background 0.15s;
-      ">
-        <svg class="cluster-arrow" width="10" height="10" viewBox="0 0 10 10" style="flex-shrink:0; transition:transform 0.2s;">
-          <path d="M3 1 L7 5 L3 9" stroke="{{ clr }}" stroke-width="1.5" fill="none" stroke-linecap="round" stroke-linejoin="round"/>
-        </svg>
-        <span style="font-family:'DM Serif Display',serif; font-size:1rem; color:var(--text);">{{ cluster.heading }}</span>
-      </summary>
-      <div class="cluster-content" style="padding:0 1.25rem 1.25rem 2.75rem; border-left:3px solid {{ clr }};">
-        {{ cluster.body_html }}
+  {% set colors = ['c0', 'c1', 'c2', 'c3'] %}
+  <div class="mosaic-grid" id="cluster-grid">
+    {% for c in clusters %}
+    {% if not c.folded %}
+    <div class="mosaic-tile mosaic-tile--{{ c.tier }} mosaic-tile--{{ colors[loop.index0 % 4] }}" data-cluster-idx="{{ loop.index0 }}" onclick="toggleClusterPanel({{ loop.index0 }})">
+      <div class="mosaic-tile-count">{{ c.title_count }} titles</div>
+      <div class="mosaic-tile-heading">{{ c.heading }}</div>
+      {% if c.tier != 'small' %}<div class="mosaic-tile-tagline">{{ c.tagline }}</div>{% endif %}
+    </div>
+    {% endif %}
+    {% endfor %}
+
+    {% set folded_clusters = clusters | selectattr('folded') | list %}
+    {% if folded_clusters %}
+    <div class="mosaic-tile mosaic-tile--more" id="cluster-more-tile" onclick="toggleMoreClusters()">
+      <div class="mosaic-tile-heading" id="cluster-more-label">+ {{ folded_clusters | length }} more clusters</div>
+    </div>
+    {% for c in clusters %}
+    {% if c.folded %}
+    <div class="mosaic-tile mosaic-tile--small mosaic-tile--extra mosaic-tile--{{ colors[loop.index0 % 4] }}" data-cluster-idx="{{ loop.index0 }}" onclick="toggleClusterPanel({{ loop.index0 }})">
+      <div class="mosaic-tile-count">{{ c.title_count }} titles</div>
+      <div class="mosaic-tile-heading">{{ c.heading }}</div>
+    </div>
+    {% endif %}
+    {% endfor %}
+    {% endif %}
+  </div>
+
+  <div id="cluster-panels">
+    {% for c in clusters %}
+    <div class="cluster-panel" id="cluster-panel-{{ loop.index0 }}">
+      <button type="button" class="cluster-panel-close" onclick="closeClusterPanel()">close &times;</button>
+      <h3 class="cluster-panel-heading">{{ c.heading }}</h3>
+      <div class="cluster-panel-essay">{{ c.body_html }}</div>
+      <div class="cluster-panel-chips">
+        {% for t in c.titles %}<span class="chip">{{ t }}</span>{% endfor %}
       </div>
-    </details>
+    </div>
     {% endfor %}
   </div>
+
+  <script>
+    (function() {
+      var openIdx = null;
+      window.toggleClusterPanel = function(idx) {
+        var panel = document.getElementById('cluster-panel-' + idx);
+        if (!panel) return;
+        document.querySelectorAll('.cluster-panel.open').forEach(function(p) { p.classList.remove('open'); });
+        document.querySelectorAll('.mosaic-tile.active').forEach(function(t) { t.classList.remove('active'); });
+        if (openIdx === idx) {
+          openIdx = null;
+          return;
+        }
+        panel.classList.add('open');
+        document.querySelectorAll('.mosaic-tile[data-cluster-idx="' + idx + '"]').forEach(function(t) { t.classList.add('active'); });
+        openIdx = idx;
+      };
+      window.closeClusterPanel = function() {
+        document.querySelectorAll('.cluster-panel.open').forEach(function(p) { p.classList.remove('open'); });
+        document.querySelectorAll('.mosaic-tile.active').forEach(function(t) { t.classList.remove('active'); });
+        openIdx = null;
+      };
+      window.toggleMoreClusters = function() {
+        var extras = document.querySelectorAll('.mosaic-tile--extra');
+        var moreTile = document.getElementById('cluster-more-tile');
+        var expanded = moreTile.dataset.expanded === '1';
+        extras.forEach(function(t) { t.style.display = expanded ? 'none' : ''; });
+        moreTile.dataset.expanded = expanded ? '0' : '1';
+        var label = document.getElementById('cluster-more-label');
+        label.textContent = expanded ? ('+ ' + extras.length + ' more clusters') : 'show fewer ↑';
+      };
+    })();
+  </script>
   {% else %}
   <div style="padding:1.5rem; background:var(--surface); border-radius:6px; border-left:3px solid var(--accent);">
     <p style="font-size:0.9rem; color:var(--body); line-height:1.85; white-space:pre-wrap;">{{ taste_profile }}</p>
@@ -171,22 +221,124 @@
 </section>
 
 <style>
-  /* Details/summary native expand */
-  .cluster-details summary::-webkit-details-marker { display: none; }
-  .cluster-details summary::marker { content: ''; }
-  .cluster-details summary:hover { background: var(--surface2); }
-  .cluster-details[open] .cluster-arrow { transform: rotate(90deg); }
+  .mosaic-grid {
+    display: grid;
+    grid-template-columns: 1.3fr 1fr 1fr;
+    grid-auto-rows: 96px;
+    gap: 0.65rem;
+  }
+  @media (max-width: 720px) {
+    .mosaic-grid { grid-template-columns: 1fr; grid-auto-rows: auto; }
+    .mosaic-tile--big { grid-row: auto; }
+  }
 
-  /* Cluster body typography */
-  .cluster-content p {
-    font-size: 0.88rem;
+  .mosaic-tile {
+    border-radius: 8px;
+    padding: 0.9rem 1.05rem;
+    position: relative;
+    overflow: hidden;
+    display: flex;
+    flex-direction: column;
+    justify-content: flex-end;
+    cursor: pointer;
+    border: 1px solid rgba(255,255,255,0.06);
+    transition: box-shadow 0.15s, transform 0.15s;
+  }
+  .mosaic-tile:hover { transform: translateY(-2px); }
+  .mosaic-tile.active { box-shadow: 0 0 0 2px var(--teal); }
+  .mosaic-tile--big { grid-row: span 2; padding: 1.2rem 1.3rem; }
+  .mosaic-tile--extra { display: none; }
+  .mosaic-tile--more {
+    background: var(--surface);
+    border: 1px dashed var(--border);
+    align-items: center;
+    justify-content: center;
+  }
+
+  .mosaic-tile--c0 { background: linear-gradient(160deg, color-mix(in srgb, var(--accent) 26%, var(--surface)), var(--surface) 75%); }
+  .mosaic-tile--c1 { background: linear-gradient(160deg, color-mix(in srgb, var(--teal) 26%, var(--surface)), var(--surface) 75%); }
+  .mosaic-tile--c2 { background: linear-gradient(160deg, color-mix(in srgb, var(--lavender) 26%, var(--surface)), var(--surface) 75%); }
+  .mosaic-tile--c3 { background: linear-gradient(160deg, color-mix(in srgb, var(--accent2) 26%, var(--surface)), var(--surface) 75%); }
+
+  .mosaic-tile-heading {
+    font-family: 'DM Sans', sans-serif;
+    font-weight: 600;
+    font-size: 0.82rem;
+    color: var(--text);
+    line-height: 1.25;
+    margin-bottom: 0.25rem;
+  }
+  .mosaic-tile--big .mosaic-tile-heading { font-size: 1.05rem; }
+  .mosaic-tile--more .mosaic-tile-heading {
+    font-family: 'JetBrains Mono', monospace;
+    font-weight: 400;
+    font-size: 0.65rem;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    color: var(--muted);
+    margin: 0;
+    text-align: center;
+  }
+  .mosaic-tile-tagline {
+    font-family: 'DM Sans', sans-serif;
+    font-style: italic;
+    font-size: 0.68rem;
+    color: rgba(255,255,255,0.72);
+    line-height: 1.35;
+  }
+  .mosaic-tile-count {
+    position: absolute;
+    top: 0.65rem;
+    right: 0.8rem;
+    font-family: 'JetBrains Mono', monospace;
+    font-size: 0.56rem;
+    color: rgba(255,255,255,0.45);
+  }
+
+  .cluster-panel {
+    display: none;
+    background: var(--surface);
+    border-radius: 8px;
+    margin-top: 0.9rem;
+    padding: 1.3rem 1.5rem;
+  }
+  .cluster-panel.open { display: block; }
+  .cluster-panel-close {
+    font-family: 'JetBrains Mono', monospace;
+    font-size: 0.6rem;
+    color: var(--muted);
+    cursor: pointer;
+    float: right;
+    background: none;
+    border: none;
+  }
+  .cluster-panel-close:hover { color: var(--text); }
+  .cluster-panel-heading {
+    font-family: 'DM Serif Display', serif;
+    font-weight: 400;
+    font-size: 1.15rem;
+    color: var(--text);
+    margin-bottom: 0.8rem;
+    padding-right: 2rem;
+  }
+  .cluster-panel-essay p {
+    font-size: 0.86rem;
     color: var(--body);
     line-height: 1.85;
     margin: 0 0 0.75rem;
   }
-  .cluster-content p:last-child { margin-bottom: 0; }
-  .cluster-content strong { color: var(--text); font-weight: 500; }
-  .cluster-content em { color: var(--text); font-style: italic; }
+  .cluster-panel-essay p:last-child { margin-bottom: 1rem; }
+  .cluster-panel-essay strong { color: var(--text); font-weight: 500; }
+  .cluster-panel-essay em { color: var(--text); font-style: italic; }
+  .cluster-panel-chips { display: flex; flex-wrap: wrap; gap: 0.4rem; }
+  .cluster-panel-chips .chip {
+    font-family: 'JetBrains Mono', monospace;
+    font-size: 0.62rem;
+    padding: 3px 9px;
+    border: 1px solid var(--border);
+    border-radius: 20px;
+    color: var(--body);
+  }
 </style>
 
 {% endblock %}

--- a/recommender/templates/index.html
+++ b/recommender/templates/index.html
@@ -62,21 +62,6 @@
   </script>
 </section>
 
-{% if recent_queries %}
-<!-- ════════ RECENT SEARCHES ════════ -->
-<section style="margin-bottom:2.5rem;">
-  <div style="display:flex; align-items:baseline; justify-content:space-between; margin-bottom:0.6rem;">
-    <span class="mono" style="font-size:0.62rem; letter-spacing:0.12em; text-transform:uppercase; color:var(--muted);">Recent searches</span>
-    <a href="/searches" class="mono" style="font-size:0.58rem; color:var(--muted); text-decoration:none; transition:color 0.15s;" onmouseover="this.style.color='var(--accent)'" onmouseout="this.style.color='var(--muted)'">View all</a>
-  </div>
-  <div style="display:flex; flex-wrap:wrap; gap:0.4rem;">
-    {% for q in recent_queries %}
-    <a href="/searches#q-{{ loop.index }}" class="btn-ghost" style="padding:4px 12px; font-size:0.7rem; text-decoration:none;"{% if q.summary %} title="{{ q.summary }}"{% endif %}>{{ q.label or q.query }}</a>
-    {% endfor %}
-  </div>
-</section>
-{% endif %}
-
 <div style="height:1px; background:linear-gradient(90deg, var(--accent), var(--lavender), var(--teal)); margin-bottom:3.5rem; opacity:0.4;"></div>
 
 <!-- ════════ TASTE PROFILE ════════ -->
@@ -109,8 +94,10 @@
     {% if not c.folded %}
     <div class="mosaic-tile mosaic-tile--{{ c.tier }} mosaic-tile--{{ colors[loop.index0 % 4] }}" data-cluster-idx="{{ loop.index0 }}" onclick="toggleClusterPanel({{ loop.index0 }})">
       <div class="mosaic-tile-count">{{ c.title_count }} titles</div>
-      <div class="mosaic-tile-heading">{{ c.heading }}</div>
-      {% if c.tier != 'small' %}<div class="mosaic-tile-tagline">{{ c.tagline }}</div>{% endif %}
+      <div class="mosaic-tile-body">
+        <div class="mosaic-tile-heading">{{ c.heading }}</div>
+        {% if c.tier != 'small' %}<div class="mosaic-tile-tagline">{{ c.tagline }}</div>{% endif %}
+      </div>
     </div>
     {% endif %}
     {% endfor %}
@@ -124,7 +111,9 @@
     {% if c.folded %}
     <div class="mosaic-tile mosaic-tile--small mosaic-tile--extra mosaic-tile--{{ colors[loop.index0 % 4] }}" data-cluster-idx="{{ loop.index0 }}" onclick="toggleClusterPanel({{ loop.index0 }})">
       <div class="mosaic-tile-count">{{ c.title_count }} titles</div>
-      <div class="mosaic-tile-heading">{{ c.heading }}</div>
+      <div class="mosaic-tile-body">
+        <div class="mosaic-tile-heading">{{ c.heading }}</div>
+      </div>
     </div>
     {% endif %}
     {% endfor %}
@@ -224,22 +213,21 @@
   .mosaic-grid {
     display: grid;
     grid-template-columns: 1.3fr 1fr 1fr;
-    grid-auto-rows: 96px;
+    grid-auto-rows: minmax(96px, auto);
     gap: 0.65rem;
   }
   @media (max-width: 720px) {
     .mosaic-grid { grid-template-columns: 1fr; grid-auto-rows: auto; }
     .mosaic-tile--big { grid-row: auto; }
+    .mosaic-tile--more { grid-column: auto; }
   }
 
   .mosaic-tile {
     border-radius: 8px;
     padding: 0.9rem 1.05rem;
-    position: relative;
     overflow: hidden;
     display: flex;
     flex-direction: column;
-    justify-content: flex-end;
     cursor: pointer;
     border: 1px solid rgba(255,255,255,0.06);
     transition: box-shadow 0.15s, transform 0.15s;
@@ -249,6 +237,7 @@
   .mosaic-tile--big { grid-row: span 2; padding: 1.2rem 1.3rem; }
   .mosaic-tile--extra { display: none; }
   .mosaic-tile--more {
+    grid-column: 2;
     background: var(--surface);
     border: 1px dashed var(--border);
     align-items: center;
@@ -279,20 +268,20 @@
     margin: 0;
     text-align: center;
   }
+  .mosaic-tile-body { margin-top: auto; }
   .mosaic-tile-tagline {
     font-family: 'DM Sans', sans-serif;
     font-style: italic;
     font-size: 0.68rem;
-    color: rgba(255,255,255,0.72);
+    color: var(--body);
     line-height: 1.35;
   }
   .mosaic-tile-count {
-    position: absolute;
-    top: 0.65rem;
-    right: 0.8rem;
+    align-self: flex-end;
     font-family: 'JetBrains Mono', monospace;
     font-size: 0.56rem;
-    color: rgba(255,255,255,0.45);
+    color: var(--muted);
+    margin-bottom: 0.4rem;
   }
 
   .cluster-panel {

--- a/recommender/web.py
+++ b/recommender/web.py
@@ -259,6 +259,43 @@ def _load_enrichments() -> dict[str, str]:
     return {}
 
 
+_CLUSTER_TITLES_RE = re.compile(r'^\*\*\*(.+)\*\*\*\s*$', re.MULTILINE)
+
+
+def _split_cluster_titles(body: str) -> tuple[str, list[str]]:
+    """Split a cluster's raw markdown body into (essay_text, title_list).
+
+    The representative-title list is a single line wrapped in ``***...***``
+    with each title individually italicized inside it, e.g.
+    ``***Slow Horses*, *Luther*, *Broadchurch***``. Inline ``**bold**`` text
+    elsewhere in the essay does not match because it isn't a whole-line
+    ``***...***`` span.
+    """
+    match = _CLUSTER_TITLES_RE.search(body)
+    if not match:
+        return body.strip(), []
+    titles = [t.strip() for t in re.findall(r'\*([^*]+)\*', match.group(1)) if t.strip()]
+    essay = body[:match.start()] + body[match.end():]
+    return essay.strip(), titles
+
+
+def _strip_markdown_emphasis(text: str) -> str:
+    return re.sub(r'\*+', '', text)
+
+
+def _first_sentence(text: str, max_len: int = 80) -> str:
+    """Return the first sentence of text, truncated to max_len at a word boundary."""
+    text = _strip_markdown_emphasis(text).strip()
+    match = re.search(r'[.!?](?:\s|$)', text)
+    sentence = text[:match.end()].strip() if match else text
+    if len(sentence) <= max_len:
+        return sentence
+    truncated = sentence[:max_len].rsplit(' ', 1)[0].rstrip(' ,;:.')
+    if not truncated:
+        truncated = sentence[:max_len]
+    return truncated + '…'
+
+
 def _md_to_html(text: str) -> str:
     html = str(escape(text))
     html = re.sub(r'\*\*(.+?)\*\*', r'<strong>\1</strong>', html)

--- a/recommender/web.py
+++ b/recommender/web.py
@@ -476,7 +476,6 @@ def dashboard() -> str:
     _assign_cluster_tiers(clusters)
 
     posters = _get_recent_posters(entries, limit=30)
-    recent_queries = query_history.load(limit=5)
 
     return render_template(
         "index.html",
@@ -487,7 +486,6 @@ def dashboard() -> str:
         movie_count=movie_count,
         enrichment_count=len(enrichments),
         posters=posters,
-        recent_queries=recent_queries,
     )
 
 

--- a/recommender/web.py
+++ b/recommender/web.py
@@ -468,7 +468,12 @@ def dashboard() -> str:
         clusters.append(current_cluster)
 
     for c in clusters:
-        c["body_html"] = _md_to_html(c["body"].strip())
+        essay, titles = _split_cluster_titles(c["body"].strip())
+        c["titles"] = titles
+        c["title_count"] = len(titles)
+        c["tagline"] = _first_sentence(essay)
+        c["body_html"] = _md_to_html(essay)
+    _assign_cluster_tiers(clusters)
 
     posters = _get_recent_posters(entries, limit=30)
     recent_queries = query_history.load(limit=5)

--- a/recommender/web.py
+++ b/recommender/web.py
@@ -296,6 +296,24 @@ def _first_sentence(text: str, max_len: int = 80) -> str:
     return truncated + '…'
 
 
+def _assign_cluster_tiers(clusters: list[dict], visible_count: int = 5) -> None:
+    """Rank clusters by title_count (desc) and assign tier + fold state in place.
+
+    Rank 1 -> 'big', ranks 2-4 -> 'medium', rank 5+ -> 'small'.
+    Ranks beyond visible_count are marked folded=True (hidden behind "+more").
+    """
+    ranked = sorted(range(len(clusters)), key=lambda i: -clusters[i]["title_count"])
+    for rank, idx in enumerate(ranked, start=1):
+        c = clusters[idx]
+        if rank == 1:
+            c["tier"] = "big"
+        elif rank <= 4:
+            c["tier"] = "medium"
+        else:
+            c["tier"] = "small"
+        c["folded"] = rank > visible_count
+
+
 def _md_to_html(text: str) -> str:
     html = str(escape(text))
     html = re.sub(r'\*\*(.+?)\*\*', r'<strong>\1</strong>', html)

--- a/recommender/web.py
+++ b/recommender/web.py
@@ -259,7 +259,7 @@ def _load_enrichments() -> dict[str, str]:
     return {}
 
 
-_CLUSTER_TITLES_RE = re.compile(r'^\*\*\*(.+)\*\*\*\s*$', re.MULTILINE)
+_CLUSTER_TITLES_RE = re.compile(r'^\*\*\*(.+?)\*\*\*\s*$', re.MULTILINE)
 
 
 def _split_cluster_titles(body: str) -> tuple[str, list[str]]:
@@ -274,7 +274,7 @@ def _split_cluster_titles(body: str) -> tuple[str, list[str]]:
     match = _CLUSTER_TITLES_RE.search(body)
     if not match:
         return body.strip(), []
-    titles = [t.strip() for t in re.findall(r'\*([^*]+)\*', match.group(1)) if t.strip()]
+    titles = [t.strip() for t in re.findall(r'([^*,]+)(?:\*|$)', match.group(1)) if t.strip()]
     essay = body[:match.start()] + body[match.end():]
     return essay.strip(), titles
 

--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -57,6 +57,34 @@ class TestFirstSentence:
         assert web._first_sentence(text, max_len=80) == "No period at the end"
 
 
+class TestAssignClusterTiers:
+    def _clusters(self, counts):
+        return [{"title_count": c} for c in counts]
+
+    def test_top_rank_is_big_next_three_medium_fifth_small_visible(self):
+        clusters = self._clusters([26, 26, 26, 23, 23, 20, 19])
+        web._assign_cluster_tiers(clusters)
+        tiers = [c["tier"] for c in clusters]
+        folded = [c["folded"] for c in clusters]
+        assert tiers[0] == "big"
+        assert tiers[1:4] == ["medium", "medium", "medium"]
+        assert tiers[4] == "small"
+        assert folded[4] is False
+        assert tiers[5:] == ["small", "small"]
+        assert folded[5:] == [True, True]
+
+    def test_fewer_than_visible_count_none_folded(self):
+        clusters = self._clusters([26, 23, 20])
+        web._assign_cluster_tiers(clusters)
+        assert all(c["folded"] is False for c in clusters)
+        assert [c["tier"] for c in clusters] == ["big", "medium", "medium"]
+
+    def test_custom_visible_count(self):
+        clusters = self._clusters([10, 9, 8, 7, 6, 5])
+        web._assign_cluster_tiers(clusters, visible_count=2)
+        assert [c["folded"] for c in clusters] == [False, False, True, True, True, True]
+
+
 @pytest.fixture
 def client():
     app.config["TESTING"] = True

--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -10,6 +10,53 @@ from recommender.jobs import Job, JobRegistry
 from recommender.web import app
 
 
+class TestSplitClusterTitles:
+    def test_extracts_titles_and_strips_line_from_essay(self):
+        body = (
+            "You gravitate toward British crime television with a consistency "
+            "that makes it your single most reliable viewing pattern.\n\n"
+            "*** *Slow Horses*, *Luther*, *Broadchurch* ***\n"
+        )
+        essay, titles = web._split_cluster_titles(body)
+        assert titles == ["Slow Horses", "Luther", "Broadchurch"]
+        assert "***" not in essay
+        assert "Slow Horses" not in essay
+        assert essay.startswith("You gravitate toward British crime television")
+
+    def test_no_title_line_returns_empty_list(self):
+        body = "Just a paragraph with no title list at all."
+        essay, titles = web._split_cluster_titles(body)
+        assert titles == []
+        assert essay == body
+
+    def test_ignores_inline_bold_that_is_not_a_title_line(self):
+        body = "This has **bold text** mid-sentence but no title list.\n"
+        essay, titles = web._split_cluster_titles(body)
+        assert titles == []
+        assert "**bold text**" in essay
+
+
+class TestFirstSentence:
+    def test_returns_first_sentence_only(self):
+        text = "Short sentence here. More text after that is ignored."
+        assert web._first_sentence(text) == "Short sentence here."
+
+    def test_strips_markdown_emphasis(self):
+        text = "*Emphasis* word here. Rest of paragraph."
+        assert web._first_sentence(text) == "Emphasis word here."
+
+    def test_truncates_long_sentence_at_word_boundary(self):
+        text = "This is a very long single sentence with no punctuation break at all so it must be truncated somewhere in the middle of it"
+        result = web._first_sentence(text, max_len=40)
+        assert len(result) <= 41  # 40 + ellipsis char
+        assert result.endswith("…")
+        assert not result[:-1].endswith(" ")
+
+    def test_short_text_without_terminal_punctuation_returned_whole(self):
+        text = "No period at the end"
+        assert web._first_sentence(text, max_len=80) == "No period at the end"
+
+
 @pytest.fixture
 def client():
     app.config["TESTING"] = True

--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -1287,3 +1287,35 @@ class TestHistoryTmdbOverview:
 
         from recommender.web import _get_tmdb_overview
         assert _get_tmdb_overview(88888, "tv") is None
+
+
+class TestDashboardClusterMosaicData:
+    SAMPLE_PROFILE = (
+        "# Consolidated Taste Profile\n\n---\n"
+        "## 1. British Crime Drama & Psychological Procedural\n\n"
+        "You gravitate toward British crime television with a consistency "
+        "that makes it your single most reliable viewing pattern.\n\n"
+        "***Slow Horses*, *Luther*, *Broadchurch*, *Hinterland*, *Happy Valley***\n\n"
+        "---\n"
+        "## 2. Indie Dramedy\n\n"
+        "You maintain a consistent appetite for quiet character cinema.\n\n"
+        "***Columbus*, *Gloria Bell***\n"
+    )
+
+    @patch("recommender.web._load_enrichments", return_value={})
+    @patch("recommender.web._get_context")
+    def test_dashboard_clusters_have_mosaic_fields(self, mock_ctx, _mock_enrichments, client):
+        mock_ctx.return_value = MagicMock(
+            taste_profile=self.SAMPLE_PROFILE,
+            watch_index=MagicMock(entries=[]),
+        )
+        with patch("recommender.web.query_history.load", return_value=[]):
+            resp = client.get("/")
+
+        assert resp.status_code == 200
+        html = resp.data.decode()
+        assert "mosaic-grid" in html
+        assert "British Crime Drama" in html
+        assert "5 titles" in html   # cluster 1 has 5 representative titles
+        assert "2 titles" in html   # cluster 2 has 2 representative titles
+        assert "Slow Horses" not in html.split('id="cluster-panels"')[0]  # chips only in panels, not tiles

--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -15,7 +15,7 @@ class TestSplitClusterTitles:
         body = (
             "You gravitate toward British crime television with a consistency "
             "that makes it your single most reliable viewing pattern.\n\n"
-            "*** *Slow Horses*, *Luther*, *Broadchurch* ***\n"
+            "***Slow Horses*, *Luther*, *Broadchurch***\n"
         )
         essay, titles = web._split_cluster_titles(body)
         assert titles == ["Slow Horses", "Luther", "Broadchurch"]


### PR DESCRIPTION
## Summary
- Replace the plain accordion-style Profile cluster list with an asymmetric mosaic grid (1 big + 3 medium + small tiles + a fold for the rest), matching the approved design spec.
- Clicking a tile opens a detail panel below the grid with the full essay and title chips; only one panel is open at a time.
- "+N more clusters" reveals/hides the remaining small tiles in place.
- Removed the "Recent searches" dashboard section.
- Fixed two visual bugs found via live browser testing: heading text overlapping the title-count badge on multi-line headings, and an oversized "+more" tile.

## Test plan
- [x] `pytest tests/test_web.py` — 62/62 passing
- [x] Full suite — 562/562 passing (prior to latest fix; web subset re-verified after)
- [x] Playwright verification: tile tier counts, panel open/close/switch behavior, full essay shown on first click (no secondary reveal), fold/unfold of extra tiles, mobile (<720px) single-column collapse
- [x] Live screenshot verification of overlap fix and "+more" tile sizing