### PR TITLE
Add guided disambiguation modal for manual title add

### DIFF
--- a/recommender/templates/_archive_disambiguate.html
+++ b/recommender/templates/_archive_disambiguate.html
@@ -37,7 +37,9 @@
                 </div>
                 {% if c.conflict %}
                   <div class="mono conflict-badge">
-                    {% if c.conflict.source == 'watchlist' %}Already on your watchlist{% else %}Already in your archive{% endif %}
+                    {% if c.conflict.source == 'watchlist' %}Already on your watchlist
+                    {% elif c.conflict.source == 'watched' %}Already in your watch history
+                    {% else %}Already in your archive{% endif %}
                   </div>
                 {% endif %}
               </div>
@@ -59,7 +61,9 @@
                     <input type="hidden" name="title" value="{{ c.title }}">
                     <input type="hidden" name="resolution" value="add">
                     <button type="submit" class="btn-primary" style="padding:0.35rem 0.75rem; font-size:0.7rem;">
-                      {{ 'Update watched date' if c.conflict and c.conflict.source == 'archive' else 'Add' }}
+                      {% if c.conflict and c.conflict.source == 'archive' %}Update watched date
+                      {% elif c.conflict and c.conflict.source == 'watched' %}Add anyway
+                      {% else %}Add{% endif %}
                     </button>
                   </form>
                 {% endif %}

--- a/recommender/templates/_archive_disambiguate.html
+++ b/recommender/templates/_archive_disambiguate.html
@@ -6,92 +6,99 @@
         onclick="document.getElementById('archive-modal').innerHTML=''">&times;</button>
     </div>
 
-    {% if api_key_missing %}
-      <p class="mono" style="color:var(--muted); font-size:0.75rem;">
-        TMDB lookup is disabled (no API key configured). You can still save the title without a TMDB match.
-      </p>
-    {% elif both_failed %}
-      <p class="mono" style="color:var(--muted); font-size:0.75rem;">
-        TMDB lookup failed. Check your connection and try again, or save without a match.
-      </p>
-    {% else %}
-      {% if hinted_type_failed or alternate_type_failed %}
-        <p class="mono" style="color:var(--muted); font-size:0.7rem;">
-          Note: the {{ 'primary' if hinted_type_failed else 'alternate' }} search failed; results may be incomplete.
+    <div class="modal-scroll">
+      {% if api_key_missing %}
+        <p class="mono" style="color:var(--muted); font-size:0.75rem;">
+          TMDB lookup is disabled (no API key configured). You can still save the title without a TMDB match.
         </p>
-      {% endif %}
-
-      {% if candidates %}
-        <div class="candidate-list">
-          {% for c in candidates %}
-            <div class="candidate-card">
-              {% if c.poster_path %}
-                <img src="https://image.tmdb.org/t/p/w92{{ c.poster_path }}" alt="" class="candidate-poster">
-              {% else %}
-                <div class="candidate-poster candidate-poster--empty"></div>
-              {% endif %}
-              <div class="candidate-info">
-                <div class="mono" style="font-size:0.8rem;">{{ c.title }}{% if c.year %} ({{ c.year }}){% endif %}</div>
-                <div class="mono" style="font-size:0.65rem; color:var(--muted); text-transform:uppercase;">
-                  {{ 'TV' if c.content_type == 'tv' else 'Film' }}
-                </div>
-                {% if c.conflict %}
-                  <div class="mono conflict-badge">
-                    {% if c.conflict.source == 'watchlist' %}Already on your watchlist
-                    {% elif c.conflict.source == 'watched' %}Already in your watch history
-                    {% else %}Already in your archive{% endif %}
-                  </div>
-                {% endif %}
-              </div>
-              <div class="candidate-actions">
-                {% if c.conflict and c.conflict.source == 'watchlist' %}
-                  <form hx-post="/archive/confirm" hx-target="#archive-modal" hx-swap="innerHTML" style="margin:0;">
-                    <input type="hidden" name="_csrf_token" value="{{ csrf_token }}">
-                    <input type="hidden" name="tmdb_id" value="{{ c.tmdb_id }}">
-                    <input type="hidden" name="content_type" value="{{ c.content_type }}">
-                    <input type="hidden" name="title" value="{{ c.title }}">
-                    <input type="hidden" name="resolution" value="mark_watched">
-                    <button type="submit" class="btn-primary" style="padding:0.35rem 0.75rem; font-size:0.7rem;">Mark as watched</button>
-                  </form>
-                {% else %}
-                  <form hx-post="/archive/confirm" hx-target="#archive-modal" hx-swap="innerHTML" style="margin:0;">
-                    <input type="hidden" name="_csrf_token" value="{{ csrf_token }}">
-                    <input type="hidden" name="tmdb_id" value="{{ c.tmdb_id }}">
-                    <input type="hidden" name="content_type" value="{{ c.content_type }}">
-                    <input type="hidden" name="title" value="{{ c.title }}">
-                    <input type="hidden" name="resolution" value="add">
-                    <button type="submit" class="btn-primary" style="padding:0.35rem 0.75rem; font-size:0.7rem;">
-                      {% if c.conflict and c.conflict.source == 'archive' %}Update watched date
-                      {% elif c.conflict and c.conflict.source == 'watched' %}Add anyway
-                      {% else %}Add{% endif %}
-                    </button>
-                  </form>
-                {% endif %}
-              </div>
-            </div>
-          {% endfor %}
-        </div>
+      {% elif both_failed %}
+        <p class="mono" style="color:var(--muted); font-size:0.75rem;">
+          TMDB lookup failed. Check your connection and try again, or save without a match.
+        </p>
       {% else %}
-        <p class="mono" style="color:var(--muted); font-size:0.75rem;">No matches found for &quot;{{ title }}&quot;.</p>
+        {% if hinted_type_failed or alternate_type_failed %}
+          <p class="mono" style="color:var(--muted); font-size:0.7rem;">
+            Note: the {{ 'primary' if hinted_type_failed else 'alternate' }} search failed; results may be incomplete.
+          </p>
+        {% endif %}
+
+        {% if candidates %}
+          <div class="candidate-list">
+            {% for c in candidates %}
+              <div class="candidate-card">
+                {% if c.poster_path %}
+                  <img src="https://image.tmdb.org/t/p/w92{{ c.poster_path }}" alt="" class="candidate-poster">
+                {% else %}
+                  <div class="candidate-poster candidate-poster--empty"></div>
+                {% endif %}
+                <div class="candidate-info">
+                  <div class="mono" style="font-size:0.8rem;">{{ c.title }}{% if c.year %} ({{ c.year }}){% endif %}</div>
+                  <div class="mono" style="font-size:0.65rem; color:var(--muted); text-transform:uppercase;">
+                    {{ 'TV' if c.content_type == 'tv' else 'Film' }}
+                  </div>
+                  {% if c.conflict %}
+                    <div class="mono conflict-badge">
+                      {% if c.conflict.source == 'watchlist' %}Already on your watchlist
+                      {% elif c.conflict.source == 'watched' %}Already in your watch history
+                      {% else %}Already in your archive{% endif %}
+                    </div>
+                  {% endif %}
+                </div>
+                <div class="candidate-actions">
+                  {% if c.conflict and c.conflict.source == 'watchlist' %}
+                    <form hx-post="/archive/confirm" hx-target="#archive-modal" hx-swap="innerHTML" style="margin:0;">
+                      <input type="hidden" name="_csrf_token" value="{{ csrf_token }}">
+                      <input type="hidden" name="tmdb_id" value="{{ c.tmdb_id }}">
+                      <input type="hidden" name="content_type" value="{{ c.content_type }}">
+                      <input type="hidden" name="title" value="{{ c.title }}">
+                      <input type="hidden" name="resolution" value="mark_watched">
+                      <button type="submit" class="{{ 'btn-primary' if loop.first else 'btn-ghost' }}" style="padding:0.35rem 0.75rem; font-size:0.7rem;">Mark as watched</button>
+                    </form>
+                  {% else %}
+                    <form hx-post="/archive/confirm" hx-target="#archive-modal" hx-swap="innerHTML" style="margin:0;">
+                      <input type="hidden" name="_csrf_token" value="{{ csrf_token }}">
+                      <input type="hidden" name="tmdb_id" value="{{ c.tmdb_id }}">
+                      <input type="hidden" name="content_type" value="{{ c.content_type }}">
+                      <input type="hidden" name="title" value="{{ c.title }}">
+                      <input type="hidden" name="resolution" value="add">
+                      <button type="submit" class="{{ 'btn-primary' if loop.first else 'btn-ghost' }}" style="padding:0.35rem 0.75rem; font-size:0.7rem;">
+                        {% if c.conflict and c.conflict.source == 'archive' %}Update watched date
+                        {% elif c.conflict and c.conflict.source == 'watched' %}Add anyway
+                        {% else %}Add{% endif %}
+                      </button>
+                    </form>
+                  {% endif %}
+                </div>
+              </div>
+            {% endfor %}
+          </div>
+        {% else %}
+          <p class="mono" style="color:var(--muted); font-size:0.75rem;">No matches found for &quot;{{ title }}&quot;.</p>
+        {% endif %}
+      {% endif %}
+      <div class="modal-scroll-fade"></div>
+    </div>
+
+    <div class="modal-footer">
+      {% if not api_key_missing and not both_failed %}
+        <form hx-post="/archive/resolve" hx-target="#archive-modal" hx-swap="innerHTML" class="retry-form">
+          <input type="hidden" name="_csrf_token" value="{{ csrf_token }}">
+          <input type="text" name="title" value="{{ title }}" class="input-field" style="padding:0.4rem 0.6rem; font-size:0.75rem;">
+          <select name="content_type" class="input-field mono" style="padding:0.4rem 0.6rem; font-size:0.65rem;">
+            <option value="tv" {% if content_type == 'tv' %}selected{% endif %}>TV</option>
+            <option value="movie" {% if content_type == 'movie' %}selected{% endif %}>Film</option>
+          </select>
+          <button type="submit" class="btn-ghost" style="padding:0.4rem 0.75rem; font-size:0.7rem;">Search again</button>
+        </form>
       {% endif %}
 
-      <form hx-post="/archive/resolve" hx-target="#archive-modal" hx-swap="innerHTML" class="retry-form">
+      <form hx-post="/archive/confirm" hx-target="#archive-modal" hx-swap="innerHTML" class="unmatched-form">
         <input type="hidden" name="_csrf_token" value="{{ csrf_token }}">
-        <input type="text" name="title" value="{{ title }}" class="input-field" style="padding:0.4rem 0.6rem; font-size:0.75rem;">
-        <select name="content_type" class="input-field mono" style="padding:0.4rem 0.6rem; font-size:0.65rem;">
-          <option value="tv" {% if content_type == 'tv' %}selected{% endif %}>TV</option>
-          <option value="movie" {% if content_type == 'movie' %}selected{% endif %}>Film</option>
-        </select>
-        <button type="submit" class="btn-ghost" style="padding:0.4rem 0.75rem; font-size:0.7rem;">Search again</button>
+        <input type="hidden" name="title" value="{{ title }}">
+        <input type="hidden" name="content_type" value="{{ content_type }}">
+        <input type="hidden" name="resolution" value="unmatched">
+        <button type="submit" class="btn-ghost" style="padding:0.4rem 0.75rem; font-size:0.7rem;">None of these — save as unmatched</button>
       </form>
-    {% endif %}
-
-    <form hx-post="/archive/confirm" hx-target="#archive-modal" hx-swap="innerHTML" class="unmatched-form">
-      <input type="hidden" name="_csrf_token" value="{{ csrf_token }}">
-      <input type="hidden" name="title" value="{{ title }}">
-      <input type="hidden" name="content_type" value="{{ content_type }}">
-      <input type="hidden" name="resolution" value="unmatched">
-      <button type="submit" class="btn-ghost" style="padding:0.4rem 0.75rem; font-size:0.7rem;">None of these — save as unmatched</button>
-    </form>
+    </div>
   </div>
 </div>

--- a/recommender/templates/_archive_disambiguate.html
+++ b/recommender/templates/_archive_disambiguate.html
@@ -1,0 +1,92 @@
+<div class="modal-overlay">
+  <div class="modal-box">
+    <div class="modal-header">
+      <span class="mono" style="font-size:0.85rem;">Confirm: {{ title }}</span>
+      <button type="button" class="btn-ghost modal-close"
+        onclick="document.getElementById('archive-modal').innerHTML=''">&times;</button>
+    </div>
+
+    {% if api_key_missing %}
+      <p class="mono" style="color:var(--muted); font-size:0.75rem;">
+        TMDB lookup is disabled (no API key configured). You can still save the title without a TMDB match.
+      </p>
+    {% elif both_failed %}
+      <p class="mono" style="color:var(--muted); font-size:0.75rem;">
+        TMDB lookup failed. Check your connection and try again, or save without a match.
+      </p>
+    {% else %}
+      {% if hinted_type_failed or alternate_type_failed %}
+        <p class="mono" style="color:var(--muted); font-size:0.7rem;">
+          Note: the {{ 'primary' if hinted_type_failed else 'alternate' }} search failed; results may be incomplete.
+        </p>
+      {% endif %}
+
+      {% if candidates %}
+        <div class="candidate-list">
+          {% for c in candidates %}
+            <div class="candidate-card">
+              {% if c.poster_path %}
+                <img src="https://image.tmdb.org/t/p/w92{{ c.poster_path }}" alt="" class="candidate-poster">
+              {% else %}
+                <div class="candidate-poster candidate-poster--empty"></div>
+              {% endif %}
+              <div class="candidate-info">
+                <div class="mono" style="font-size:0.8rem;">{{ c.title }}{% if c.year %} ({{ c.year }}){% endif %}</div>
+                <div class="mono" style="font-size:0.65rem; color:var(--muted); text-transform:uppercase;">
+                  {{ 'TV' if c.content_type == 'tv' else 'Film' }}
+                </div>
+                {% if c.conflict %}
+                  <div class="mono conflict-badge">
+                    {% if c.conflict.source == 'watchlist' %}Already on your watchlist{% else %}Already in your archive{% endif %}
+                  </div>
+                {% endif %}
+              </div>
+              <div class="candidate-actions">
+                <form hx-post="/archive/confirm" hx-target="#archive-modal" hx-swap="innerHTML" style="margin:0;">
+                  <input type="hidden" name="_csrf_token" value="{{ csrf_token }}">
+                  <input type="hidden" name="tmdb_id" value="{{ c.tmdb_id }}">
+                  <input type="hidden" name="content_type" value="{{ c.content_type }}">
+                  <input type="hidden" name="title" value="{{ c.title }}">
+                  <input type="hidden" name="resolution" value="add">
+                  <button type="submit" class="btn-primary" style="padding:0.35rem 0.75rem; font-size:0.7rem;">
+                    {{ 'Update watched date' if c.conflict and c.conflict.source == 'archive' else 'Add' }}
+                  </button>
+                </form>
+                {% if c.conflict and c.conflict.source == 'watchlist' %}
+                  <form hx-post="/archive/confirm" hx-target="#archive-modal" hx-swap="innerHTML" style="margin:0;">
+                    <input type="hidden" name="_csrf_token" value="{{ csrf_token }}">
+                    <input type="hidden" name="tmdb_id" value="{{ c.tmdb_id }}">
+                    <input type="hidden" name="content_type" value="{{ c.content_type }}">
+                    <input type="hidden" name="title" value="{{ c.title }}">
+                    <input type="hidden" name="resolution" value="mark_watched">
+                    <button type="submit" class="btn-ghost" style="padding:0.35rem 0.75rem; font-size:0.7rem;">Mark as watched</button>
+                  </form>
+                {% endif %}
+              </div>
+            </div>
+          {% endfor %}
+        </div>
+      {% else %}
+        <p class="mono" style="color:var(--muted); font-size:0.75rem;">No matches found for &quot;{{ title }}&quot;.</p>
+      {% endif %}
+
+      <form hx-post="/archive/resolve" hx-target="#archive-modal" hx-swap="innerHTML" class="retry-form">
+        <input type="hidden" name="_csrf_token" value="{{ csrf_token }}">
+        <input type="text" name="title" value="{{ title }}" class="input-field" style="padding:0.4rem 0.6rem; font-size:0.75rem;">
+        <select name="content_type" class="input-field mono" style="padding:0.4rem 0.6rem; font-size:0.65rem;">
+          <option value="tv" {% if content_type == 'tv' %}selected{% endif %}>TV</option>
+          <option value="movie" {% if content_type == 'movie' %}selected{% endif %}>Film</option>
+        </select>
+        <button type="submit" class="btn-ghost" style="padding:0.4rem 0.75rem; font-size:0.7rem;">Search again</button>
+      </form>
+    {% endif %}
+
+    <form hx-post="/archive/confirm" hx-target="#archive-modal" hx-swap="innerHTML" class="unmatched-form">
+      <input type="hidden" name="_csrf_token" value="{{ csrf_token }}">
+      <input type="hidden" name="title" value="{{ title }}">
+      <input type="hidden" name="content_type" value="{{ content_type }}">
+      <input type="hidden" name="resolution" value="unmatched">
+      <button type="submit" class="btn-ghost" style="padding:0.4rem 0.75rem; font-size:0.7rem;">None of these — save as unmatched</button>
+    </form>
+  </div>
+</div>

--- a/recommender/templates/_archive_disambiguate.html
+++ b/recommender/templates/_archive_disambiguate.html
@@ -42,16 +42,6 @@
                 {% endif %}
               </div>
               <div class="candidate-actions">
-                <form hx-post="/archive/confirm" hx-target="#archive-modal" hx-swap="innerHTML" style="margin:0;">
-                  <input type="hidden" name="_csrf_token" value="{{ csrf_token }}">
-                  <input type="hidden" name="tmdb_id" value="{{ c.tmdb_id }}">
-                  <input type="hidden" name="content_type" value="{{ c.content_type }}">
-                  <input type="hidden" name="title" value="{{ c.title }}">
-                  <input type="hidden" name="resolution" value="add">
-                  <button type="submit" class="btn-primary" style="padding:0.35rem 0.75rem; font-size:0.7rem;">
-                    {{ 'Update watched date' if c.conflict and c.conflict.source == 'archive' else 'Add' }}
-                  </button>
-                </form>
                 {% if c.conflict and c.conflict.source == 'watchlist' %}
                   <form hx-post="/archive/confirm" hx-target="#archive-modal" hx-swap="innerHTML" style="margin:0;">
                     <input type="hidden" name="_csrf_token" value="{{ csrf_token }}">
@@ -59,7 +49,18 @@
                     <input type="hidden" name="content_type" value="{{ c.content_type }}">
                     <input type="hidden" name="title" value="{{ c.title }}">
                     <input type="hidden" name="resolution" value="mark_watched">
-                    <button type="submit" class="btn-ghost" style="padding:0.35rem 0.75rem; font-size:0.7rem;">Mark as watched</button>
+                    <button type="submit" class="btn-primary" style="padding:0.35rem 0.75rem; font-size:0.7rem;">Mark as watched</button>
+                  </form>
+                {% else %}
+                  <form hx-post="/archive/confirm" hx-target="#archive-modal" hx-swap="innerHTML" style="margin:0;">
+                    <input type="hidden" name="_csrf_token" value="{{ csrf_token }}">
+                    <input type="hidden" name="tmdb_id" value="{{ c.tmdb_id }}">
+                    <input type="hidden" name="content_type" value="{{ c.content_type }}">
+                    <input type="hidden" name="title" value="{{ c.title }}">
+                    <input type="hidden" name="resolution" value="add">
+                    <button type="submit" class="btn-primary" style="padding:0.35rem 0.75rem; font-size:0.7rem;">
+                      {{ 'Update watched date' if c.conflict and c.conflict.source == 'archive' else 'Add' }}
+                    </button>
                   </form>
                 {% endif %}
               </div>

--- a/recommender/templates/base.html
+++ b/recommender/templates/base.html
@@ -171,6 +171,32 @@
     }
     .btn-ghost:hover { border-color: var(--accent); color: var(--text); text-decoration: none; }
 
+    .modal-overlay {
+      position: fixed; inset: 0; background: rgba(0,0,0,0.6);
+      display: flex; align-items: center; justify-content: center;
+      z-index: 1000;
+    }
+    .modal-box {
+      background: var(--surface); border: 1px solid var(--border); border-radius: 8px;
+      padding: 1.25rem; max-width: 480px; width: 90%; max-height: 80vh; overflow-y: auto;
+    }
+    .modal-header {
+      display: flex; justify-content: space-between; align-items: center; margin-bottom: 0.75rem;
+    }
+    .modal-close { font-size: 1.1rem; line-height: 1; padding: 0.2rem 0.5rem; }
+    .candidate-list { display: flex; flex-direction: column; gap: 0.5rem; margin: 0.5rem 0; }
+    .candidate-card {
+      display: flex; gap: 0.6rem; align-items: center; padding: 0.5rem;
+      border: 1px solid var(--border); border-radius: 6px;
+    }
+    .candidate-poster { width: 40px; height: 60px; object-fit: cover; border-radius: 3px; flex-shrink: 0; }
+    .candidate-poster--empty { background: var(--surface2); }
+    .candidate-info { flex: 1; min-width: 0; }
+    .conflict-badge { color: var(--accent2); font-size: 0.6rem; margin-top: 0.15rem; }
+    .candidate-actions { display: flex; flex-direction: column; gap: 0.3rem; }
+    .retry-form { display: flex; gap: 0.4rem; margin-top: 0.75rem; flex-wrap: wrap; }
+    .unmatched-form { margin-top: 0.5rem; }
+
     /* Thumb rating buttons */
     .btn-thumb {
       background: none;

--- a/recommender/templates/base.html
+++ b/recommender/templates/base.html
@@ -171,6 +171,23 @@
     }
     .btn-ghost:hover { border-color: var(--accent); color: var(--text); text-decoration: none; }
 
+    .btn-teal {
+      background: transparent;
+      border: 1px solid var(--teal);
+      color: var(--teal);
+      font-family: 'JetBrains Mono', monospace;
+      font-size: 0.7rem;
+      letter-spacing: 0.08em;
+      text-transform: uppercase;
+      font-weight: 500;
+      border-radius: 4px;
+      cursor: pointer;
+      transition: background 0.15s, color 0.15s, transform 0.1s;
+    }
+    .btn-teal:hover { background: rgba(58,184,160,0.12); transform: translateY(-1px); }
+    .btn-teal.is-active { background: var(--teal); color: var(--bg); }
+    .btn-teal.is-active:hover { opacity: 0.9; transform: none; }
+
     .modal-overlay {
       position: fixed; inset: 0; background: rgba(0,0,0,0.6);
       display: flex; align-items: center; justify-content: center;
@@ -178,12 +195,21 @@
     }
     .modal-box {
       background: var(--surface); border: 1px solid var(--border); border-radius: 8px;
-      padding: 1.25rem; max-width: 480px; width: 90%; max-height: 80vh; overflow-y: auto;
+      padding: 1.25rem; max-width: 480px; width: 90%; max-height: 80vh;
+      display: flex; flex-direction: column;
     }
     .modal-header {
       display: flex; justify-content: space-between; align-items: center; margin-bottom: 0.75rem;
+      flex-shrink: 0;
     }
     .modal-close { font-size: 1.1rem; line-height: 1; padding: 0.2rem 0.5rem; }
+    .modal-scroll { flex: 1 1 auto; min-height: 0; overflow-y: auto; }
+    .modal-scroll-fade {
+      position: sticky; bottom: 0; left: 0; right: 0; height: 18px; margin-top: -18px;
+      background: linear-gradient(to bottom, transparent, var(--surface));
+      pointer-events: none;
+    }
+    .modal-footer { flex-shrink: 0; }
     .candidate-list { display: flex; flex-direction: column; gap: 0.5rem; margin: 0.5rem 0; }
     .candidate-card {
       display: flex; gap: 0.6rem; align-items: center; padding: 0.5rem;
@@ -192,7 +218,7 @@
     .candidate-poster { width: 40px; height: 60px; object-fit: cover; border-radius: 3px; flex-shrink: 0; }
     .candidate-poster--empty { background: var(--surface2); }
     .candidate-info { flex: 1; min-width: 0; }
-    .conflict-badge { color: var(--accent2); font-size: 0.6rem; margin-top: 0.15rem; }
+    .conflict-badge { color: var(--teal); font-size: 0.6rem; margin-top: 0.15rem; }
     .candidate-actions { display: flex; flex-direction: column; gap: 0.3rem; }
     .retry-form { display: flex; gap: 0.4rem; margin-top: 0.75rem; flex-wrap: wrap; }
     .unmatched-form { margin-top: 0.5rem; }

--- a/recommender/templates/history.html
+++ b/recommender/templates/history.html
@@ -50,7 +50,7 @@
 
   <!-- Collapsible Add Title form -->
   <div id="add-form-wrapper" style="display:none; margin-top:0.5rem; padding:0.75rem 1rem; background:var(--surface); border:1px solid var(--border); border-radius:6px;">
-    <form hx-post="/archive/add" hx-target="#add-result" hx-swap="innerHTML" style="display:flex; gap:0.5rem; align-items:center; flex-wrap:wrap;">
+    <form hx-post="/archive/resolve" hx-target="#archive-modal" hx-swap="innerHTML" style="display:flex; gap:0.5rem; align-items:center; flex-wrap:wrap;">
       <input type="hidden" name="_csrf_token" value="{{ csrf_token }}">
       <input type="text" name="title" placeholder="Title you watched..." id="add-title-input"
         class="input-field" style="padding:0.5rem 0.75rem; flex:1; min-width:180px;">
@@ -60,8 +60,8 @@
       </select>
       <button type="submit" class="btn-primary" style="padding:0.5rem 1rem;">Add</button>
       <button type="button" onclick="toggleAddForm()" class="btn-ghost" style="padding:0.5rem 0.75rem;">Cancel</button>
-      <span id="add-result" style="display:inline;"></span>
     </form>
+    <div id="archive-modal"></div>
   </div>
 
   <div style="display:flex; align-items:center; justify-content:space-between; margin-top:0.75rem;">

--- a/recommender/templates/history.html
+++ b/recommender/templates/history.html
@@ -3,8 +3,13 @@
 {% block content %}
 
 <div style="margin-bottom:2rem;">
-  <span class="mono" style="font-size:0.62rem; letter-spacing:0.12em; text-transform:uppercase; color:var(--teal);">Collection</span>
-  <h1 style="font-size:clamp(2rem, 4.5vw, 3rem); margin-top:0.2rem; margin-bottom:1.25rem;">Archive</h1>
+  <div style="display:flex; align-items:flex-end; justify-content:space-between; flex-wrap:wrap; gap:0.75rem; margin-bottom:1.25rem;">
+    <div>
+      <span class="mono" style="font-size:0.62rem; letter-spacing:0.12em; text-transform:uppercase; color:var(--teal);">Collection</span>
+      <h1 style="font-size:clamp(2rem, 4.5vw, 3rem); margin-top:0.2rem;">Archive</h1>
+    </div>
+    <button type="button" id="add-toggle" onclick="toggleAddForm()" class="btn-teal" style="padding:0.6rem 1rem; margin-bottom:0.35rem;">+ Add Watched</button>
+  </div>
 
   <!-- Filter row -->
   <form method="get" action="/history" id="filter-form" style="display:flex; gap:0.5rem; flex-wrap:wrap; align-items:center;">
@@ -42,10 +47,6 @@
     {% if q or ct_filter or platform_filter or rating_filter or sort != 'az' %}
     <a href="/history" class="btn-ghost" style="padding:0.6rem 0.9rem;">Clear</a>
     {% endif %}
-    <!-- Add watched toggle — inline at end of filter row -->
-    <button type="button" id="add-toggle" onclick="toggleAddForm()"
-      class="btn-ghost"
-      style="padding:0.6rem 0.9rem; margin-left:auto;">+ Add watched</button>
   </form>
 
   <!-- Collapsible Add Title form -->
@@ -313,8 +314,7 @@ function toggleAddForm() {
   const btn = document.getElementById('add-toggle');
   const open = wrapper.style.display !== 'none';
   wrapper.style.display = open ? 'none' : '';
-  btn.style.color = open ? '' : 'var(--teal)';
-  btn.style.borderColor = open ? '' : 'var(--teal)';
+  btn.classList.toggle('is-active', !open);
   if (!open) {
     setTimeout(() => document.getElementById('add-title-input').focus(), 50);
   }

--- a/recommender/tmdb_client.py
+++ b/recommender/tmdb_client.py
@@ -142,10 +142,13 @@ class TmdbClient:
         results = data.get("results", [])
         return results[0]["id"] if results else None
 
-    def _search_candidates(
+    def _search_candidates_or_error(
         self, title: str, content_type: str, hints: MatchHints | None = None,
-    ) -> list[dict]:
-        """Return up to 5 TMDB search results. Uses year hint when available."""
+    ) -> tuple[list[dict], bool]:
+        """Like _search_candidates, but reports whether the request itself
+        succeeded (True, even with zero results) or failed due to a
+        network/API error (False) - the two are otherwise indistinguishable.
+        """
         endpoint = "search/tv" if content_type == "tv" else "search/movie"
         params: dict = {"query": title}
 
@@ -157,17 +160,24 @@ class TmdbClient:
                 data = self._get(endpoint, hinted_params)
                 results = data.get("results", [])[:5]
                 if results:
-                    return results
+                    return results, True
             except Exception as exc:
                 log.debug("TMDB hinted search error for %r: %s", title, exc)
 
         # Fall back to unhinted search
         try:
             data = self._get(endpoint, params)
-            return data.get("results", [])[:5]
+            return data.get("results", [])[:5], True
         except Exception as exc:
             log.debug("TMDB search error for %r (%s): %s", title, content_type, exc)
-            return []
+            return [], False
+
+    def _search_candidates(
+        self, title: str, content_type: str, hints: MatchHints | None = None,
+    ) -> list[dict]:
+        """Return up to 5 TMDB search results. Uses year hint when available."""
+        results, _ = self._search_candidates_or_error(title, content_type, hints)
+        return results
 
     def _score_candidate(
         self, candidate: dict, title: str, content_type: str,

--- a/recommender/tmdb_client.py
+++ b/recommender/tmdb_client.py
@@ -56,6 +56,25 @@ class MatchHints:
     language: str | None = None  # TMDB original_language code, e.g. "hi"
 
 
+@dataclass
+class DisambiguationCandidate:
+    """A ranked TMDB search result offered to the user for manual-add disambiguation."""
+    tmdb_id: int
+    content_type: str       # "tv" or "movie"
+    title: str
+    year: int | None
+    poster_path: str | None
+    score: float
+
+
+@dataclass
+class DisambiguationResult:
+    """Result of searching both content types for a manual-add title."""
+    candidates: list[DisambiguationCandidate] = field(default_factory=list)
+    hinted_type_failed: bool = False
+    alternate_type_failed: bool = False
+
+
 def _normalize_for_match(s: str) -> str:
     """Lowercase, strip articles and punctuation for title comparison."""
     s = s.lower().strip()
@@ -178,6 +197,45 @@ class TmdbClient:
         """Return up to 5 TMDB search results. Uses year hint when available."""
         results, _ = self._search_candidates_or_error(title, content_type, hints)
         return results
+
+    def get_disambiguation_candidates(
+        self, title: str, content_type_hint: str, hints: MatchHints | None = None,
+    ) -> DisambiguationResult:
+        """Search both content types for `title` and return a ranked, deduped
+        candidate list plus per-type search-failure flags.
+
+        Candidates are deduped by (content_type, tmdb_id) - the same identity
+        key the user store uses - since TMDB ids are a separate namespace per
+        content type and a movie/tv pair can collide on the same integer id.
+        """
+        alt_type = "movie" if content_type_hint == "tv" else "tv"
+
+        hinted_raw, hinted_ok = self._search_candidates_or_error(title, content_type_hint, hints)
+        alt_raw, alt_ok = self._search_candidates_or_error(title, alt_type, hints)
+
+        merged: dict[tuple[str, int], DisambiguationCandidate] = {}
+        for ct, raw_list in ((content_type_hint, hinted_raw), (alt_type, alt_raw)):
+            for raw in raw_list:
+                key = (ct, raw["id"])
+                if key in merged:
+                    continue
+                date_str = raw.get("first_air_date") or raw.get("release_date") or ""
+                year = int(date_str[:4]) if date_str and len(date_str) >= 4 else None
+                merged[key] = DisambiguationCandidate(
+                    tmdb_id=raw["id"],
+                    content_type=ct,
+                    title=raw.get("name") or raw.get("title") or "",
+                    year=year,
+                    poster_path=raw.get("poster_path"),
+                    score=self._score_candidate(raw, title, ct, hints),
+                )
+
+        ranked = sorted(merged.values(), key=lambda c: c.score, reverse=True)[:5]
+        return DisambiguationResult(
+            candidates=ranked,
+            hinted_type_failed=not hinted_ok,
+            alternate_type_failed=not alt_ok,
+        )
 
     def _score_candidate(
         self, candidate: dict, title: str, content_type: str,

--- a/recommender/user_store.py
+++ b/recommender/user_store.py
@@ -373,6 +373,35 @@ def apply_rating_multipliers(scores: dict[str, float],
     return modified
 
 
+def find_conflict(db_path: str, content_type: str, tmdb_id: int) -> dict | None:
+    """Return the existing entry matching (content_type, tmdb_id) in the
+    watchlist or archive, or None if there is no conflict.
+
+    Checks saved_titles before manual_archive_entries: a watchlist hit
+    usually implies a different intended action (mark as watched) than
+    an archive hit (already logged as watched).
+    """
+    conn = _connect(db_path)
+    try:
+        row = conn.execute(
+            "SELECT title FROM saved_titles WHERE content_type = ? AND tmdb_id = ?",
+            (content_type, tmdb_id),
+        ).fetchone()
+        if row:
+            return {"source": "watchlist", "title": row["title"]}
+
+        row = conn.execute(
+            "SELECT title FROM manual_archive_entries WHERE content_type = ? AND tmdb_id = ?",
+            (content_type, tmdb_id),
+        ).fetchone()
+        if row:
+            return {"source": "archive", "title": row["title"]}
+
+        return None
+    finally:
+        conn.close()
+
+
 def add_to_archive(db_path: str, title: str, content_type: str,
                    tmdb_id: int | None = None, source: str = "web") -> None:
     """Upsert a manual archive entry."""

--- a/recommender/user_store.py
+++ b/recommender/user_store.py
@@ -384,7 +384,7 @@ def find_conflict(db_path: str, content_type: str, tmdb_id: int) -> dict | None:
     conn = _connect(db_path)
     try:
         row = conn.execute(
-            "SELECT title FROM saved_titles WHERE content_type = ? AND tmdb_id = ?",
+            "SELECT title FROM saved_titles WHERE content_type = ? AND tmdb_id = ? AND status = 'watchlist'",
             (content_type, tmdb_id),
         ).fetchone()
         if row:

--- a/recommender/web.py
+++ b/recommender/web.py
@@ -1304,9 +1304,22 @@ def archive_resolve() -> str:
     tmdb = TmdbClient(api_key=config.TMDB_API_KEY, cache_dir=config.CACHE_DIR)
     result = tmdb.get_disambiguation_candidates(title, ct)
 
+    watched_index: dict[tuple[str, int], str] = {}
+    try:
+        ctx = _get_context()
+        for e in ctx.watch_index.entries:
+            tid = e.get("tmdb_id")
+            if tid:
+                watched_index.setdefault((e.get("content_type", "tv"), tid), e.get("title", ""))
+    except Exception:
+        pass
+
     candidates = []
     for cand in result.candidates:
+        key = (cand.content_type, cand.tmdb_id)
         conflict = user_store.find_conflict(config.EVENT_DB_PATH, cand.content_type, cand.tmdb_id)
+        if conflict is None and key in watched_index:
+            conflict = {"source": "watched", "title": watched_index[key]}
         candidates.append({
             "tmdb_id": cand.tmdb_id,
             "content_type": cand.content_type,

--- a/recommender/web.py
+++ b/recommender/web.py
@@ -1326,6 +1326,48 @@ def archive_resolve() -> str:
     )
 
 
+@app.route("/archive/confirm", methods=["POST"])
+def archive_confirm() -> str:
+    resolution = request.form.get("resolution")
+    title = (request.form.get("title") or "").strip()
+    ct = request.form.get("content_type", "tv")
+    tmdb_id = request.form.get("tmdb_id", type=int)
+    if not title:
+        return "Missing title", 400
+    _ensure_user_store_once()
+
+    if resolution == "unmatched":
+        user_store.add_to_archive(config.EVENT_DB_PATH, title, ct, tmdb_id=None, source="web")
+        final_title = title
+    elif resolution in ("add", "mark_watched"):
+        if tmdb_id is None:
+            return "Missing tmdb_id", 400
+        final_title = title
+        if config.TMDB_API_KEY:
+            from recommender.tmdb_client import TmdbClient
+            tmdb = TmdbClient(api_key=config.TMDB_API_KEY, cache_dir=config.CACHE_DIR)
+            data = tmdb._load_cache(ct, tmdb_id)
+            if not data:
+                try:
+                    data = tmdb._fetch_details(tmdb_id, ct)
+                    tmdb._save_cache(ct, tmdb_id, data)
+                except Exception:
+                    data = None
+            if data:
+                final_title = data.get("name") or data.get("title") or title
+        if resolution == "mark_watched":
+            user_store.mark_watched_from_watchlist(config.EVENT_DB_PATH, final_title, ct, tmdb_id=tmdb_id)
+        else:
+            user_store.add_to_archive(config.EVENT_DB_PATH, final_title, ct, tmdb_id=tmdb_id, source="web")
+    else:
+        return "Invalid resolution", 400
+
+    Path(config.PROFILE_STALE_FLAG).touch()
+    uid = f"aa-{hash(final_title) & 0xFFFFFF:06x}"
+    return render_template("_rating_prompt.html", title=final_title, content_type=ct,
+                           tmdb_id=tmdb_id, uid=uid)
+
+
 @app.route("/archive/rate", methods=["POST"])
 def archive_rate() -> str:
     title = (request.form.get("title") or "").strip()

--- a/recommender/web.py
+++ b/recommender/web.py
@@ -1285,6 +1285,47 @@ def archive_add() -> str:
                            tmdb_id=tmdb_id, uid=uid)
 
 
+@app.route("/archive/resolve", methods=["POST"])
+def archive_resolve() -> str:
+    title = (request.form.get("title") or "").strip()
+    ct = request.form.get("content_type", "tv")
+    if not title:
+        return "Missing title", 400
+    _ensure_user_store_once()
+
+    if not config.TMDB_API_KEY:
+        return render_template(
+            "_archive_disambiguate.html", title=title, content_type=ct,
+            api_key_missing=True, both_failed=False,
+            hinted_type_failed=False, alternate_type_failed=False, candidates=[],
+        )
+
+    from recommender.tmdb_client import TmdbClient
+    tmdb = TmdbClient(api_key=config.TMDB_API_KEY, cache_dir=config.CACHE_DIR)
+    result = tmdb.get_disambiguation_candidates(title, ct)
+
+    candidates = []
+    for cand in result.candidates:
+        conflict = user_store.find_conflict(config.EVENT_DB_PATH, cand.content_type, cand.tmdb_id)
+        candidates.append({
+            "tmdb_id": cand.tmdb_id,
+            "content_type": cand.content_type,
+            "title": cand.title,
+            "year": cand.year,
+            "poster_path": cand.poster_path,
+            "conflict": conflict,
+        })
+
+    return render_template(
+        "_archive_disambiguate.html", title=title, content_type=ct,
+        api_key_missing=False,
+        both_failed=result.hinted_type_failed and result.alternate_type_failed,
+        hinted_type_failed=result.hinted_type_failed,
+        alternate_type_failed=result.alternate_type_failed,
+        candidates=candidates,
+    )
+
+
 @app.route("/archive/rate", methods=["POST"])
 def archive_rate() -> str:
     title = (request.form.get("title") or "").strip()

--- a/tests/test_tmdb_client.py
+++ b/tests/test_tmdb_client.py
@@ -604,3 +604,42 @@ def test_load_cache_treats_corrupt_json_as_cache_miss(tmp_path):
     result = client._load_cache("movie", 42)
 
     assert result is None
+
+
+def test_search_candidates_or_error_reports_success_with_results():
+    with tempfile.TemporaryDirectory() as tmp:
+        client = make_client(tmp)
+        with patch.object(client, "_get") as mock_get:
+            mock_get.return_value = {"results": [_make_tv_search_result(1, "A Show")]}
+            results, ok = client._search_candidates_or_error("A Show", "tv")
+        assert ok is True
+        assert len(results) == 1
+
+
+def test_search_candidates_or_error_reports_success_with_zero_results():
+    with tempfile.TemporaryDirectory() as tmp:
+        client = make_client(tmp)
+        with patch.object(client, "_get") as mock_get:
+            mock_get.return_value = {"results": []}
+            results, ok = client._search_candidates_or_error("Nonexistent", "tv")
+        assert ok is True
+        assert results == []
+
+
+def test_search_candidates_or_error_reports_failure_on_exception():
+    with tempfile.TemporaryDirectory() as tmp:
+        client = make_client(tmp)
+        with patch.object(client, "_get", side_effect=RuntimeError("boom")):
+            results, ok = client._search_candidates_or_error("A Show", "tv")
+        assert ok is False
+        assert results == []
+
+
+def test_search_candidates_still_returns_plain_list_after_refactor():
+    """_search_candidates keeps its original contract."""
+    with tempfile.TemporaryDirectory() as tmp:
+        client = make_client(tmp)
+        with patch.object(client, "_get") as mock_get:
+            mock_get.return_value = {"results": [_make_tv_search_result(1, "A Show")]}
+            results = client._search_candidates("A Show", "tv")
+        assert results == [_make_tv_search_result(1, "A Show")]

--- a/tests/test_tmdb_client.py
+++ b/tests/test_tmdb_client.py
@@ -643,3 +643,65 @@ def test_search_candidates_still_returns_plain_list_after_refactor():
             mock_get.return_value = {"results": [_make_tv_search_result(1, "A Show")]}
             results = client._search_candidates("A Show", "tv")
         assert results == [_make_tv_search_result(1, "A Show")]
+
+
+def test_get_disambiguation_candidates_merges_both_types():
+    with tempfile.TemporaryDirectory() as tmp:
+        client = make_client(tmp)
+        tv_results = [_make_tv_search_result(1, "The Office", "2005-03-24")]
+        movie_results = [_make_search_result(2, "The Office (2001 Film)", "2001-01-01")]
+        with patch.object(client, "_search_candidates_or_error") as mock_search:
+            mock_search.side_effect = [(tv_results, True), (movie_results, True)]
+            result = client.get_disambiguation_candidates("The Office", "tv")
+        assert {c.tmdb_id for c in result.candidates} == {1, 2}
+        assert result.hinted_type_failed is False
+        assert result.alternate_type_failed is False
+
+
+def test_get_disambiguation_candidates_dedupes_by_type_and_id():
+    """A movie and a tv show can legitimately share the same numeric TMDB id."""
+    with tempfile.TemporaryDirectory() as tmp:
+        client = make_client(tmp)
+        same_id_tv = [_make_tv_search_result(5, "Show A", "2010-01-01")]
+        same_id_movie = [_make_search_result(5, "Unrelated Movie", "1999-01-01")]
+        with patch.object(client, "_search_candidates_or_error") as mock_search:
+            mock_search.side_effect = [(same_id_tv, True), (same_id_movie, True)]
+            result = client.get_disambiguation_candidates("Show A", "tv")
+        assert len(result.candidates) == 2
+        types = {(c.content_type, c.tmdb_id) for c in result.candidates}
+        assert types == {("tv", 5), ("movie", 5)}
+
+
+def test_get_disambiguation_candidates_ranks_by_score():
+    with tempfile.TemporaryDirectory() as tmp:
+        client = make_client(tmp)
+        strong = _make_tv_search_result(1, "Kesari", "2019-03-21", vote_count=1000, popularity=50)
+        weak = _make_tv_search_result(2, "Kesar", "2019-01-01", vote_count=1, popularity=1)
+        with patch.object(client, "_search_candidates_or_error") as mock_search:
+            mock_search.side_effect = [([strong, weak], True), ([], True)]
+            result = client.get_disambiguation_candidates("Kesari", "tv")
+        assert result.candidates[0].tmdb_id == 1
+
+
+def test_get_disambiguation_candidates_reports_per_type_failure():
+    with tempfile.TemporaryDirectory() as tmp:
+        client = make_client(tmp)
+        with patch.object(client, "_search_candidates_or_error") as mock_search:
+            mock_search.side_effect = [([], True), ([], False)]
+            result = client.get_disambiguation_candidates("Kesari", "tv")
+        assert result.hinted_type_failed is False
+        assert result.alternate_type_failed is True
+        assert result.candidates == []
+
+
+def test_get_disambiguation_candidates_caps_at_five():
+    with tempfile.TemporaryDirectory() as tmp:
+        client = make_client(tmp)
+        many = [
+            _make_tv_search_result(i, f"Show {i}", "2010-01-01", vote_count=100 - i, popularity=10)
+            for i in range(6)
+        ]
+        with patch.object(client, "_search_candidates_or_error") as mock_search:
+            mock_search.side_effect = [(many, True), ([], True)]
+            result = client.get_disambiguation_candidates("Show", "tv")
+        assert len(result.candidates) == 5

--- a/tests/test_user_store.py
+++ b/tests/test_user_store.py
@@ -485,3 +485,43 @@ def test_ensure_user_store_retries_rename_if_marker_set(tmp_path):
     # Should have renamed without re-importing
     assert not Path(feedback_path).exists()
     assert Path(feedback_path + ".migrated").exists()
+
+
+def test_find_conflict_returns_none_when_no_match(tmp_path):
+    db = str(tmp_path / "test.db")
+    from recommender.user_store import init_db, find_conflict
+
+    init_db(db)
+    assert find_conflict(db, "tv", 999) is None
+
+
+def test_find_conflict_detects_watchlist_hit(tmp_path):
+    db = str(tmp_path / "test.db")
+    from recommender.user_store import init_db, save_title, find_conflict
+
+    init_db(db)
+    save_title(db, "The Bear", "tv", tmdb_id=194583)
+
+    conflict = find_conflict(db, "tv", 194583)
+    assert conflict == {"source": "watchlist", "title": "The Bear"}
+
+
+def test_find_conflict_detects_archive_hit(tmp_path):
+    db = str(tmp_path / "test.db")
+    from recommender.user_store import init_db, add_to_archive, find_conflict
+
+    init_db(db)
+    add_to_archive(db, "The Bear", "tv", tmdb_id=194583)
+
+    conflict = find_conflict(db, "tv", 194583)
+    assert conflict == {"source": "archive", "title": "The Bear"}
+
+
+def test_find_conflict_is_scoped_to_content_type(tmp_path):
+    db = str(tmp_path / "test.db")
+    from recommender.user_store import init_db, add_to_archive, find_conflict
+
+    init_db(db)
+    add_to_archive(db, "Up", "movie", tmdb_id=14160)
+
+    assert find_conflict(db, "tv", 14160) is None

--- a/tests/test_user_store.py
+++ b/tests/test_user_store.py
@@ -506,6 +506,17 @@ def test_find_conflict_detects_watchlist_hit(tmp_path):
     assert conflict == {"source": "watchlist", "title": "The Bear"}
 
 
+def test_find_conflict_ignores_dismissed_titles(tmp_path):
+    """A dismissed title is not on the watchlist and must not be reported as one."""
+    db = str(tmp_path / "test.db")
+    from recommender.user_store import init_db, dismiss_title, find_conflict
+
+    init_db(db)
+    dismiss_title(db, "The Bear", "tv", tmdb_id=194583)
+
+    assert find_conflict(db, "tv", 194583) is None
+
+
 def test_find_conflict_detects_archive_hit(tmp_path):
     db = str(tmp_path / "test.db")
     from recommender.user_store import init_db, add_to_archive, find_conflict

--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -1226,6 +1226,97 @@ class TestArchiveResolve:
         assert b"TMDB lookup failed" in resp.data
 
 
+class TestArchiveConfirm:
+    def _post(self, client, **overrides):
+        data = {
+            **_csrf_form(),
+            "title": "The Bear",
+            "content_type": "tv",
+            "resolution": "add",
+            "tmdb_id": "194583",
+        }
+        data.update(overrides)
+        return client.post("/archive/confirm", data=data)
+
+    def test_missing_title_returns_400(self, client):
+        resp = self._post(client, title="")
+        assert resp.status_code == 400
+
+    def test_add_without_tmdb_id_returns_400(self, client):
+        resp = self._post(client, tmdb_id="")
+        assert resp.status_code == 400
+
+    def test_invalid_resolution_returns_400(self, client):
+        resp = self._post(client, resolution="bogus")
+        assert resp.status_code == 400
+
+    def test_unmatched_saves_with_no_tmdb_id(self, client, tmp_path, monkeypatch):
+        from recommender.user_store import init_db, list_manual_archive
+
+        db = str(tmp_path / "test.db")
+        init_db(db)
+        monkeypatch.setattr("config.EVENT_DB_PATH", db)
+        monkeypatch.setattr("config.TMDB_API_KEY", "")
+        monkeypatch.setattr("config.PROFILE_STALE_FLAG", str(tmp_path / ".profile_stale"))
+
+        resp = self._post(client, resolution="unmatched", tmdb_id="")
+
+        assert resp.status_code == 200
+        entries = list_manual_archive(db)
+        assert len(entries) == 1
+        assert entries[0]["tmdb_id"] is None
+
+    def test_add_fetches_canonical_title_before_saving(self, client, tmp_path, monkeypatch):
+        from recommender.user_store import init_db, list_manual_archive
+
+        db = str(tmp_path / "test.db")
+        init_db(db)
+        monkeypatch.setattr("config.EVENT_DB_PATH", db)
+        monkeypatch.setattr("config.TMDB_API_KEY", "test-key")
+        monkeypatch.setattr("config.PROFILE_STALE_FLAG", str(tmp_path / ".profile_stale"))
+
+        with patch("recommender.tmdb_client.TmdbClient") as MockClient:
+            instance = MockClient.return_value
+            instance._load_cache.return_value = None
+            instance._fetch_details.return_value = {"name": "The Bear (Canonical)"}
+            resp = self._post(client, title="the bear typo")
+
+        assert resp.status_code == 200
+        entries = list_manual_archive(db)
+        assert len(entries) == 1
+        assert entries[0]["title"] == "The Bear (Canonical)"
+
+    def test_mark_watched_moves_from_watchlist_to_archive(self, client, tmp_path, monkeypatch):
+        from recommender.user_store import init_db, save_title, list_saved_titles, list_manual_archive
+
+        db = str(tmp_path / "test.db")
+        init_db(db)
+        save_title(db, "The Bear", "tv", tmdb_id=194583)
+        monkeypatch.setattr("config.EVENT_DB_PATH", db)
+        monkeypatch.setattr("config.TMDB_API_KEY", "")
+        monkeypatch.setattr("config.PROFILE_STALE_FLAG", str(tmp_path / ".profile_stale"))
+
+        resp = self._post(client, resolution="mark_watched")
+
+        assert resp.status_code == 200
+        assert list_saved_titles(db) == []
+        assert len(list_manual_archive(db)) == 1
+
+    def test_stale_flag_touched_after_confirm(self, client, tmp_path, monkeypatch):
+        from recommender.user_store import init_db
+
+        db = str(tmp_path / "test.db")
+        init_db(db)
+        stale_flag = tmp_path / ".profile_stale"
+        monkeypatch.setattr("config.EVENT_DB_PATH", db)
+        monkeypatch.setattr("config.TMDB_API_KEY", "")
+        monkeypatch.setattr("config.PROFILE_STALE_FLAG", str(stale_flag))
+
+        self._post(client, resolution="unmatched", tmdb_id="")
+
+        assert stale_flag.exists()
+
+
 class TestHistoryTmdbOverview:
     """Archive/history page shows TMDB overview when enrichment text is absent."""
 

--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -1402,6 +1402,17 @@ class TestArchiveDisambiguatePartial:
         assert "Already on your watchlist" in html
         assert "value=\"mark_watched\"" in html
 
+    def test_watchlist_conflict_does_not_offer_add_button(self):
+        """A watchlist conflict must only offer mark_watched, never a fresh add -
+        clicking Add would leave the same (content_type, tmdb_id) in both
+        saved_titles and manual_archive_entries."""
+        html = self._render(candidates=[{
+            "tmdb_id": 194583, "content_type": "tv", "title": "The Bear",
+            "year": 2022, "poster_path": None,
+            "conflict": {"source": "watchlist", "title": "The Bear"},
+        }])
+        assert "value=\"add\"" not in html
+
     def test_renders_archive_conflict_with_update_watched_date_label(self):
         html = self._render(candidates=[{
             "tmdb_id": 194583, "content_type": "tv", "title": "The Bear",

--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -1424,6 +1424,35 @@ class TestArchiveDisambiguatePartial:
         assert "2022" in html
         assert "value=\"add\"" in html
 
+    def test_only_top_ranked_candidate_gets_primary_emphasis(self):
+        """Candidates are already rank-ordered by score; only the top match
+        should read as the loud, primary action - the rest are secondary
+        so five equally emphasized buttons don't compete for attention."""
+        html = self._render(candidates=[
+            {"tmdb_id": 1, "content_type": "tv", "title": "First", "year": 2020,
+             "poster_path": None, "conflict": None},
+            {"tmdb_id": 2, "content_type": "tv", "title": "Second", "year": 2019,
+             "poster_path": None, "conflict": None},
+            {"tmdb_id": 3, "content_type": "tv", "title": "Third", "year": 2018,
+             "poster_path": None, "conflict": None},
+        ])
+        assert html.count('class="btn-primary"') == 1
+        assert html.count('class="btn-ghost"', html.index("candidate-list")) >= 2
+
+    def test_modal_has_scrollable_body_and_pinned_footer(self):
+        """Search-again/save-unmatched must live outside the scrollable
+        candidate region so they stay reachable in a long candidate list."""
+        html = self._render(candidates=[{
+            "tmdb_id": 194583, "content_type": "tv", "title": "The Bear",
+            "year": 2022, "poster_path": None, "conflict": None,
+        }])
+        assert "modal-scroll" in html
+        assert "modal-footer" in html
+        scroll_start = html.index("modal-scroll")
+        footer_start = html.index("modal-footer")
+        unmatched_start = html.index("save as unmatched")
+        assert scroll_start < footer_start < unmatched_start
+
     def test_renders_watchlist_conflict_with_mark_watched_button(self):
         html = self._render(candidates=[{
             "tmdb_id": 194583, "content_type": "tv", "title": "The Bear",

--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -1212,3 +1212,62 @@ class TestHistoryTmdbOverview:
 
         from recommender.web import _get_tmdb_overview
         assert _get_tmdb_overview(88888, "tv") is None
+
+
+class TestArchiveDisambiguatePartial:
+    def _render(self, **overrides):
+        from recommender.web import app
+        defaults = dict(
+            title="The Bear", content_type="tv",
+            api_key_missing=False, both_failed=False,
+            hinted_type_failed=False, alternate_type_failed=False,
+            candidates=[],
+        )
+        defaults.update(overrides)
+        with app.test_request_context():
+            from flask import render_template
+            return render_template("_archive_disambiguate.html", **defaults)
+
+    def test_renders_plain_candidate_with_add_button(self):
+        html = self._render(candidates=[{
+            "tmdb_id": 194583, "content_type": "tv", "title": "The Bear",
+            "year": 2022, "poster_path": None, "conflict": None,
+        }])
+        assert "The Bear" in html
+        assert "2022" in html
+        assert "value=\"add\"" in html
+
+    def test_renders_watchlist_conflict_with_mark_watched_button(self):
+        html = self._render(candidates=[{
+            "tmdb_id": 194583, "content_type": "tv", "title": "The Bear",
+            "year": 2022, "poster_path": None,
+            "conflict": {"source": "watchlist", "title": "The Bear"},
+        }])
+        assert "Already on your watchlist" in html
+        assert "value=\"mark_watched\"" in html
+
+    def test_renders_archive_conflict_with_update_watched_date_label(self):
+        html = self._render(candidates=[{
+            "tmdb_id": 194583, "content_type": "tv", "title": "The Bear",
+            "year": 2022, "poster_path": None,
+            "conflict": {"source": "archive", "title": "The Bear"},
+        }])
+        assert "Already in your archive" in html
+        assert "Update watched date" in html
+
+    def test_renders_no_api_key_message(self):
+        html = self._render(api_key_missing=True)
+        assert "no API key configured" in html
+
+    def test_renders_both_failed_message(self):
+        html = self._render(both_failed=True)
+        assert "TMDB lookup failed" in html
+
+    def test_renders_no_matches_message_when_search_succeeded_with_zero_results(self):
+        html = self._render(candidates=[])
+        assert "No matches found" in html
+
+    def test_unmatched_button_always_present(self):
+        html = self._render()
+        assert "value=\"unmatched\"" in html
+        assert "save as unmatched" in html

--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -1207,6 +1207,37 @@ class TestArchiveResolve:
         assert resp.status_code == 200
         assert b"Already on your watchlist" in resp.data
 
+    def test_renders_candidates_already_in_watch_history(self, client, tmp_path, monkeypatch):
+        """A title already present in the ingested watch_index (not the SQL
+        tables) must still be flagged, or the modal misses most real
+        already-watched titles from platform ingestion/rebuilds."""
+        from recommender.user_store import init_db
+        from recommender.tmdb_client import DisambiguationCandidate, DisambiguationResult
+
+        db = str(tmp_path / "test.db")
+        init_db(db)
+        monkeypatch.setattr("config.EVENT_DB_PATH", db)
+        monkeypatch.setattr("config.TMDB_API_KEY", "test-key")
+
+        mock_ctx = MagicMock()
+        mock_ctx.watch_index.entries = [
+            {"title": "1917", "content_type": "movie", "tmdb_id": 530915, "platforms": ["manual"]},
+        ]
+
+        with patch("recommender.tmdb_client.TmdbClient") as MockClient, \
+             patch("recommender.web._get_context", return_value=mock_ctx):
+            MockClient.return_value.get_disambiguation_candidates.return_value = DisambiguationResult(
+                candidates=[DisambiguationCandidate(
+                    tmdb_id=530915, content_type="movie", title="1917",
+                    year=2019, poster_path=None, score=90.0,
+                )],
+            )
+            resp = self._post(client, title="1917", content_type="movie")
+
+        assert resp.status_code == 200
+        assert b"Already in your watch history" in resp.data
+        assert b"Add anyway" in resp.data
+
     def test_both_searches_failing_shows_error_state(self, client, tmp_path, monkeypatch):
         from recommender.user_store import init_db
         from recommender.tmdb_client import DisambiguationResult
@@ -1412,6 +1443,16 @@ class TestArchiveDisambiguatePartial:
             "conflict": {"source": "watchlist", "title": "The Bear"},
         }])
         assert "value=\"add\"" not in html
+
+    def test_renders_watch_history_conflict_with_add_anyway_label(self):
+        html = self._render(candidates=[{
+            "tmdb_id": 530915, "content_type": "movie", "title": "1917",
+            "year": 2019, "poster_path": None,
+            "conflict": {"source": "watched", "title": "1917"},
+        }])
+        assert "Already in your watch history" in html
+        assert "Add anyway" in html
+        assert "value=\"mark_watched\"" not in html
 
     def test_renders_archive_conflict_with_update_watched_date_label(self):
         html = self._render(candidates=[{

--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -1161,6 +1161,71 @@ class TestArchiveAdd:
         mock_llm.assert_not_called()
 
 
+class TestArchiveResolve:
+    def _post(self, client, title="The Bear", content_type="tv"):
+        return client.post("/archive/resolve", data={
+            **_csrf_form(),
+            "title": title,
+            "content_type": content_type,
+        })
+
+    def test_missing_title_returns_400(self, client):
+        resp = self._post(client, title="")
+        assert resp.status_code == 400
+
+    def test_no_api_key_renders_unmatched_only_state(self, client, tmp_path, monkeypatch):
+        from recommender.user_store import init_db
+
+        db = str(tmp_path / "test.db")
+        init_db(db)
+        monkeypatch.setattr("config.EVENT_DB_PATH", db)
+        monkeypatch.setattr("config.TMDB_API_KEY", "")
+
+        resp = self._post(client)
+        assert resp.status_code == 200
+        assert b"no API key configured" in resp.data
+
+    def test_renders_candidates_with_watchlist_conflict(self, client, tmp_path, monkeypatch):
+        from recommender.user_store import init_db, save_title
+        from recommender.tmdb_client import DisambiguationCandidate, DisambiguationResult
+
+        db = str(tmp_path / "test.db")
+        init_db(db)
+        save_title(db, "The Bear", "tv", tmdb_id=194583)
+        monkeypatch.setattr("config.EVENT_DB_PATH", db)
+        monkeypatch.setattr("config.TMDB_API_KEY", "test-key")
+
+        with patch("recommender.tmdb_client.TmdbClient") as MockClient:
+            MockClient.return_value.get_disambiguation_candidates.return_value = DisambiguationResult(
+                candidates=[DisambiguationCandidate(
+                    tmdb_id=194583, content_type="tv", title="The Bear",
+                    year=2022, poster_path=None, score=90.0,
+                )],
+            )
+            resp = self._post(client)
+
+        assert resp.status_code == 200
+        assert b"Already on your watchlist" in resp.data
+
+    def test_both_searches_failing_shows_error_state(self, client, tmp_path, monkeypatch):
+        from recommender.user_store import init_db
+        from recommender.tmdb_client import DisambiguationResult
+
+        db = str(tmp_path / "test.db")
+        init_db(db)
+        monkeypatch.setattr("config.EVENT_DB_PATH", db)
+        monkeypatch.setattr("config.TMDB_API_KEY", "test-key")
+
+        with patch("recommender.tmdb_client.TmdbClient") as MockClient:
+            MockClient.return_value.get_disambiguation_candidates.return_value = DisambiguationResult(
+                candidates=[], hinted_type_failed=True, alternate_type_failed=True,
+            )
+            resp = self._post(client)
+
+        assert resp.status_code == 200
+        assert b"TMDB lookup failed" in resp.data
+
+
 class TestHistoryTmdbOverview:
     """Archive/history page shows TMDB overview when enrichment text is absent."""
 


### PR DESCRIPTION
## Summary
- Replaces the web UI's silent, single-shot manual "add title" flow with a guided modal: TMDB search now covers both content types (tv/movie), reports search failures distinctly from zero results, and lets the user pick from ranked candidates instead of a silent auto-resolve-or-give-up.
- Adds watchlist/archive conflict detection (keyed by `(content_type, tmdb_id)`, never `tmdb_id` alone) so adding a title already on the watchlist offers "Mark as watched" instead of creating a duplicate.
- The "save unmatched" fallback (`tmdb_id=None`) is preserved, now as an explicit user choice rather than a silent one.
- Two new routes: `POST /archive/resolve` (search-only) and `POST /archive/confirm` (the only route that writes) — `/archive/add` (used by the recommendations page for already-known tmdb_ids) is untouched.

Design doc: `docs/superpowers/specs/2026-07-07-manual-add-disambiguation-modal-design.md`
Implementation plan: `docs/superpowers/plans/2026-07-07-manual-add-disambiguation-modal.md`

## Test plan
- [x] `venv/bin/python3 -m pytest tests/ -v` — 582/582 passing, no regressions
- [x] Per-task code review (spec compliance + quality) for all 7 tasks — clean
- [x] Final whole-branch review — Ready to merge, no Critical/Important issues (5 Minor/optional findings noted in PR discussion if needed)
- [x] Live manual verification via headless Playwright against an isolated temp DB + real TMDB API (not production data): candidate list rendering, conflict badge + mark-as-watched atomic move (verified via direct sqlite inspection), no-match/search-failed state, and unmatched-save fallback all confirmed working end-to-end